### PR TITLE
fix(engenharia): fecha os últimos gaps de dados e dashboard do ciclo de NLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,16 +329,15 @@ O pipeline roda de ponta a ponta: `uv run python pipeline.py` materializa Bronze
 
 Esta seção registra honestamente o que ainda não está fechado.
 
-**O ciclo da modelagem fecha ao rodar o notebook 03.** `notebooks/03_modelagem_hibrida.ipynb` lê Bronze/Silver/Gold via `DeltaRepository` e, ao final, grava os resultados direto em Gold através do `ModelEnricher`: sentimento e tópicos em `governor_sentiment` (os tópicos do BERTopic viajam junto, nas colunas `Topic`/`Name` — não há uma tabela separada), e clusters em `governor_clusters`. A clusterização é por **reel** (PCA de engajamento/duração do vídeo via `AutoClusterHPO`), não por perfil — não há, e nunca houve, clusterização de governadores no projeto. Essa etapa continua sendo executada manualmente, fora do `pipeline.py`: depende de uma API key do Gemini (`GeminiDocsRefiner`) e de BERTopic, e é uma etapa de pesquisa exploratória, não um job batch.
+**O ciclo da modelagem fecha ao rodar o notebook 03.** `notebooks/03_modelagem_hibrida.ipynb` lê Bronze/Silver/Gold via `DeltaRepository` e, ao final, grava os resultados direto em Gold através do `ModelEnricher`: sentimento e tópicos em `governor_sentiment` (os tópicos do BERTopic viajam junto, nas colunas `Topic`/`Name` — não há uma tabela separada), e clusters em `governor_clusters`. A clusterização é por **reel** (PCA de engajamento/duração do vídeo via `AutoClusterHPO`), não por perfil — não há, e nunca houve, clusterização de governadores no projeto. Essa etapa continua sendo executada manualmente, fora do `pipeline.py`: depende de uma API key do Gemini (`GeminiDocsRefiner`) e de BERTopic, e é uma etapa de pesquisa exploratória, não um job batch. O dashboard de modelagem (`pages/02_modeling.py`) exibe a distribuição de sentimento, os tópicos mais frequentes e os clusters de reels assim que essas tabelas existem — e se ainda não existirem, mostra instruções em vez de quebrar.
 
-**Notebooks parcialmente migrados.** Os notebooks 01 e 02 ainda leem Excel; 03, 04 e 05 já usam `DeltaRepository`.
+**Notebooks já migrados para Delta.** Os 5 notebooks usam `DeltaRepository`/`run_medallion_pipeline` — nenhum lê mais `all.xlsx` como fonte de pipeline (o notebook 01 só toca Excel para ler `governadores.xlsx`, a lista de perfis a coletar, que é configuração, não dado).
 
 **Pendências de documentação.** Os capítulos 6 (Resultados) e 7 (Conclusões) do TCC ainda estão no texto-modelo, embora os resultados já existam e estejam redigidos no capítulo 5.
 
 ### Próximos passos
 
-1. Migrar os notebooks 01 e 02 para `DeltaRepository`, aposentando o `all.xlsx`
-2. Completar os capítulos 6 (Resultados) e 7 (Conclusões) do TCC
+1. Completar os capítulos 6 (Resultados) e 7 (Conclusões) do TCC
 
 ---
 
@@ -352,12 +351,13 @@ Esta seção registra honestamente o que ainda não está fechado.
 | `test_repository.py` | Leitura das tabelas Delta reais (pula quando não materializadas) |
 | `test_delta_io.py` | Conformação ao contrato de schema: descarta colunas extras, cria as anuláveis ausentes e falha em campo obrigatório vazio |
 | `test_engagement_aggregator.py` | Perfil sem publicações não recebe recência máxima, agregados conformam ao contrato Gold, `% ENGAJAMENTO` não divide por zero |
+| `test_model_enricher.py` | `write_sentiment`/`write_clusters` na granularidade de reel, falha clara quando falta coluna esperada |
 | `test_engagement.py` | `EngagementFeatureBuilder` cria `TOTAL ENGAJAMENTO`, `% ENGAJAMENTO`, `RECENCIA`, `FREQUENCIA` e não gera percentuais negativos |
 | `test_comments.py` | `CommentsTransformer` filtra comentários com 512 caracteres ou mais |
 | `test_transform_lambda.py` | Handler Silver retorna `200` / `silver_complete`; retorna `400` sem `S3_BUCKET` |
 | `test_load_lambda.py` | Handler Gold retorna `200` / `gold_complete`; retorna `400` sem `S3_BUCKET` |
 
-**Resultado atual: 30 testes, todos passando.**
+**Resultado atual: 34 testes, todos passando.**
 
 `.github/workflows/python-app.yml` roda a cada push e pull request na `main`: checkout, Python 3.11, `pip install -e .[dev]`, pytest com cobertura e `ruff check src/`.
 

--- a/notebooks/02_analise_exploratoria.ipynb
+++ b/notebooks/02_analise_exploratoria.ipynb
@@ -61,58 +61,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "90801f11",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 27 entries, 0 to 26\n",
-      "Data columns (total 32 columns):\n",
-      " #   Column                Non-Null Count  Dtype         \n",
-      "---  ------                --------------  -----         \n",
-      " 0   inputUrl              27 non-null     object        \n",
-      " 1   id                    27 non-null     object        \n",
-      " 2   username              27 non-null     object        \n",
-      " 3   url                   27 non-null     object        \n",
-      " 4   fullName              27 non-null     object        \n",
-      " 5   biography             27 non-null     object        \n",
-      " 6   externalUrls          27 non-null     object        \n",
-      " 7   externalUrl           21 non-null     object        \n",
-      " 8   externalUrlShimmed    21 non-null     object        \n",
-      " 9   followersCount        27 non-null     int32         \n",
-      " 10  followsCount          27 non-null     int32         \n",
-      " 11  hasChannel            27 non-null     bool          \n",
-      " 12  isBusinessAccount     27 non-null     bool          \n",
-      " 13  joinedRecently        27 non-null     bool          \n",
-      " 14  businessCategoryName  25 non-null     category      \n",
-      " 15  private               27 non-null     bool          \n",
-      " 16  verified              27 non-null     bool          \n",
-      " 17  profilePicUrl         27 non-null     object        \n",
-      " 18  profilePicUrlHD       27 non-null     object        \n",
-      " 19  postsCount            27 non-null     int32         \n",
-      " 20  fbid                  27 non-null     object        \n",
-      " 21  businessAddress       1 non-null      object        \n",
-      " 22  ownerUsername         27 non-null     object        \n",
-      " 23  commentsSum           27 non-null     int64         \n",
-      " 24  likesSum              27 non-null     int64         \n",
-      " 25  minData               27 non-null     datetime64[ns]\n",
-      " 26  maxData               27 non-null     datetime64[ns]\n",
-      " 27  count                 27 non-null     int64         \n",
-      " 28  TOTAL ENGAJAMENTO     27 non-null     int64         \n",
-      " 29  % ENGAJAMENTO         27 non-null     float64       \n",
-      " 30  RECENCIA              27 non-null     float64       \n",
-      " 31  FREQUENCIA            27 non-null     float64       \n",
-      "dtypes: bool(5), category(1), datetime64[ns](2), float64(3), int32(3), int64(4), object(14)\n",
-      "memory usage: 5.8+ KB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dtype = {\n    'inputUrl': 'str',\n    'id': 'str',  # IDs são melhor tratados como texto\n    'username': 'str',\n    'url': 'str',\n    'fullName': 'str',\n    'biography': 'str',\n    'externalUrls': 'str', # Provavelmente JSON, ler como texto primeiro\n    'externalUrl': 'str',\n    'externalUrlShimmed': 'str',\n    'followersCount': 'int32',  # int32 economiza memória\n    'followsCount': 'int32',\n    'hasChannel': 'bool',\n    'highlightReelCount': 'int32',\n    'isBusinessAccount': 'bool',\n    'joinedRecently': 'bool',\n    'businessCategoryName': 'category',  # 'category' é ideal para textos repetidos\n    'private': 'bool',\n    'verified': 'bool',\n    'profilePicUrl': 'str',\n    'profilePicUrlHD': 'str',\n    'igtvVideoCount': 'int32',\n    'relatedProfiles': 'str', # Provavelmente JSON, ler como texto primeiro\n    'latestIgtvVideos': 'str',\n    'latestPosts': 'str',\n    'postsCount': 'int32',\n    'fbid': 'str',  # IDs são melhor tratados como texto\n    'businessAddress': 'str'\n}\ndf_profiles = repo.load_profiles().drop([\n    'highlightReelCount', 'igtvVideoCount', 'latestPosts', 'latestIgtvVideos', 'relatedProfiles',\n], axis=1, errors='ignore')\ndf_profiles['inputUrl'] = df_profiles['inputUrl'].str[:-1]\ndf_profiles.info()"
+    "df_profiles = repo.load_profiles().drop([\n",
+    "    'highlightReelCount', 'igtvVideoCount', 'latestPosts', 'latestIgtvVideos', 'relatedProfiles',\n",
+    "], axis=1, errors='ignore')\n",
+    "df_profiles['inputUrl'] = df_profiles['inputUrl'].str[:-1]\n",
+    "df_profiles.info()\n"
    ]
   },
   {
@@ -129,57 +87,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "caebccc3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 810 entries, 0 to 809\n",
-      "Data columns (total 31 columns):\n",
-      " #   Column                     Non-Null Count  Dtype         \n",
-      "---  ------                     --------------  -----         \n",
-      " 0   inputUrl                   810 non-null    object        \n",
-      " 1   id                         810 non-null    object        \n",
-      " 2   shortCode                  810 non-null    object        \n",
-      " 3   caption                    810 non-null    object        \n",
-      " 4   mentions                   810 non-null    object        \n",
-      " 5   url                        810 non-null    object        \n",
-      " 6   commentsCount              810 non-null    int64         \n",
-      " 7   likesCount                 810 non-null    int64         \n",
-      " 8   videoViewCount             810 non-null    int64         \n",
-      " 9   videoPlayCount             810 non-null    int64         \n",
-      " 10  ownerFullName              810 non-null    object        \n",
-      " 11  ownerUsername              810 non-null    object        \n",
-      " 12  ownerId                    810 non-null    object        \n",
-      " 13  videoDuration              810 non-null    float64       \n",
-      " 14  isSponsored                810 non-null    bool          \n",
-      " 15  musicInfo                  801 non-null    object        \n",
-      " 16  isCommentsDisabled         810 non-null    bool          \n",
-      " 17  coauthorProducers          180 non-null    object        \n",
-      " 18  locationName               328 non-null    object        \n",
-      " 19  locationId                 328 non-null    object        \n",
-      " 20  isPinned                   810 non-null    bool          \n",
-      " 21  data_hora                  810 non-null    datetime64[ns]\n",
-      " 22  Width X Height             810 non-null    object        \n",
-      " 23  Total de Engajamento       810 non-null    int64         \n",
-      " 24  PC1_Engajamento_videoPlay  810 non-null    float64       \n",
-      " 25  PC2_videoDuration          810 non-null    float64       \n",
-      " 26  Clusters (AutoClusterHPO)  810 non-null    int64         \n",
-      " 27  model                      810 non-null    object        \n",
-      " 28  config                     0 non-null      float64       \n",
-      " 29  score                      810 non-null    float64       \n",
-      " 30  algo_name                  810 non-null    object        \n",
-      "dtypes: bool(3), datetime64[ns](1), float64(5), int64(6), object(16)\n",
-      "memory usage: 179.7+ KB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dtype = {\n    'inputUrl': 'object',\n    'id': 'str',\n    'type': 'object',\n    'shortCode': 'object',\n    'caption': 'object',\n    'hashtags': 'object',\n    'mentions': 'object',\n    'url': 'object',\n    'commentsCount': 'int64',\n    'firstComment': 'object',\n    'latestComments': 'object',\n    'dimensionsHeight': 'str',\n    'dimensionsWidth': 'str',\n    'displayUrl': 'object',\n    'images': 'object',\n    'videoUrl': 'object',\n    'alt': 'float64',\n    'likesCount': 'int64',\n    'videoViewCount': 'int64',\n    'videoPlayCount': 'int64',\n    'timestamp': 'object',\n    'childPosts': 'object',\n    'ownerFullName': 'object',\n    'ownerUsername': 'object',\n    'ownerId': 'str',\n    'productType': 'object',\n    'videoDuration': 'float64',\n    'isSponsored': 'bool',\n    'musicInfo': 'object',\n    'isCommentsDisabled': 'bool',\n    'taggedUsers': 'object',\n    'coauthorProducers': 'object',\n    'locationName': 'object',\n    'locationId': 'str',\n    'isPinned': 'float64',\n    'data_hora': 'datetime64[ns]',\n    'Tipo': 'object'\n}\ndf_reels = repo.load_reels().drop([\n    'firstComment', 'latestComments', 'videoUrl', 'alt', 'timestamp', 'childPosts',\n    'productType', 'taggedUsers', 'type', 'hashtags', 'displayUrl',\n    'dimensionsHeight', 'dimensionsWidth', 'images', 'Tipo',\n], axis=1, errors='ignore')\ndf_reels['isPinned'] = df_reels['isPinned'].astype(bool)\ndf_reels.info()"
+    "df_reels = repo.load_reels().drop([\n",
+    "    'firstComment', 'latestComments', 'videoUrl', 'alt', 'timestamp', 'childPosts',\n",
+    "    'productType', 'taggedUsers', 'type', 'hashtags', 'displayUrl',\n",
+    "    'dimensionsHeight', 'dimensionsWidth', 'images', 'Tipo',\n",
+    "], axis=1, errors='ignore')\n",
+    "df_reels.info()\n"
    ]
   },
   {
@@ -196,47 +114,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "39bb6d5c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'pandas.core.frame.DataFrame'>\n",
-      "RangeIndex: 810 entries, 0 to 809\n",
-      "Data columns (total 21 columns):\n",
-      " #   Column              Non-Null Count  Dtype         \n",
-      "---  ------              --------------  -----         \n",
-      " 0   inputUrl            810 non-null    object        \n",
-      " 1   id                  810 non-null    object        \n",
-      " 2   type                810 non-null    object        \n",
-      " 3   shortCode           810 non-null    object        \n",
-      " 4   caption             809 non-null    object        \n",
-      " 5   mentions            810 non-null    object        \n",
-      " 6   url                 810 non-null    object        \n",
-      " 7   commentsCount       810 non-null    int64         \n",
-      " 8   likesCount          810 non-null    int64         \n",
-      " 9   videoViewCount      564 non-null    float64       \n",
-      " 10  videoPlayCount      564 non-null    float64       \n",
-      " 11  ownerFullName       810 non-null    object        \n",
-      " 12  ownerUsername       810 non-null    object        \n",
-      " 13  ownerId             810 non-null    object        \n",
-      " 14  videoDuration       564 non-null    float64       \n",
-      " 15  isSponsored         810 non-null    bool          \n",
-      " 16  isPinned            810 non-null    bool          \n",
-      " 17  isCommentsDisabled  810 non-null    bool          \n",
-      " 18  coauthorProducers   169 non-null    object        \n",
-      " 19  locationName        346 non-null    object        \n",
-      " 20  data_hora           810 non-null    datetime64[ns]\n",
-      "dtypes: bool(3), datetime64[ns](1), float64(3), int64(2), object(12)\n",
-      "memory usage: 116.4+ KB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dtypes = {\n    'inputUrl': 'object',\n    'id': 'object',\n    'type': 'object',\n    'shortCode': 'object',\n    'caption': 'object',\n    'mentions': 'object',\n    'url': 'object',\n    'commentsCount': 'int64',\n    'likesCount': 'int64',\n    'videoViewCount': 'float64',\n    'videoPlayCount': 'float64',\n    'ownerFullName': 'object',\n    'ownerUsername': 'object',\n    'ownerId': 'object',\n    'videoDuration': 'float64',\n    'isSponsored': 'bool',\n    'isPinned': 'float64',\n    'isCommentsDisabled': 'bool',\n    'coauthorProducers': 'object',\n    'locationName': 'object',\n}\ndf_posts = repo.load_posts().drop([\n    'firstComment', 'latestComments', 'videoUrl', 'alt', 'timestamp', 'childPosts',\n    'productType', 'taggedUsers', 'hashtags', 'displayUrl', 'dimensionsHeight',\n    'dimensionsWidth', 'images', 'Tipo', 'musicInfo', 'locationId',\n], axis=1, errors='ignore')\ndf_posts['isPinned'] = df_posts['isPinned'].astype(bool)\ndf_posts.info()"
+    "df_posts = repo.load_posts().drop([\n",
+    "    'firstComment', 'latestComments', 'videoUrl', 'alt', 'timestamp', 'childPosts',\n",
+    "    'productType', 'taggedUsers', 'hashtags', 'displayUrl', 'dimensionsHeight',\n",
+    "    'dimensionsWidth', 'images', 'Tipo', 'musicInfo', 'locationId',\n",
+    "], axis=1, errors='ignore')\n",
+    "df_posts.info()\n"
    ]
   },
   {

--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import pandas as pd
 import streamlit as st
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -11,7 +12,7 @@ if ROOT_DIR not in sys.path:
 
 from config import settings
 from src.repositories.delta_repository import DeltaRepository
-from src.visualization.charts import plot_top_n_bar
+from src.visualization.charts import plot_top_n_bar, plot_value_counts
 
 # --- CONFIGURAÇÃO DA PÁGINA ---
 st.set_page_config(
@@ -24,10 +25,16 @@ st.set_page_config(
 @st.cache_data
 def load_data():
     repo = DeltaRepository(settings.GOLD_DIR, settings.SILVER_DIR)
-    return repo.load_comments(), repo.load_reels()
+    df_comments, df_reels = repo.load_comments(), repo.load_reels()
+    try:
+        df_clusters = repo.load_clusters()
+    except FileNotFoundError:
+        df_clusters = pd.DataFrame()
+    return df_comments, df_reels, df_clusters
 
 
-df_comments, df_reels = load_data()
+df_comments, df_reels, df_clusters = load_data()
+tem_modelagem = "sentiment_label" in df_comments.columns
 
 # --- BARRA LATERAL (SIDEBAR) PARA FILTROS ---
 st.sidebar.header("Filtros do Dashboard")
@@ -52,11 +59,7 @@ else:
     qtd_reels = int(df_filtrado_comments["id_reel"].nunique())
     qtd_comments = int(df_filtrado_comments["id_comment"].nunique())
     qtd_replies = int(df_filtrado_comments["repliesCount"].sum())
-    qtd_likes = (
-        int(df_filtrado_comments["likesCount_comment"].sum())
-        if "likesCount_comment" in df_filtrado_comments.columns
-        else int(df_filtrado_comments["likesCount"].sum())
-    )
+    qtd_likes = int(df_filtrado_comments["likesCount"].sum())
 
     col1, col2, col3, col4 = st.columns(4)
     col1.metric(label="Qtd de Reels", value=qtd_reels)
@@ -84,33 +87,58 @@ else:
         )
 
     with col2:
-        st.markdown("#### Resumo do Tópico")
-        if not df_filtrado_comments.empty:
-            name_col = (
-                "ownerFullName"
-                if "ownerFullName" in df_filtrado_comments.columns
-                else "owner.username"
-                if "owner.username" in df_filtrado_comments.columns
-                else None
+        st.markdown("#### Distribuição de Sentimento")
+        if tem_modelagem:
+            st.plotly_chart(
+                plot_value_counts(
+                    df_filtrado_comments,
+                    column="sentiment_label",
+                    title="Sentimento dos comentários",
+                ),
+                width="stretch",
             )
-            if name_col:
-                st.write(df_filtrado_comments[name_col].iloc[0])
-
-        cols = [
-            col
-            for col in [
-                "timestamp_comment",
-                "owner.username",
-                "text",
-                "repliesCount",
-                "likesCount_comment",
-            ]
-            if col in df_filtrado_comments.columns
-        ]
-        if cols:
-            st.dataframe(df_filtrado_comments[cols])
         else:
-            st.info("Não há colunas adicionais disponíveis para exibição.")
+            st.info(
+                "Sentimento ainda não gerado para este governador. "
+                "Rode `notebooks/03_modelagem_hibrida.ipynb` para popular `governor_sentiment`."
+            )
+
+    st.markdown("#### Tópicos mais frequentes")
+    if tem_modelagem and "Name" in df_filtrado_comments.columns:
+        df_topicos = (
+            df_filtrado_comments["Name"].value_counts().reset_index(name="count")
+        )
+        df_topicos.columns = ["Name", "count"]
+        st.plotly_chart(
+            plot_top_n_bar(
+                df_topicos, x="count", y="Name", title="Top tópicos por volume de comentários"
+            ),
+            width="stretch",
+        )
+    else:
+        st.info(
+            "Tópicos ainda não gerados para este governador. "
+            "Rode `notebooks/03_modelagem_hibrida.ipynb` para popular `governor_sentiment`."
+        )
+
+    st.markdown("#### Clusters dos reels (AutoClusterHPO)")
+    if df_clusters.empty:
+        st.info(
+            "`governor_clusters` ainda não existe. "
+            "Rode `notebooks/03_modelagem_hibrida.ipynb` para gerá-la."
+        )
+    else:
+        df_reels_com_cluster = df_filtrado_reels.merge(
+            df_clusters, left_on="id", right_on="id_reel", how="inner"
+        )
+        if df_reels_com_cluster.empty:
+            st.info("Nenhum reel deste governador tem cluster atribuído.")
+        else:
+            st.dataframe(
+                df_reels_com_cluster.groupby("cluster_label")
+                .agg(qtd_reels=("id_reel", "nunique"), algoritmo=("cluster_algo", "first"))
+                .reset_index()
+            )
 
 # Para mostrar os dados brutos (opcional)
 if st.checkbox("Mostrar dados brutos filtrados"):

--- a/src/delta_io.py
+++ b/src/delta_io.py
@@ -32,6 +32,22 @@ def conform_to_schema(df: pd.DataFrame, schema: pa.Schema) -> pa.Table:
     return pa.Table.from_pandas(df_conformed, schema=schema, preserve_index=False)
 
 
+def deduplicate_latest(
+    df: pd.DataFrame, id_col: str, timestamp_col: str = "_ingested_at"
+) -> pd.DataFrame:
+    """
+    Mantém apenas a linha mais recente por `id_col`.
+
+    A camada Bronze é append-only e acumula todas as execuções do pipeline;
+    sem isso, reprocessar duplicaria cada registro na Silver.
+    """
+    if id_col not in df.columns:
+        return df
+    if timestamp_col in df.columns:
+        df = df.sort_values(timestamp_col, ascending=False)
+    return df.drop_duplicates(subset=[id_col], keep="first")
+
+
 def write_delta(
     path: Path | str,
     df: pd.DataFrame,

--- a/src/features/gold/model_enricher.py
+++ b/src/features/gold/model_enricher.py
@@ -31,6 +31,13 @@ class ModelEnricher:
         """Grava clusters de reels (AutoClusterHPO). Espera as colunas
         produzidas pelo notebook 03: id, ownerUsername, 'Clusters (AutoClusterHPO)',
         algo_name, score."""
+        required = {"id", "ownerUsername", "Clusters (AutoClusterHPO)", "algo_name", "score"}
+        missing = required - set(df_reels_clustered.columns)
+        if missing:
+            raise ValueError(
+                f"df_reels_clustered não tem as colunas esperadas: {sorted(missing)}"
+            )
+
         df_clusters = pd.DataFrame(
             {
                 "id_reel": df_reels_clustered["id"].values,

--- a/src/features/silver/comment_cleaner.py
+++ b/src/features/silver/comment_cleaner.py
@@ -10,7 +10,7 @@ from typing import ClassVar
 
 import pandas as pd
 
-from src.delta_io import write_delta
+from src.delta_io import deduplicate_latest, write_delta
 from src.schemas_delta import SILVER_COMMENTS_SCHEMA
 
 
@@ -60,7 +60,7 @@ class CommentCleaner:
             df_result = df_result.drop(columns=cols_to_drop)
         df_result["comprimento texto"] = df_result["text"].astype(str).str.len()
         df_result = df_result[df_result["comprimento texto"] < self.MAX_TEXT_LENGTH]
-        df_result = df_result.drop_duplicates()
+        df_result = deduplicate_latest(df_result, id_col="id_comment")
         df_result["_source_layer"] = "bronze"
 
         return df_result

--- a/src/features/silver/post_cleaner.py
+++ b/src/features/silver/post_cleaner.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 
 import pandas as pd
 
-from src.delta_io import write_delta
+from src.delta_io import deduplicate_latest, write_delta
 from src.schemas_delta import SILVER_POSTS_SCHEMA, SILVER_REELS_SCHEMA
 
 
@@ -26,7 +26,7 @@ class PostCleaner:
 
     def clean_posts(self, df_bronze: pd.DataFrame) -> pd.DataFrame:
         df = df_bronze.copy()
-        df = self._deduplicate(df)
+        df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
         df["Tipo"] = "FEED"
         df = self._cast_numerics(df)
@@ -36,7 +36,7 @@ class PostCleaner:
 
     def clean_reels(self, df_bronze: pd.DataFrame) -> pd.DataFrame:
         df = df_bronze.copy()
-        df = self._deduplicate(df)
+        df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
         df["Tipo"] = "REELS"
         df["Total de Engajamento"] = (
@@ -61,18 +61,6 @@ class PostCleaner:
 
     def write_reels(self, df_silver: pd.DataFrame, path: Path | str) -> None:
         write_delta(path, df_silver, SILVER_REELS_SCHEMA)
-
-    def _deduplicate(self, df: pd.DataFrame) -> pd.DataFrame:
-        """
-        A camada Bronze é append-only e acumula todas as execuções. Sem esta
-        deduplicação, reprocessar o pipeline multiplicaria cada publicação e
-        inflaria as métricas de engajamento agregadas na camada Gold.
-        """
-        if "id" not in df.columns:
-            return df
-        if "_ingested_at" in df.columns:
-            df = df.sort_values("_ingested_at", ascending=False)
-        return df.drop_duplicates(subset=["id"], keep="first")
 
     def _parse_timestamp(self, df: pd.DataFrame) -> pd.DataFrame:
         if "timestamp" in df.columns:

--- a/src/features/silver/profile_cleaner.py
+++ b/src/features/silver/profile_cleaner.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 
 import pandas as pd
 
-from src.delta_io import write_delta
+from src.delta_io import deduplicate_latest, write_delta
 from src.schemas_delta import SILVER_PROFILES_SCHEMA
 
 
@@ -51,10 +51,7 @@ class ProfileCleaner:
             if col in df.columns:
                 df[col] = df[col].fillna(False).astype(bool)
 
-        if "id" in df.columns and "_ingested_at" in df.columns:
-            df = df.sort_values("_ingested_at", ascending=False).drop_duplicates(
-                subset=["id"], keep="first"
-            )
+        df = deduplicate_latest(df, id_col="id")
 
         if "fullName" not in df.columns:
             if "username" in df.columns:

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -68,6 +68,13 @@ def plot_correlation_heatmap(df: pd.DataFrame, method: str = "pearson") -> go.Fi
     )
 
 
+def plot_value_counts(df: pd.DataFrame, column: str, title: str) -> go.Figure:
+    """Gráfico de pizza com a contagem de valores de uma coluna categórica."""
+    counts = df[column].value_counts().reset_index(name="count")
+    counts.columns = [column, "count"]
+    return px.pie(counts, names=column, values="count", title=title)
+
+
 def plot_scatter(df: pd.DataFrame, x: str, y: str) -> go.Figure:
     """Gráfico de dispersão interativo."""
     return px.scatter(df, x=x, y=y, hover_data=df.columns, height=800)

--- a/tests/test_model_enricher.py
+++ b/tests/test_model_enricher.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from deltalake import DeltaTable
 
 from src.features.gold.model_enricher import ModelEnricher
@@ -57,3 +58,10 @@ def test_write_clusters_usa_granularidade_de_reel(tmp_path):
     assert len(out) == 2
     assert set(out.columns) >= {"id_reel", "ownerUsername", "cluster_label"}
     assert out.loc[out["id_reel"] == "r2", "cluster_label"].iloc[0] == -1
+
+
+def test_write_clusters_falha_com_mensagem_clara_se_faltar_coluna(tmp_path):
+    df_incompleto = _reels_clusterizados().drop(columns=["algo_name"])
+
+    with pytest.raises(ValueError, match="algo_name"):
+        ModelEnricher().write_clusters(df_incompleto, tmp_path / "governor_clusters", run_id="r1")

--- a/tests/test_silver_cleaners.py
+++ b/tests/test_silver_cleaners.py
@@ -129,3 +129,27 @@ def test_comment_cleaner_promove_colunas_do_comentario():
     assert out.iloc[0]["ownerUsername"] == "eleitor"
     assert out.iloc[0]["likesCount"] == 3
     assert out.iloc[0]["timestamp"].startswith("2026-05-02")
+
+
+def test_comment_cleaner_deduplica_execucoes_acumuladas():
+    """
+    Assim como a Bronze de posts/reels, o mesmo comentário reaparece a cada
+    reprocessamento do pipeline (o reel é reingerido inteiro, com
+    latestComments embutido). Sem deduplicar por id_comment, comentários se
+    acumulariam a cada execução.
+    """
+    comment = '[{"id": "c1", "text": "ok", "ownerUsername": "eleitor"}]'
+    df_reels = pd.DataFrame(
+        {
+            "id": ["r1", "r1"],
+            "ownerUsername": ["governador", "governador"],
+            "latestComments": [comment, comment],
+            "_ingested_at": pd.to_datetime(["2026-05-01", "2026-05-02"], utc=True),
+            "_run_id": ["r1_run", "r2_run"],
+        }
+    )
+
+    out = CommentCleaner().clean(df_reels)
+
+    assert len(out) == 1
+    assert out.iloc[0]["_run_id"] == "r2_run"


### PR DESCRIPTION
Fechamento final da engenharia, seguindo o `/code-review` detalhado rodado sobre a PR #3. A investigação pós-review achou 2 problemas reais que não eram conhecidos antes (não estavam documentados como limitação em lugar nenhum).

## Achados

**`comment_cleaner.py` tinha o mesmo bug de acumulação já corrigido em `post_cleaner`/`profile_cleaner`, só que ainda não aqui.** O dedup era `drop_duplicates()` de linha inteira. Como `_ingested_at`/`_run_id` da Bronze mudam a cada execução do pipeline, duas execuções nunca produziam linhas idênticas — nada era deduplicado entre reprocessamentos, e comentários se acumulariam a cada rerun. Consolidei os três cleaners em `deduplicate_latest()` (`src/delta_io.py`) e corrigi o `comment_cleaner` para deduplicar por `id_comment`.

**`notebooks/02_analise_exploratoria.ipynb` já usava `DeltaRepository`** (não lia mais Excel — isso já estava desatualizado no README), **mas duas células crashavam com `KeyError`.** `df_reels['isPinned']`/`df_posts['isPinned']` nunca chegam no Silver — a coluna foi excluída de propósito, e com razão: a própria célula 25 do notebook documenta que 100% dos 810 reels vêm marcados `isPinned=True`, impossível na prática (Instagram permite no máximo 3), e conclui que a variável "deve ser desconsiderada". Removi as duas linhas e os 3 dicionários `dtype`/`dtypes` órfãos da era `pd.read_excel`. Executei o notebook até a célula 10 com os dados reais para confirmar.

**`pages/02_modeling.py` se chama "Modelagem" mas não mostrava nenhum resultado de modelagem.** Já lia `governor_sentiment`, mas a seção "Resumo do Tópico" checava colunas (`ownerFullName`/`owner.username`) que não existem em nenhum schema do projeto — branch morto. `governor_clusters` nunca era carregado. Agora a página mostra distribuição de sentimento, tópicos mais frequentes e clusters de reels (join com `governor_clusters` por `id`/`id_reel`), com fallback gracioso (`st.info`, não crash) para antes de rodar o notebook 03.

**`write_clusters()` ganhou guard de colunas obrigatórias** — antes falhava com `KeyError` cru se o DataFrame de entrada não tivesse exatamente as colunas esperadas.

README atualizado: notebooks já migrados (removido da lista de pendências), dashboard de modelagem documentado, contagem de testes atualizada (30 → 34).

## Nota à parte: CI

No meio deste trabalho descobri que a CI deste repositório falhava desde setembro de 2025 (`ModuleNotFoundError: No module named 'src'` — `pytest` puro não adiciona a raiz do repo ao `sys.path`, só `python -m pytest` faz isso). Não tinha relação com o conteúdo de nenhuma PR; já foi corrigido e mergeado separadamente (PR #4, `pythonpath = ["."]` em `pyproject.toml`) antes desta branch. Esta PR já nasce com CI verde.

## Test plan

- [x] `pytest tests/ -q` — 34 passando, incluindo 2 testes novos (dedup de comentários, guard de `write_clusters`)
- [x] `ruff check src/` limpo
- [x] Notebook 02 executado (células 0–10) contra dados reais — sem `KeyError`
- [x] `pages/02_modeling.py`: simulei `load_data()` + merge de clusters + as duas funções de gráfico novas em dois cenários (antes e depois de popular `governor_sentiment`/`governor_clusters`) diretamente contra as tabelas Delta reais — sem exceção em nenhum dos dois. Não consegui abrir no navegador nesta sessão (sem browser conectado); a verificação foi só programática.