### PR TITLE
feat(pipeline): adiciona flag opcional run_modeling ao pipeline Medallion

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,13 +213,15 @@ repo_v3 = DeltaRepository(settings.GOLD_DIR, as_of_version=3)
 
 ### Pipeline local
 
-`pipeline.py` orquestra as três camadas e resolve a fonte dos dados em cascata ([`pipeline.py:66-99`](pipeline.py)):
+`pipeline.py` orquestra as três camadas e resolve a fonte dos dados em cascata ([`pipeline.py:62-101`](pipeline.py)):
 
 1. Tabelas Bronze já existentes — o caminho mais barato
 2. JSONs em `data/raw/` — migra para Bronze sem chamar a API
 3. API Apify — só quando não há nada local (consome créditos)
 
 Passar `force_extract=True` pula direto para a API.
+
+`run_medallion_pipeline(..., run_modeling=True)` roda também o estágio determinístico de modelagem (`src.modeling.orchestration.run_deterministic_modeling`) ao final do Gold — desligado por padrão porque é pesado (o embedding do BERTopic sozinho leva ~14 min). O refinamento de tópicos via Gemini nunca é chamado daqui: continua manual, só pelo notebook 03 (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
 
 ### Pipeline serverless
 
@@ -252,7 +254,7 @@ As três Lambdas em `lambdas/` reproduzem o mesmo fluxo sobre S3, encadeadas via
 ├── pages/                  # Dashboards Streamlit (exploratório, modelagem)
 ├── lambdas/                # extract / transform / load para AWS
 ├── notebooks/              # 01 extração · 02 EDA · 03 modelagem · 04 regressão · 05 síntese
-├── tests/                  # 18 arquivos de teste (pytest)
+├── tests/                  # 19 arquivos de teste (pytest)
 ├── data/                   # raw/ · bronze/ · silver/ · gold/ · processed/ (legado)
 ├── reports/
 │   ├── academic/           # TCC completo em LaTeX — 7 capítulos, bibliografia, figuras

--- a/pipeline.py
+++ b/pipeline.py
@@ -11,6 +11,8 @@ from src.features.gold.engagement_aggregator import EngagementAggregator
 from src.features.silver.comment_cleaner import CommentCleaner
 from src.features.silver.post_cleaner import PostCleaner
 from src.features.silver.profile_cleaner import ProfileCleaner
+from src.modeling.config import ModelingConfig
+from src.modeling.orchestration import run_deterministic_modeling
 from src.run_id import build_run_id
 
 
@@ -45,6 +47,7 @@ def run_medallion_pipeline(
     results_limit: int = 30,
     run_id: str | None = None,
     force_extract: bool = False,
+    run_modeling: bool = False,
 ) -> str:
     run_id = build_run_id(run_id)
 
@@ -128,6 +131,22 @@ def run_medallion_pipeline(
         aggregator.write(df_gold, settings.GOLD_ENGAGEMENT)
     except Exception as e:
         raise RuntimeError(f"[GOLD] Falha na agregação de métricas: {e}") from e
+
+    if run_modeling:
+        # Só o estágio determinístico. O refinamento de tópicos via Gemini
+        # (src.modeling.orchestration.refine_topics_with_gemini) fica de
+        # fora de propósito — é uma etapa manual e de revisão humana, não
+        # deve rodar sozinha a cada execução do pipeline (ver ADR 0001).
+        try:
+            print(
+                "[MODELAGEM] Rodando estágio determinístico "
+                "(PCA -> clustering -> sentimento -> tópicos)..."
+            )
+            run_deterministic_modeling(
+                df_reels_silver, df_comments_silver, ModelingConfig(), run_id=run_id
+            )
+        except Exception as e:
+            raise RuntimeError(f"[MODELAGEM] Falha no estágio determinístico: {e}") from e
 
     return run_id
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+
+def _fake_bronze_writer_class(df_profiles, df_posts, df_reels):
+    class FakeBronzeWriter:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_latest_profiles(self):
+            return df_profiles
+
+        def get_latest_posts(self):
+            return df_posts
+
+        def get_latest_reels(self):
+            return df_reels
+
+        def write_profiles(self, *a, **k):
+            pass
+
+        def write_posts(self, *a, **k):
+            pass
+
+        def write_reels(self, *a, **k):
+            pass
+
+    return FakeBronzeWriter
+
+
+def _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver):
+    df_profiles = pd.DataFrame({"id": ["1"]})
+    df_posts = pd.DataFrame({"id": ["1"]})
+    df_reels = pd.DataFrame({"id": ["1"]})
+
+    monkeypatch.setattr(
+        "pipeline.BronzeWriter", _fake_bronze_writer_class(df_profiles, df_posts, df_reels)
+    )
+
+    profile_cleaner = MagicMock()
+    profile_cleaner.clean.return_value = pd.DataFrame({"id": ["1"]})
+    post_cleaner = MagicMock()
+    post_cleaner.clean_posts.return_value = pd.DataFrame({"id": ["1"]})
+    post_cleaner.clean_reels.return_value = df_reels_silver
+    comment_cleaner = MagicMock()
+    comment_cleaner.clean.return_value = df_comments_silver
+    aggregator = MagicMock()
+    aggregator.aggregate.return_value = pd.DataFrame({"id": ["1"]})
+
+    monkeypatch.setattr("pipeline.ProfileCleaner", lambda: profile_cleaner)
+    monkeypatch.setattr("pipeline.PostCleaner", lambda: post_cleaner)
+    monkeypatch.setattr("pipeline.CommentCleaner", lambda: comment_cleaner)
+    monkeypatch.setattr("pipeline.EngagementAggregator", lambda: aggregator)
+
+    fake_run_deterministic_modeling = MagicMock()
+    monkeypatch.setattr("pipeline.run_deterministic_modeling", fake_run_deterministic_modeling)
+    return fake_run_deterministic_modeling
+
+
+def test_run_medallion_pipeline_nao_roda_modelagem_por_padrao(monkeypatch):
+    import pipeline
+
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    fake_modeling = _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+
+    pipeline.run_medallion_pipeline(apify_api_token="token", links=["l"], run_id="r1")
+
+    fake_modeling.assert_not_called()
+
+
+def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(monkeypatch):
+    import pipeline
+
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    fake_modeling = _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+
+    pipeline.run_medallion_pipeline(
+        apify_api_token="token", links=["l"], run_id="r1", run_modeling=True
+    )
+
+    fake_modeling.assert_called_once()
+    args, kwargs = fake_modeling.call_args
+    assert args[0] is df_reels_silver
+    assert args[1] is df_comments_silver
+    assert kwargs["run_id"] == "r1"
+
+
+def test_run_medallion_pipeline_nunca_chama_refinamento_via_gemini(monkeypatch):
+    """O refinamento via Gemini é sempre manual (ver ADR 0001) -- não deve
+    existir nenhum caminho em pipeline.py que o dispare automaticamente."""
+    import pipeline
+
+    assert not hasattr(pipeline, "refine_topics_with_gemini")


### PR DESCRIPTION
## Resumo

Wire a etapa determinística de modelagem no `pipeline.py`, respondendo à pergunta "por que a modelagem não está no pipeline se já temos `src/modeling/`?" — a extração feita na PR #7 deixou isso possível, mas por decisão explícita do ADR 0001 não estava conectado ainda.

- `run_medallion_pipeline(..., run_modeling: bool = False)` — nova flag opcional, desligada por padrão.
- Quando `True`, roda `run_deterministic_modeling(df_reels_silver, df_comments_silver, ModelingConfig(), run_id=run_id)` logo após o Gold-engagement, reaproveitando o mesmo `run_id` do restante do pipeline (mesma convenção que Bronze/Silver/Gold-engagement já usam).
- **O refinamento de tópicos via Gemini continua fora do `pipeline.py` de propósito** — é uma etapa manual, de revisão humana (o texto gerado vira citação no TCC), só disparada pelo notebook 03. Isso não muda nesta PR.
- Desligado por padrão porque é pesado: só o embedding do BERTopic leva ~14 min na base atual, e isso adicionaria esse tempo a toda execução do pipeline mesmo quando o objetivo é só atualizar métricas de engajamento.

## Testes

`tests/test_pipeline.py` (novo — não havia teste de `pipeline.py` ainda): mocka todas as dependências pesadas (`BronzeWriter`, cleaners, `EngagementAggregator`, `run_deterministic_modeling`) para verificar, sem downloads nem custo de API:
- `run_modeling=False` (padrão) → `run_deterministic_modeling` nunca é chamado
- `run_modeling=True` → é chamado com `df_reels_silver`/`df_comments_silver`/`run_id` corretos
- `pipeline.py` nunca expõe nem chama `refine_topics_with_gemini`

- [x] `pytest tests/` — 55 passed, 3 skipped (pré-existentes, não relacionados)
- [x] `ruff check src/ pipeline.py tests/test_pipeline.py` — sem apontamentos