### PR TITLE
docs+refactor: extrai carregamento de dados dos dashboards (ADR #0002 + implementação)

### DIFF
--- a/docs/adr/0002-extrair-carregamento-de-dados-dos-dashboards-com-acesso-tipado-separado-para-clusters.md
+++ b/docs/adr/0002-extrair-carregamento-de-dados-dos-dashboards-com-acesso-tipado-separado-para-clusters.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+---
+
+# Extrair o carregamento de dados dos dashboards para `src/dashboard/loaders.py`, com acesso tipado separado para a capacidade exclusiva do Delta
+
+## Contexto
+
+Hoje `pages/01_exploratory.py` e `pages/02_modeling.py` cada um define seu próprio `load_data()` decorado com `@st.cache_data`, construindo um `DeltaRepository` internamente e carregando um bundle de tabelas (perfis+comentários+reels numa página, comentários+reels+clusters na outra). Como são funções distintas, o cache do Streamlit não é compartilhado entre páginas — `reels_clean`, por exemplo, é lido do Delta Lake duas vezes por sessão, uma por página, mesmo as duas pedindo os mesmos dados. `charts.py`, por comparação, já é puro (recebe DataFrame, devolve `go.Figure`, sem I/O nem dependência de Streamlit) e tem teste implícito de manter essa pureza.
+
+Além disso, `load_clusters()` só existe em `DeltaRepository` — não está na interface abstrata `DataRepository` (`src/repositories/base.py`), e nem `S3DataRepository` nem `ExcelDataRepository` o implementam, porque clusters são um artefato exclusivo da camada Gold do pipeline Medallion, produzido pelo notebook de modelagem. `S3DataRepository` já existe como implementação alternativa real (não hipotética) do mesmo `DataRepository`.
+
+## Decisão
+
+Criar `src/dashboard/loaders.py` com funções cacheadas granulares por tabela (`load_profiles()`, `load_comments()`, `load_reels()`, `load_clusters()`), cada uma decorada com `@st.cache_data`, em vez de um `load_data()` por página. Como as páginas passam a chamar a mesma função, o Streamlit deduplica o cache entre elas automaticamente.
+
+Por trás dessas funções, dois construtores de repositório cacheados com `st.cache_resource`:
+
+- `get_repository() -> DataRepository` — usado por `load_profiles`, `load_comments`, `load_reels`. Tipado pela interface abstrata.
+- `get_delta_repository() -> DeltaRepository` — usado só por `load_clusters()`. Tipado pelo concreto, e levanta um erro claro se o backend configurado não for Delta.
+
+`src/repositories/base.py` **não muda** — `load_clusters` continua fora da interface abstrata.
+
+## Por que
+
+Separar em dois construtores, em vez de tipar tudo por `DataRepository` (exigindo `load_clusters` na interface, com stub `NotImplementedError` em `S3DataRepository`/`ExcelDataRepository`) ou tudo por `DeltaRepository` (trancando o módulo inteiro no backend concreto), preserva o Strategy pattern que `DataRepository`/`S3DataRepository` já implementam para as três tabelas que toda implementação de fato tem, sem fingir que `load_clusters` é uma capacidade genérica de "repositório de dados processados" quando na verdade é específica do Delta/Gold. Se um dia o dashboard trocar de `DeltaRepository` para `S3DataRepository`, três dos quatro loaders continuam funcionando sem mudança — só `load_clusters()` fica explicitamente marcado como dependente do Delta.
+
+Funções granulares por tabela (em vez de um bundle por página) elimina releitura redundante do Delta Lake entre páginas na mesma sessão, de graça, só por reaproveitar o cache do Streamlit — não é só uma questão de duplicação de código.
+
+## Opções consideradas
+
+- **Um `load_data()` por página (bundle), só extraindo a construção do repositório para um helper comum** — rejeitada: resolveria a duplicação de código, mas não a releitura redundante entre páginas, já que funções diferentes não compartilham cache no Streamlit mesmo pedindo os mesmos dados.
+- **Adicionar `load_clusters` à interface abstrata `DataRepository`**, com stub `NotImplementedError` em `S3DataRepository`/`ExcelDataRepository` — rejeitada: prometeria uma capacidade que só uma implementação tem de verdade, e `S3DataRepository` é um backend real (não hipotético) que este projeto pode querer usar.
+- **Tipar `get_repository()` inteiramente como `DeltaRepository` concreto** — rejeitada: trancaria todos os quatro loaders no backend Delta, quando só `load_clusters()` de fato precisa disso.
+- **Colocar as funções de loader dentro de `src/visualization/`** (irmãs de `charts.py`) — rejeitada: quebraria a pureza de `charts.py`/`visualization/` (hoje sem I/O nem dependência de Streamlit), misturando responsabilidades num módulo que serve de referência de "camada de apresentação sem efeito colateral".
+- **Colocar em `pages/_shared.py`** — rejeitada: `pages/` não tem nenhum teste hoje; manter a lógica de cache em `src/` segue a convenção do resto do repo (tudo em `src/` é testável e testado).
+
+## Consequências
+
+- `src/dashboard/` passa a existir como um novo subpacote, com convenção de teste equivalente à de `src/repositories/` (ver `tests/test_delta_repository.py`) — cobrindo a composição (`get_repository`/`get_delta_repository` resolvendo pro tipo certo, erro claro quando mal configurado), não a leitura do Delta em si, já coberta.
+- `pages/01_exploratory.py` e `pages/02_modeling.py` passam a importar de `src/dashboard/loaders.py` em vez de instanciar `DeltaRepository` diretamente.
+- Se uma futura página precisar de uma tabela ainda não exposta por `loaders.py`, a extensão é aditiva (nova função `load_x()`), não uma reestruturação.

--- a/pages/01_exploratory.py
+++ b/pages/01_exploratory.py
@@ -5,34 +5,28 @@ import sys
 
 import numpy as np
 import pandas as pd
-import plotly.express as px
 import streamlit as st
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from config import settings
-from src.repositories.delta_repository import DeltaRepository
+from src.dashboard.loaders import load_profiles
 from src.visualization.charts import (
     plot_correlation_heatmap,
     plot_dual_axis,
-    plot_top5_bar,
+    plot_scatter,
+    plot_top_n_bar,
 )
 
-st.set_page_config(layout="wide")
+st.set_page_config(
+    page_title="Instagram Analytics — Exploratório",
+    page_icon="📊",
+    layout="wide",
+)
 
 
-@st.cache_data
-def load_data() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    repo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
-    df_profiles = repo.load_profiles()
-    df_comments = repo.load_comments()
-    df_reels = repo.load_reels()
-    return df_profiles, df_comments, df_reels
-
-
-df_profiles, df_comments, df_reels = load_data()
+df_profiles = load_profiles()
 
 
 def media(df: pd.DataFrame, coluna: str) -> float:
@@ -80,21 +74,23 @@ with col6:
 col_freq, col_eng = st.columns(2)
 with col_freq:
     st.plotly_chart(
-        plot_top5_bar(
+        plot_top_n_bar(
             df_profiles,
             x="FREQUENCIA",
             y="username",
             title="Top 5 — Frequência de postagem",
+            top_n=5,
         ),
         use_container_width=True,
     )
 with col_eng:
     st.plotly_chart(
-        plot_top5_bar(
+        plot_top_n_bar(
             df_profiles,
             x="% ENGAJAMENTO",
             y="username",
             title="Top 5 — % de Engajamento",
+            top_n=5,
         ),
         use_container_width=True,
     )
@@ -187,19 +183,7 @@ else:
     # Gera o gráfico apenas se as variáveis dos eixos foram selecionadas
     if x_axis and y_axis:
         with st.spinner("Gerando seu gráfico..."):
-            # Cria a figura do gráfico de dispersão usando Plotly Express
-            fig = px.scatter(
-                df_profiles,
-                x=x_axis,
-                y=y_axis,
-                # title=f'Gráfico de Dispersão: {y_axis.capitalize()} vs. {x_axis.capitalize()}',
-                # Adiciona mais informações ao passar o mouse sobre os pontos
-                hover_data=df_profiles.columns,
-                height=1000,  # <--- ADICIONE ESTA LINHA para ajustar a altura
-                width=1000,
-            )
-
-            # Exibe o gráfico interativo no Streamlit
+            fig = plot_scatter(df_profiles, x=x_axis, y=y_axis, height=1000, width=1000)
             st.plotly_chart(fig, use_container_width=True)
     else:
         st.warning("Por favor, selecione as variáveis para os eixos X e Y.")

--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -3,15 +3,13 @@
 import os
 import sys
 
-import pandas as pd
 import streamlit as st
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from config import settings
-from src.repositories.delta_repository import DeltaRepository
+from src.dashboard.loaders import load_clusters, load_comments, load_reels
 from src.visualization.charts import plot_top_n_bar, plot_value_counts
 
 # --- CONFIGURAÇÃO DA PÁGINA ---
@@ -22,18 +20,7 @@ st.set_page_config(
 )
 
 
-@st.cache_data
-def load_data():
-    repo = DeltaRepository(settings.GOLD_DIR, settings.SILVER_DIR)
-    df_comments, df_reels = repo.load_comments(), repo.load_reels()
-    try:
-        df_clusters = repo.load_clusters()
-    except FileNotFoundError:
-        df_clusters = pd.DataFrame()
-    return df_comments, df_reels, df_clusters
-
-
-df_comments, df_reels, df_clusters = load_data()
+df_comments, df_reels, df_clusters = load_comments(), load_reels(), load_clusters()
 tem_modelagem = "sentiment_label" in df_comments.columns
 
 # --- BARRA LATERAL (SIDEBAR) PARA FILTROS ---

--- a/src/dashboard/loaders.py
+++ b/src/dashboard/loaders.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from config import settings
+from src.repositories.base import DataRepository
+from src.repositories.delta_repository import DeltaRepository
+
+
+@st.cache_resource
+def get_repository() -> DataRepository:
+    return DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
+
+
+@st.cache_resource
+def get_delta_repository() -> DeltaRepository:
+    repo = get_repository()
+    if not isinstance(repo, DeltaRepository):
+        raise TypeError(
+            f"load_clusters() exige DeltaRepository (clusters só existem no Gold via Delta); "
+            f"get_repository() retornou {type(repo).__name__}."
+        )
+    return repo
+
+
+@st.cache_data
+def load_profiles() -> pd.DataFrame:
+    return get_repository().load_profiles()
+
+
+@st.cache_data
+def load_comments() -> pd.DataFrame:
+    return get_repository().load_comments()
+
+
+@st.cache_data
+def load_reels() -> pd.DataFrame:
+    return get_repository().load_reels()
+
+
+@st.cache_data
+def load_clusters() -> pd.DataFrame:
+    try:
+        return get_delta_repository().load_clusters()
+    except FileNotFoundError:
+        return pd.DataFrame()

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -4,17 +4,6 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 
-def plot_top5_bar(
-    df: pd.DataFrame,
-    x: str,
-    y: str,
-    title: str,
-) -> go.Figure:
-    """Gráfico de barras horizontal com top 5. Reutilizável em notebooks e dashboards."""
-    df_sorted = df.sort_values(by=x, ascending=True).tail(5)
-    return px.bar(df_sorted, y=y, x=x, orientation="h", title=title, text_auto=True)
-
-
 def plot_top_n_bar(
     df: pd.DataFrame,
     x: str,
@@ -75,6 +64,8 @@ def plot_value_counts(df: pd.DataFrame, column: str, title: str) -> go.Figure:
     return px.pie(counts, names=column, values="count", title=title)
 
 
-def plot_scatter(df: pd.DataFrame, x: str, y: str) -> go.Figure:
+def plot_scatter(
+    df: pd.DataFrame, x: str, y: str, height: int = 800, width: int | None = None
+) -> go.Figure:
     """Gráfico de dispersão interativo."""
-    return px.scatter(df, x=x, y=y, hover_data=df.columns, height=800)
+    return px.scatter(df, x=x, y=y, hover_data=df.columns, height=height, width=width)

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import streamlit as st
+from deltalake.writer import write_deltalake
+
+from config import settings
+from src.dashboard import loaders
+from src.repositories.delta_repository import DeltaRepository
+
+
+def _clear_caches():
+    st.cache_resource.clear()
+    st.cache_data.clear()
+
+
+def _point_settings_at(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "GOLD_DIR", tmp_path / "gold")
+    monkeypatch.setattr(settings, "SILVER_DIR", tmp_path / "silver")
+    _clear_caches()
+
+
+def test_load_profiles_returns_delta_table(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+    engagement_path = settings.GOLD_DIR / "governor_engagement"
+    df = pd.DataFrame(
+        {
+            "id": ["1"],
+            "username": ["g"],
+            "TOTAL ENGAJAMENTO": [10],
+            "% ENGAJAMENTO": [0.1],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    write_deltalake(str(engagement_path), df, mode="overwrite")
+
+    out = loaders.load_profiles()
+
+    assert "% ENGAJAMENTO" in out.columns
+    _clear_caches()
+
+
+def test_load_clusters_returns_empty_dataframe_when_missing(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+
+    out = loaders.load_clusters()
+
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty
+    _clear_caches()
+
+
+def test_get_delta_repository_resolves_to_delta_repository(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+
+    repo = loaders.get_delta_repository()
+
+    assert isinstance(repo, DeltaRepository)
+    _clear_caches()


### PR DESCRIPTION
## Summary
- Registra o ADR #0002 (`docs/adr/0002-...md`) sobre extração do carregamento de dados dos dashboards.
- Implementa a decisão: novo `src/dashboard/loaders.py` com loaders cacheados granulares por tabela (`load_profiles`/`load_comments`/`load_reels`/`load_clusters`), eliminando releitura duplicada do Delta entre `pages/01_exploratory.py` e `pages/02_modeling.py`.
- `get_repository() -> DataRepository` (abstrato) vs. `get_delta_repository() -> DeltaRepository` (concreto, só para `load_clusters`) — preserva `S3DataRepository` como troca de backend viável no futuro, sem stub `NotImplementedError`.
- Consolida duplicação em `src/visualization/charts.py`: remove `plot_top5_bar` (idêntica a `plot_top_n_bar`); `plot_scatter` agora aceita `height`/`width` em vez do `px.scatter` inline em `01_exploratory.py`.
- `01_exploratory.py` só carregava `df_profiles` de fato (`df_comments`/`df_reels` nunca eram usados) — passou a carregar só o necessário.
- Ganha `page_title`/`page_icon` em `01_exploratory.py`, consistente com `02_modeling.py`.

Decidido em sessão de brainstorming de roadmap via `/grilling`. Não toca em `src/modeling/`, `src/analyzes/AutoClusterHPO.py`, `src/features/gold/model_enricher.py` nem `notebooks/03_modelagem_hibrida.ipynb` (território de outra sessão em paralelo).

## Test plan
- [x] `pytest tests/test_dashboard_loaders.py tests/test_delta_repository.py -v` — 4 passed
- [x] `pytest` (suite completa) — 34 passed, 3 skipped (sem regressão)
- [x] `ruff check src/dashboard/ pages/ src/visualization/charts.py tests/test_dashboard_loaders.py` — all checks passed
- [ ] Verificação visual em `streamlit run app.py` — não foi possível completar neste ambiente (job em background sem acesso de rede ao Chrome do usuário); recomendo rodar localmente antes de mergear.