### PR TITLE
fix(ci): corrige import de src/config nos testes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *.pyc
+.coverage
 
 # Arquivo com Variáveis de Ambiente
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ dev = [
     "pandas-stubs>=2.0",
     "ruff>=0.4",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
A CI roda `pytest tests/ ...` diretamente (não `python -m pytest`), então o diretório do repo nunca entrava no `sys.path` — todo run de CI deste repositório desde setembro de 2025 falha com `ModuleNotFoundError: No module named 'src'`/`'config'`, incluindo os merges das PRs #1, #2 e #3. Não tem relação com o conteúdo dessas PRs; é um problema de configuração pré-existente.

Reproduzi localmente rodando `pytest` fora do diretório do repositório (mesma condição da CI) e confirmei o mesmo erro. `[tool.pytest.ini_options] pythonpath = ["."]` resolve sem tocar no workflow nem no empacotamento do projeto — testado com o comando exato da CI (`pytest tests/ -v --cov=src --cov-report=term-missing`), 32 testes passando, 89% de cobertura.

Também ignora `.coverage` no `.gitignore` (artefato gerado ao rodar com `--cov`).

## Test plan

- [x] Reproduzido o erro da CI localmente (pytest fora do diretório do repo)
- [x] `pytest tests/ -v --cov=src --cov-report=term-missing` — 32 passando, 89% cobertura
- [x] `ruff check src/` limpo