### PR TITLE
feat(modeling): desacopla modelagem do notebook via scripts CLI e checkpoint local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ data/raw/
 data/bronze/
 data/silver/
 data/gold/
+data/model_checkpoints/
 !data/bronze/**/.gitkeep
 !data/silver/**/.gitkeep
 !data/gold/**/.gitkeep

--- a/README.md
+++ b/README.md
@@ -221,7 +221,18 @@ repo_v3 = DeltaRepository(settings.GOLD_DIR, as_of_version=3)
 
 Passar `force_extract=True` pula direto para a API.
 
-`run_medallion_pipeline(..., run_modeling=True)` roda também o estágio determinístico de modelagem (`src.modeling.orchestration.run_deterministic_modeling`) ao final do Gold — desligado por padrão porque é pesado (o embedding do BERTopic sozinho leva ~14 min). O refinamento de tópicos via Gemini nunca é chamado daqui: continua manual, só pelo notebook 03 (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
+`run_medallion_pipeline(..., run_modeling=True)` roda também o estágio determinístico de modelagem (`src.modeling.orchestration.run_deterministic_modeling`) ao final do Gold — desligado por padrão porque é pesado (o embedding do BERTopic sozinho leva ~14 min). O refinamento de tópicos via Gemini nunca é chamado daqui: continua manual, só via `scripts/refine_topics.py` (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
+
+### Scripts de modelagem
+
+O notebook 03 não dispara mais nenhuma escrita — só lê Gold/checkpoint para análise (ver [ADR 0003](docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)). Os disparadores são dois scripts em `scripts/`:
+
+```bash
+uv run python scripts/run_modeling.py                  # estágio determinístico, sobre a Silver existente
+uv run python scripts/refine_topics.py --run-id <ID>    # refinamento manual via Gemini, sobre o checkpoint acima
+```
+
+`run_modeling.py` imprime o `run_id` usado — é esse valor que vai em `--run-id` do `refine_topics.py` (e em `RUN_ID` no notebook 03). Cada chamada de `run_deterministic_modeling` (daqui, do `pipeline.py --run-modeling`, ou do notebook, se alguém ainda chamar diretamente) grava incondicionalmente um checkpoint local em `data/model_checkpoints/<run_id>/` — o `topic_model` do BERTopic, o `df_comments`/`df_reels` provisórios e os modelos de PCA/clustering — porque sem isso o refinamento via Gemini só poderia rodar no mesmo processo que acabou de ajustar o `topic_model`. `refine_topics.py` atualiza esse checkpoint com os rótulos finais depois de refinar.
 
 ### Pipeline serverless
 
@@ -259,10 +270,10 @@ As três Lambdas em `lambdas/` reproduzem o mesmo fluxo sobre S3, encadeadas via
 ├── reports/
 │   ├── academic/           # TCC completo em LaTeX — 7 capítulos, bibliografia, figuras
 │   └── figures/            # Figuras geradas pelos notebooks
-└── scripts/                # Migração para Medallion, sync de figuras para o TCC
+└── scripts/                # run_modeling.py, refine_topics.py, migração para Medallion, sync de figuras para o TCC
 ```
 
-O notebook `03_modelagem_hibrida.ipynb` é um driver fino sobre `src/modeling/`: chama `run_deterministic_modeling` (PCA → `AutoClusterHPO` → sentimento → BERTopic, com representação determinística) e, em seguida, `refine_topics_with_gemini` (refinamento manual dos rótulos de tópico, separado por decisão registrada no [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
+A modelagem roda via `scripts/run_modeling.py` (PCA → `AutoClusterHPO` → sentimento → BERTopic, representação determinística) e `scripts/refine_topics.py` (refinamento manual dos rótulos de tópico via Gemini) — não mais pelo notebook, que virou leitura pura de Gold/checkpoint para análise e visualização (ver [ADR 0003](docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)).
 
 ---
 
@@ -289,15 +300,19 @@ cp .env.example .env      # editar e preencher APIFY_API_TOKEN
 # 4. Gerar as tabelas Delta
 uv run python pipeline.py
 
-# 5. Abrir os dashboards
+# 5. (opcional) Modelagem — preencher API_GEMINI no .env antes do segundo comando
+uv run python scripts/run_modeling.py
+uv run python scripts/refine_topics.py --run-id <ID_IMPRESSO_ACIMA>
+
+# 6. Abrir os dashboards
 uv run streamlit run app.py     # http://localhost:8501
 
-# 6. Testes e lint
+# 7. Testes e lint
 uv run pytest tests/ -v --cov=src --cov-report=term-missing
 uv run ruff check src/
 ```
 
-> **Sobre créditos da API:** os JSONs de `data/raw/` já estão presentes no repositório local, então o passo 4 **não consome créditos Apify** — o pipeline detecta os arquivos e migra para Bronze. Um token só é necessário para coletar dados novos.
+> **Sobre créditos da API:** os JSONs de `data/raw/` já estão presentes no repositório local, então o passo 4 **não consome créditos Apify** — o pipeline detecta os arquivos e migra para Bronze. Um token só é necessário para coletar dados novos. O passo 5 é opcional e pesado (~14 min só o embedding do BERTopic) — pule se só quiser ver os dashboards com dados de modelagem já existentes.
 
 ### Referência rápida de comandos `uv`
 
@@ -332,7 +347,7 @@ O pipeline roda de ponta a ponta: `uv run python pipeline.py` materializa Bronze
 
 Esta seção registra honestamente o que ainda não está fechado.
 
-**O ciclo da modelagem fecha ao rodar o notebook 03.** `notebooks/03_modelagem_hibrida.ipynb` lê Bronze/Silver/Gold via `DeltaRepository` e é um driver fino sobre `src/modeling/`, que faz o trabalho em duas etapas (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)): `run_deterministic_modeling` (PCA → `AutoClusterHPO` → sentimento → BERTopic com representação determinística) grava clusters e sentimento/tópicos provisórios em Gold via `ModelEnricher` sob um `run_id`; em seguida, `refine_topics_with_gemini` reescreve só os rótulos de tópico com o refinamento manual via Gemini, sob um segundo `run_id` — sentimento e tópicos vivem em `governor_sentiment` (os tópicos do BERTopic viajam junto, nas colunas `Topic`/`Name` — não há uma tabela separada), e clusters em `governor_clusters`. A clusterização é por **reel** (PCA de engajamento/duração do vídeo via `AutoClusterHPO`), não por perfil — não há, e nunca houve, clusterização de governadores no projeto. Essa etapa continua sendo executada manualmente, fora do `pipeline.py`: o estágio determinístico já não depende de API externa (usa `KeyBERTInspired` para representação de tópicos), mas o refinamento via `GeminiDocsRefiner` depende de uma API key do Gemini e é uma etapa de revisão humana, não um job batch — motivo pelo qual ficou separada do estágio automatizável. O dashboard de modelagem (`pages/02_modeling.py`) exibe a distribuição de sentimento, os tópicos mais frequentes e os clusters de reels assim que essas tabelas existem — e se ainda não existirem, mostra instruções em vez de quebrar.
+**O ciclo da modelagem fecha via dois scripts, não mais pelo notebook.** `scripts/run_modeling.py` lê a Silver via `DeltaRepository` e roda o estágio determinístico (PCA → `AutoClusterHPO` → sentimento → BERTopic com representação determinística via `KeyBERTInspired`, sem depender de API externa), gravando clusters e sentimento/tópicos provisórios em Gold via `ModelEnricher` sob um `run_id`, e um checkpoint local em `data/model_checkpoints/<run_id>/` (o `topic_model` do BERTopic, `df_comments`/`df_reels`, os modelos de PCA/clustering). `scripts/refine_topics.py --run-id <ID>` carrega esse checkpoint e roda o refinamento manual dos rótulos de tópico via Gemini (`GeminiDocsRefiner`) — depende de uma API key do Gemini e é uma etapa de revisão humana (o texto gerado vira citação no TCC), por isso continua separada e manual mesmo com o estágio determinístico automatizável (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md) e [ADR 0003](docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)); reescreve `governor_sentiment` sob um segundo `run_id` e atualiza o checkpoint com os rótulos finais. Sentimento e tópicos vivem em `governor_sentiment` (os tópicos do BERTopic viajam junto, nas colunas `Topic`/`Name` — não há uma tabela separada), e clusters em `governor_clusters`. A clusterização é por **reel** (PCA de engajamento/duração do vídeo via `AutoClusterHPO`), não por perfil — não há, e nunca houve, clusterização de governadores no projeto. `notebooks/03_modelagem_hibrida.ipynb` agora só lê (`governor_sentiment`/`governor_clusters` da Gold, mais o checkpoint para as visualizações de PCA/validação de cluster) — não dispara nenhuma escrita. O dashboard de modelagem (`pages/02_modeling.py`) exibe a distribuição de sentimento, os tópicos mais frequentes e os clusters de reels assim que essas tabelas existem — e se ainda não existirem, mostra instruções em vez de quebrar.
 
 **Notebooks já migrados para Delta.** Os 5 notebooks usam `DeltaRepository`/`run_medallion_pipeline` — nenhum lê mais `all.xlsx` como fonte de pipeline (o notebook 01 só toca Excel para ler `governadores.xlsx`, a lista de perfis a coletar, que é configuração, não dado).
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -56,6 +56,10 @@ GOLD_ENGAGEMENT = GOLD_DIR / "governor_engagement"
 GOLD_SENTIMENT = GOLD_DIR / "governor_sentiment"
 GOLD_CLUSTERS = GOLD_DIR / "governor_clusters"
 
+# Checkpoints locais do estágio determinístico de modelagem (ver ADR 0003) —
+# não são Delta, ficam fora do git.
+MODEL_CHECKPOINTS_DIR = DATA_DIR / "model_checkpoints"
+
 # S3 prefixes (cloud)
 S3_BRONZE_PREFIX = os.environ.get("S3_BRONZE_PREFIX", "bronze/")
 S3_SILVER_PREFIX = os.environ.get("S3_SILVER_PREFIX", "silver/")

--- a/notebooks/03_modelagem_hibrida.ipynb
+++ b/notebooks/03_modelagem_hibrida.ipynb
@@ -24,15 +24,13 @@
    "id": "8e338c18",
    "metadata": {},
    "outputs": [],
-   "source": "import sys\nimport os\n\n# Adiciona o diretório raiz do projeto ao sys.path\nproject_root = os.path.abspath(os.path.join(os.getcwd(), '..'))\nif project_root not in sys.path:\n    sys.path.append(project_root)\n\nfrom config import settings\nfrom src.repositories.delta_repository import DeltaRepository\nfrom src.modeling.config import ModelingConfig, GeminiRefinerConfig\nfrom src.modeling.orchestration import run_deterministic_modeling, refine_topics_with_gemini\nfrom dotenv import load_dotenv\nimport pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport matplotlib.gridspec as gridspec\nimport seaborn as sns\n\nload_dotenv()\n\npd.set_option('display.float_format', '{:.2f}'.format)\nAPI_KEY = os.getenv(\"API_GEMINI\")\n\nrepo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)"
+   "source": "import sys\nimport os\n\n# Adiciona o diretório raiz do projeto ao sys.path\nproject_root = os.path.abspath(os.path.join(os.getcwd(), '..'))\nif project_root not in sys.path:\n    sys.path.append(project_root)\n\nfrom config import settings\nfrom src.repositories.delta_repository import DeltaRepository\nfrom src.modeling.checkpoint import load_checkpoint\nfrom dotenv import load_dotenv\nimport pandas as pd\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport matplotlib.gridspec as gridspec\nimport seaborn as sns\n\nload_dotenv()\n\npd.set_option('display.float_format', '{:.2f}'.format)\n\nrepo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)"
   },
   {
    "cell_type": "markdown",
    "id": "729e76ba",
    "metadata": {},
-   "source": [
-    "# Leitura de Dados"
-   ]
+   "source": "# Leitura de Dados\n\nEste notebook não dispara nenhuma etapa de escrita — a modelagem roda via\n`scripts/run_modeling.py` e `scripts/refine_topics.py`\n(ver [ADR 0003](../docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)).\nAqui só lemos os resultados: `df_comments` vem direto da Gold\n(`governor_sentiment`, já com o refinamento via Gemini se ele já tiver\nrodado) e `checkpoint` vem do checkpoint local salvo por `run_modeling.py`\npara um `run_id` específico — preencha `RUN_ID` na célula abaixo com o valor\nimpresso por esse script."
   },
   {
    "cell_type": "code",
@@ -48,21 +46,13 @@
    "id": "00c0d9e8",
    "metadata": {},
    "outputs": [],
-   "source": "df_reels = repo.load_reels()\ndf_reels.columns"
+   "source": "RUN_ID = \"PREENCHA_AQUI_COM_O_RUN_ID_IMPRESSO_POR_run_modeling.py\"\n\ncheckpoint = load_checkpoint(RUN_ID)\nprint(f\"Checkpoint carregado para run_id={RUN_ID}\")"
   },
   {
    "cell_type": "markdown",
    "id": "b74ecc06",
    "metadata": {},
-   "source": "# Modelagem determinística (PCA, clusterização, sentimento, tópicos)\n\nA partir daqui, todas as etapas 100% automatizáveis (PCA -> clusterização via\n`AutoClusterHPO` -> sentimento -> tópicos via BERTopic com representação\ndeterminística) rodam em uma única chamada a\n`run_deterministic_modeling`, que já grava os resultados provisórios em Gold\n(ver [ADR 0001](../docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).\nAs seções abaixo só inspecionam o resultado dessa chamada — não recomputam nada.\n\n## Análise de Componentes Principais"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4a04580",
-   "metadata": {},
-   "outputs": [],
-   "source": "# @title\nconfig = ModelingConfig()\n\nresult = run_deterministic_modeling(df_reels, df_comments, config)\n\nprint(f\"run_id (estágio determinístico): {result.run_id}\")"
+   "source": "# Análise de Componentes Principais\n\nAs visualizações abaixo (PCA e validação de cluster) vêm do checkpoint\ncarregado acima — não recomputam nada, só inspecionam o que\n`scripts/run_modeling.py` já calculou e persistiu."
   },
   {
    "cell_type": "code",
@@ -70,7 +60,7 @@
    "id": "077da523",
    "metadata": {},
    "outputs": [],
-   "source": "# @title\n# Porcentagem de variância explicada por cada componente\nexpl_var = result.pca_model.explained_variance_ratio_\ndados = {\n    'Componente': [f'PC{i+1}' for i in range(len(expl_var))],\n    'Variância Explicada': expl_var,\n    'Variancia Acumulada': np.cumsum(expl_var),\n}\ndf_expl_var = pd.DataFrame(dados)\ndf_expl_var"
+   "source": "# @title\n# Porcentagem de variância explicada por cada componente\nexpl_var = checkpoint.pca_model.explained_variance_ratio_\ndados = {\n    'Componente': [f'PC{i+1}' for i in range(len(expl_var))],\n    'Variância Explicada': expl_var,\n    'Variancia Acumulada': np.cumsum(expl_var),\n}\ndf_expl_var = pd.DataFrame(dados)\ndf_expl_var"
   },
   {
    "cell_type": "code",
@@ -78,7 +68,7 @@
    "id": "f094a4e3",
    "metadata": {},
    "outputs": [],
-   "source": "# @title\nloadings = pd.DataFrame(\n    result.pca_model.components_.T,\n    index=config.pca.feature_columns,\n    columns=[f\"PC{i+1}\" for i in range(config.pca.n_components)],\n)\n\nloadings"
+   "source": "# @title\nloadings = pd.DataFrame(\n    checkpoint.pca_model.components_.T,\n    index=checkpoint.pca_feature_columns,\n    columns=[f\"PC{i+1}\" for i in range(checkpoint.pca_model.n_components_)],\n)\n\nloadings"
   },
   {
    "cell_type": "markdown",
@@ -94,7 +84,7 @@
    "id": "dce20790",
    "metadata": {},
    "outputs": [],
-   "source": "print(f\"Melhor algoritmo: {result.cluster_algo_name}\")\nprint(f\"Melhores parâmetros: {result.cluster_config}\")\nprint(f\"Melhor pontuação CVI combinada: {result.cluster_score:.4f}\")"
+   "source": "print(f\"Melhor algoritmo: {checkpoint.cluster_algo_name}\")\nprint(f\"Melhores parâmetros: {checkpoint.cluster_config}\")\nprint(f\"Melhor pontuação CVI combinada: {checkpoint.cluster_score:.4f}\")"
   },
   {
    "cell_type": "code",
@@ -102,7 +92,7 @@
    "id": "264d089f",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_reels.columns"
+   "source": "checkpoint.df_reels.columns"
   },
   {
    "cell_type": "markdown",
@@ -118,7 +108,7 @@
    "id": "37b5ddfc",
    "metadata": {},
    "outputs": [],
-   "source": "print(\"\\nDistribuição dos sentimentos:\")\nresult.df_comments['sentiment_label'].value_counts()"
+   "source": "print(\"\\nDistribuição dos sentimentos:\")\ndf_comments['sentiment_label'].value_counts()"
   },
   {
    "cell_type": "code",
@@ -126,7 +116,7 @@
    "id": "59fc6511",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_comments.columns"
+   "source": "df_comments.columns"
   },
   {
    "cell_type": "markdown",
@@ -142,7 +132,7 @@
    "id": "4a507ab7",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_comments[['text', 'text clean', 'text_demojized']].head()"
+   "source": "checkpoint.df_comments[['text', 'text clean', 'text_demojized']].head()"
   },
   {
    "cell_type": "markdown",
@@ -158,7 +148,7 @@
    "id": "b492261d",
    "metadata": {},
    "outputs": [],
-   "source": "print(f\"Tópicos após redução: {result.topic_model.get_topic_info().shape[0]}\")\nresult.df_comments.head()"
+   "source": "print(f\"Tópicos após redução: {checkpoint.topic_model.get_topic_info().shape[0]}\")\ncheckpoint.df_comments.head()"
   },
   {
    "cell_type": "code",
@@ -166,13 +156,13 @@
    "id": "5d84874c",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_comments.columns"
+   "source": "checkpoint.df_comments.columns"
   },
   {
    "cell_type": "markdown",
    "id": "8e63befb",
    "metadata": {},
-   "source": "# Refinamento de tópicos via Gemini (manual)\n\nEtapa manual e dependente de API paga, separada do estágio determinístico\n(ver [ADR 0001](../docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).\n`refine_topics_with_gemini` reaproveita a clusterização já ajustada via\n`topic_model.update_topics(...)` — não refaz embeddings/UMAP/HDBSCAN, e chama\na API do Gemini uma única vez (ao contrário de passar `GeminiDocsRefiner`\ndireto no construtor do `BERTopic`, que a chamaria duas vezes: em\n`fit_transform` e em `reduce_topics`). Grava os rótulos finais em Gold sob um\nsegundo `run_id`, sem tocar em `governor_clusters`."
+   "source": "# Refinamento de tópicos via Gemini\n\nEsta etapa não roda mais aqui — é feita por\n`scripts/refine_topics.py --run-id <RUN_ID>` (ver\n[ADR 0003](../docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)),\nque também atualiza o checkpoint local com os rótulos finais. A célula\nabaixo só confere, na Gold (`df_comments`, lido no topo do notebook), se os\nrótulos já têm cara de refinamento via Gemini (frases em vez de listas de\npalavras-chave)."
   },
   {
    "cell_type": "code",
@@ -180,7 +170,7 @@
    "id": "d4ad852e",
    "metadata": {},
    "outputs": [],
-   "source": "gemini_config = GeminiRefinerConfig(api_key=API_KEY)\n\nrefinement = refine_topics_with_gemini(\n    result.topic_model, result.docs, result.df_comments, gemini_config\n)\n\nprint(f\"run_id (estágio determinístico): {result.run_id}\")\nprint(f\"run_id (refinamento via Gemini): {refinement.run_id}\")"
+   "source": "df_comments['Name'].drop_duplicates().head()"
   },
   {
    "cell_type": "markdown",
@@ -204,7 +194,7 @@
    "id": "0cb372ce",
    "metadata": {},
    "outputs": [],
-   "source": "def plotarFigura1():\n\n    df = result.df_reels[['PC2_videoDuration', 'PC1_Engajamento_videoPlay']]\n\n    # 2. Criar a figura e os eixos (subplots)\n    # A estrutura da grade continua a mesma: 2 linhas e 4 colunas.\n    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(16, 8))\n\n    # 3. \"Achatando\" o array de eixos para facilitar a iteração\n    axes = axes.flatten()\n\n    # 4. Iterar pelas colunas do DataFrame e plotar cada uma em um eixo\n    # Usamos enumerate(df.columns) para obter tanto o índice (i) quanto o nome da coluna.\n    for i, col_name in enumerate(df.columns):\n        # Selecionamos o eixo atual (axes[i])\n        ax = axes[i]\n\n        # Criamos o boxplot usando os dados da coluna atual (df[col_name])\n        ax.boxplot(df[col_name])\n\n        # Usamos o nome da coluna como título do subplot\n        ax.set_title(f'Boxplot da {col_name}')\n        ax.set_ylabel('Valores')\n\n    # 5. Ajustar o layout para evitar sobreposição\n    plt.tight_layout()\n\n    # 6. Salvar e exibir o gráfico\n    plt.savefig('boxplot_do_dataframe.png')\n\n    # Mostra a figura gerada\n    plt.show()\n\nplotarFigura1()"
+   "source": "def plotarFigura1():\n\n    df = checkpoint.df_reels[['PC2_videoDuration', 'PC1_Engajamento_videoPlay']]\n\n    # 2. Criar a figura e os eixos (subplots)\n    # A estrutura da grade continua a mesma: 2 linhas e 4 colunas.\n    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(16, 8))\n\n    # 3. \"Achatando\" o array de eixos para facilitar a iteração\n    axes = axes.flatten()\n\n    # 4. Iterar pelas colunas do DataFrame e plotar cada uma em um eixo\n    # Usamos enumerate(df.columns) para obter tanto o índice (i) quanto o nome da coluna.\n    for i, col_name in enumerate(df.columns):\n        # Selecionamos o eixo atual (axes[i])\n        ax = axes[i]\n\n        # Criamos o boxplot usando os dados da coluna atual (df[col_name])\n        ax.boxplot(df[col_name])\n\n        # Usamos o nome da coluna como título do subplot\n        ax.set_title(f'Boxplot da {col_name}')\n        ax.set_ylabel('Valores')\n\n    # 5. Ajustar o layout para evitar sobreposição\n    plt.tight_layout()\n\n    # 6. Salvar e exibir o gráfico\n    plt.savefig('boxplot_do_dataframe.png')\n\n    # Mostra a figura gerada\n    plt.show()\n\nplotarFigura1()"
   },
   {
    "cell_type": "markdown",
@@ -272,7 +262,7 @@
    "id": "465ec099",
    "metadata": {},
    "outputs": [],
-   "source": "analiseValidacaoModeloPCA(\n    result.df_reels[['PC2_videoDuration', 'PC1_Engajamento_videoPlay', 'Clusters (AutoClusterHPO)']],\n    result.cluster_algo_name,\n    result.cluster_score,\n)"
+   "source": "analiseValidacaoModeloPCA(\n    checkpoint.df_reels[['PC2_videoDuration', 'PC1_Engajamento_videoPlay', 'Clusters (AutoClusterHPO)']],\n    checkpoint.cluster_algo_name,\n    checkpoint.cluster_score,\n)"
   },
   {
    "cell_type": "code",
@@ -280,7 +270,7 @@
    "id": "92dcadcb",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_reels['Clusters (AutoClusterHPO)'].value_counts()"
+   "source": "checkpoint.df_reels['Clusters (AutoClusterHPO)'].value_counts()"
   },
   {
    "cell_type": "code",
@@ -288,7 +278,7 @@
    "id": "6da7cdd7",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_reels.columns"
+   "source": "checkpoint.df_reels.columns"
   },
   {
    "cell_type": "code",
@@ -296,7 +286,7 @@
    "id": "c6a7c306",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_reels.groupby(['Clusters (AutoClusterHPO)'])[['commentsCount', 'likesCount', 'videoDuration', 'videoPlayCount']].describe().T"
+   "source": "checkpoint.df_reels.groupby(['Clusters (AutoClusterHPO)'])[['commentsCount', 'likesCount', 'videoDuration', 'videoPlayCount']].describe().T"
   },
   {
    "cell_type": "code",
@@ -304,7 +294,7 @@
    "id": "2d95935c",
    "metadata": {},
    "outputs": [],
-   "source": "result.df_reels.columns"
+   "source": "checkpoint.df_reels.columns"
   },
   {
    "cell_type": "code",
@@ -312,7 +302,7 @@
    "id": "0ae5b86f",
    "metadata": {},
    "outputs": [],
-   "source": "df = result.df_reels[result.df_reels['PC1_Engajamento_videoPlay'] > 10].describe()\n\ndf.groupby(['Clusters (AutoClusterHPO)'])[['commentsCount', 'likesCount', 'videoDuration', 'videoPlayCount']].describe().T"
+   "source": "df = checkpoint.df_reels[checkpoint.df_reels['PC1_Engajamento_videoPlay'] > 10].describe()\n\ndf.groupby(['Clusters (AutoClusterHPO)'])[['commentsCount', 'likesCount', 'videoDuration', 'videoPlayCount']].describe().T"
   },
   {
    "cell_type": "markdown",
@@ -328,7 +318,7 @@
    "id": "0df273fa",
    "metadata": {},
    "outputs": [],
-   "source": "df_comments_plot = refinement.df_comments\n\nfig, axes = plt.subplots(1, 3, figsize=(18, 6))\n\n# Define um título principal para a figura inteira.\nfig.suptitle('Análise de Sentimento: Visualizações Principais', fontsize=18, y=1.02)\n\n# --- 3. PLOTAGEM DOS GRÁFICOS ---\n\n# Gráfico 1: Distribuição dos Rótulos (Gráfico de Barras)\nsns.countplot(\n    data=df_comments_plot,\n    x='sentiment_label',\n    order=df_comments_plot['sentiment_label'].value_counts().index,\n    ax=axes[0]\n)\naxes[0].set_title('Distribuição de Sentimentos', fontsize=14)\naxes[0].set_xlabel('Rótulo de Sentimento')\naxes[0].set_ylabel('Contagem de Comentários')\n\n# Gráfico 2: Distribuição da Pontuação (Histograma e Densidade)\nsns.histplot(\n    data=df_comments_plot,\n    x='sentiment_score',\n    kde=True,\n    ax=axes[1],\n    bins=20\n)\naxes[1].set_title('Distribuição das Pontuações de Confiança', fontsize=14)\naxes[1].set_xlabel('Pontuação (Score)')\naxes[1].set_ylabel('Frequência')\n\n# Crie a ordem dinamicamente a partir dos valores únicos\nordem_presente = df_comments_plot['sentiment_label'].unique()\n\n# Em seguida, passe essa lista para o parâmetro 'order'\nsns.boxplot(\n    data=df_comments_plot,\n    x='sentiment_label',\n    y='sentiment_score',\n    order=ordem_presente, # <-- Aqui está a mudança\n    ax=axes[2]\n)\naxes[2].set_title('Distribuição da Pontuação por Sentimento', fontsize=14)\naxes[2].set_xlabel('Rótulo de Sentimento')\naxes[2].set_ylabel('Pontuação (Score)')\n\n# --- 4. EXIBIÇÃO DA FIGURA ---\n# Ajusta o layout para evitar sobreposição de títulos e rótulos.\nplt.tight_layout()\n\nplt.savefig('sentiment_plots.png')\n\n# Exibe a figura completa.\nplt.show()"
+   "source": "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n\n# Define um título principal para a figura inteira.\nfig.suptitle('Análise de Sentimento: Visualizações Principais', fontsize=18, y=1.02)\n\n# --- 3. PLOTAGEM DOS GRÁFICOS ---\n\n# Gráfico 1: Distribuição dos Rótulos (Gráfico de Barras)\nsns.countplot(\n    data=df_comments,\n    x='sentiment_label',\n    order=df_comments['sentiment_label'].value_counts().index,\n    ax=axes[0]\n)\naxes[0].set_title('Distribuição de Sentimentos', fontsize=14)\naxes[0].set_xlabel('Rótulo de Sentimento')\naxes[0].set_ylabel('Contagem de Comentários')\n\n# Gráfico 2: Distribuição da Pontuação (Histograma e Densidade)\nsns.histplot(\n    data=df_comments,\n    x='sentiment_score',\n    kde=True,\n    ax=axes[1],\n    bins=20\n)\naxes[1].set_title('Distribuição das Pontuações de Confiança', fontsize=14)\naxes[1].set_xlabel('Pontuação (Score)')\naxes[1].set_ylabel('Frequência')\n\n# Crie a ordem dinamicamente a partir dos valores únicos\nordem_presente = df_comments['sentiment_label'].unique()\n\n# Em seguida, passe essa lista para o parâmetro 'order'\nsns.boxplot(\n    data=df_comments,\n    x='sentiment_label',\n    y='sentiment_score',\n    order=ordem_presente, # <-- Aqui está a mudança\n    ax=axes[2]\n)\naxes[2].set_title('Distribuição da Pontuação por Sentimento', fontsize=14)\naxes[2].set_xlabel('Rótulo de Sentimento')\naxes[2].set_ylabel('Pontuação (Score)')\n\n# --- 4. EXIBIÇÃO DA FIGURA ---\n# Ajusta o layout para evitar sobreposição de títulos e rótulos.\nplt.tight_layout()\n\nplt.savefig('sentiment_plots.png')\n\n# Exibe a figura completa.\nplt.show()"
   },
   {
    "cell_type": "markdown",
@@ -344,7 +334,7 @@
    "id": "fce8eb70",
    "metadata": {},
    "outputs": [],
-   "source": "refinement.topic_model.visualize_topics()"
+   "source": "checkpoint.topic_model.visualize_topics()"
   },
   {
    "cell_type": "markdown",
@@ -360,7 +350,7 @@
    "id": "c6836abc",
    "metadata": {},
    "outputs": [],
-   "source": "refinement.topic_model.visualize_documents(result.docs)"
+   "source": "checkpoint.topic_model.visualize_documents(checkpoint.docs)"
   },
   {
    "cell_type": "code",
@@ -368,7 +358,7 @@
    "id": "cc6dda68",
    "metadata": {},
    "outputs": [],
-   "source": "hierarchical_topics = refinement.topic_model.hierarchical_topics(result.docs)\nrefinement.topic_model.visualize_hierarchy(hierarchical_topics=hierarchical_topics)"
+   "source": "hierarchical_topics = checkpoint.topic_model.hierarchical_topics(checkpoint.docs)\ncheckpoint.topic_model.visualize_hierarchy(hierarchical_topics=hierarchical_topics)"
   },
   {
    "cell_type": "code",
@@ -376,7 +366,7 @@
    "id": "c4222de0",
    "metadata": {},
    "outputs": [],
-   "source": "refinement.topic_model.visualize_heatmap()"
+   "source": "checkpoint.topic_model.visualize_heatmap()"
   },
   {
    "cell_type": "code",
@@ -384,7 +374,7 @@
    "id": "40619a2e",
    "metadata": {},
    "outputs": [],
-   "source": "(refinement.df_comments.groupby(['Topic', 'Name'])\n            .size()\n            .reset_index(name='Count')\n            .to_excel('topicos.xlsx', index=False))"
+   "source": "(df_comments.groupby(['Topic', 'Name'])\n            .size()\n            .reset_index(name='Count')\n            .to_excel('topicos.xlsx', index=False))"
   }
  ],
  "metadata": {

--- a/scripts/refine_topics.py
+++ b/scripts/refine_topics.py
@@ -1,0 +1,74 @@
+"""
+Refina os rótulos de tópico de um checkpoint já gerado por `run_modeling.py`,
+via Gemini (GeminiDocsRefiner). Etapa manual e de revisão humana -- decida
+quando rodar depois de inspecionar os resultados provisórios em
+`governor_sentiment`. Ver ADR 0003.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.modeling.checkpoint import load_checkpoint, save_checkpoint
+from src.modeling.config import GeminiRefinerConfig
+from src.modeling.orchestration import refine_topics_with_gemini
+
+
+def run(run_id: str) -> str:
+    checkpoint = load_checkpoint(run_id)
+
+    api_key = os.getenv("API_GEMINI")
+    if not api_key:
+        raise ValueError("API_GEMINI nao definida no .env.")
+
+    config = GeminiRefinerConfig(api_key=api_key)
+    refinement = refine_topics_with_gemini(
+        checkpoint.topic_model, checkpoint.docs, checkpoint.df_comments, config
+    )
+
+    # Reescreve o checkpoint em run_id (nao no run_id novo do refinamento):
+    # sem isso, o topic_model salvo em disco ficaria com os rotulos
+    # provisorios do estagio deterministico para sempre, e o notebook 03
+    # mostraria labels desatualizados mesmo depois do refinamento rodar.
+    save_checkpoint(
+        run_id,
+        topic_model=refinement.topic_model,
+        df_comments=refinement.df_comments,
+        df_reels=checkpoint.df_reels,
+        pca_model=checkpoint.pca_model,
+        pca_feature_columns=checkpoint.pca_feature_columns,
+        cluster_model=checkpoint.cluster_model,
+        cluster_config=checkpoint.cluster_config,
+        cluster_score=checkpoint.cluster_score,
+        cluster_algo_name=checkpoint.cluster_algo_name,
+        embedding_model_name=checkpoint.embedding_model_name,
+    )
+
+    return refinement.run_id
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Refina os rotulos de topico de um checkpoint via Gemini "
+            "(etapa manual, ver ADR 0003)."
+        )
+    )
+    parser.add_argument(
+        "--run-id",
+        required=True,
+        help="run_id do checkpoint gerado por run_modeling.py.",
+    )
+    args = parser.parse_args()
+
+    refinement_run_id = run(run_id=args.run_id)
+    # Sem emoji: o console padrao do Windows usa cp1252 e levanta
+    # UnicodeEncodeError ao imprimi-los.
+    print(f"[OK] Refinamento via Gemini concluido com run_id: {refinement_run_id}")

--- a/scripts/run_modeling.py
+++ b/scripts/run_modeling.py
@@ -1,0 +1,52 @@
+"""
+Roda o estágio determinístico de modelagem (PCA -> clustering -> sentimento
+-> tópicos) sobre a Silver já existente, sem reprocessar Bronze/Silver/
+Gold-engagement. Ver ADR 0003.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from config import settings
+from src.modeling.config import ModelingConfig
+from src.modeling.orchestration import run_deterministic_modeling
+from src.repositories.delta_repository import DeltaRepository
+
+
+def run(run_id: str | None = None) -> str:
+    repo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
+    df_reels = repo.load_reels()
+    df_comments = repo.load_comments()
+
+    result = run_deterministic_modeling(
+        df_reels, df_comments, ModelingConfig(), run_id=run_id
+    )
+    return result.run_id
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Roda o estagio deterministico de modelagem "
+            "(PCA, clustering, sentimento, topicos) sobre a Silver existente."
+        )
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="run_id a usar para esta execucao (default: gerado automaticamente).",
+    )
+    args = parser.parse_args()
+
+    run_id = run(run_id=args.run_id)
+    # Sem emoji: o console padrao do Windows usa cp1252 e levanta
+    # UnicodeEncodeError ao imprimi-los.
+    print(f"[OK] Modelagem deterministica concluida com run_id: {run_id}")
+    print(f"[OK] Checkpoint salvo em: {settings.MODEL_CHECKPOINTS_DIR / run_id}")

--- a/src/modeling/checkpoint.py
+++ b/src/modeling/checkpoint.py
@@ -1,0 +1,124 @@
+"""Persistência local do checkpoint do estágio determinístico (ver ADR 0003)"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from bertopic import BERTopic
+
+from config import settings
+
+
+@dataclass
+class DeterministicCheckpoint:
+    topic_model: BERTopic
+    df_comments: pd.DataFrame
+    df_reels: pd.DataFrame
+    docs: list[str]
+    pca_model: object
+    pca_feature_columns: list[str]
+    cluster_model: object
+    cluster_config: dict | None
+    cluster_score: float
+    cluster_algo_name: str | None
+    embedding_model_name: str
+
+
+def save_checkpoint(
+    run_id: str,
+    *,
+    topic_model: BERTopic,
+    df_comments: pd.DataFrame,
+    df_reels: pd.DataFrame,
+    pca_model: object,
+    pca_feature_columns: list[str],
+    cluster_model: object,
+    cluster_config: dict | None,
+    cluster_score: float,
+    cluster_algo_name: str | None,
+    embedding_model_name: str,
+    checkpoints_dir: Path | None = None,
+) -> Path:
+    """Grava o checkpoint de `run_id` em `<checkpoints_dir>/<run_id>/`.
+
+    `df_reels` (com `PC1_Engajamento_videoPlay`/`PC2_videoDuration`/
+    `Clusters (AutoClusterHPO)`) é persistido porque `governor_clusters` no
+    Gold só guarda `cluster_label`, não as coordenadas de PCA — sem isso o
+    notebook não conseguiria reproduzir o gráfico de validação do cluster
+    sem reprocessar a Silver.
+
+    O modelo de embedding não é reserializado junto do `topic_model`
+    (`save_embedding_model=False`) — é grande, compartilhado entre execuções
+    e já reproduzível a partir do nome (`embedding_model_name`), então
+    duplicá-lo a cada checkpoint só desperdiçaria disco."""
+    checkpoint_dir = (checkpoints_dir or settings.MODEL_CHECKPOINTS_DIR) / run_id
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    topic_model.save(
+        str(checkpoint_dir / "topic_model"),
+        serialization="pickle",
+        save_embedding_model=False,
+    )
+    df_comments.to_parquet(checkpoint_dir / "df_comments.parquet", index=False)
+    # 'model'/'config' (de cluster_reels) carregam objeto sklearn/dict cru
+    # broadcast em toda linha -- não são serializáveis em parquet e já
+    # ficam redundantes com cluster_model.joblib/metadata.json abaixo.
+    df_reels.drop(columns=["model", "config"], errors="ignore").to_parquet(
+        checkpoint_dir / "df_reels.parquet", index=False
+    )
+    joblib.dump(pca_model, checkpoint_dir / "pca_model.joblib")
+    joblib.dump(cluster_model, checkpoint_dir / "cluster_model.joblib")
+
+    metadata = {
+        "cluster_config": cluster_config,
+        "cluster_score": cluster_score,
+        "cluster_algo_name": cluster_algo_name,
+        "embedding_model_name": embedding_model_name,
+        "pca_feature_columns": pca_feature_columns,
+    }
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return checkpoint_dir
+
+
+def load_checkpoint(
+    run_id: str, checkpoints_dir: Path | None = None
+) -> DeterministicCheckpoint:
+    """Carrega o checkpoint de `run_id`. `docs` é derivado de
+    `df_comments['text_demojized']`, não persistido à parte — evita os dois
+    artefatos dessincronizarem."""
+    checkpoint_dir = (checkpoints_dir or settings.MODEL_CHECKPOINTS_DIR) / run_id
+    if not checkpoint_dir.exists():
+        raise FileNotFoundError(
+            f"Checkpoint não encontrado para run_id={run_id!r} em {checkpoint_dir}"
+        )
+
+    metadata = json.loads((checkpoint_dir / "metadata.json").read_text(encoding="utf-8"))
+    topic_model = BERTopic.load(
+        str(checkpoint_dir / "topic_model"),
+        embedding_model=metadata["embedding_model_name"],
+    )
+    df_comments = pd.read_parquet(checkpoint_dir / "df_comments.parquet")
+    df_reels = pd.read_parquet(checkpoint_dir / "df_reels.parquet")
+    docs = df_comments["text_demojized"].tolist()
+    pca_model = joblib.load(checkpoint_dir / "pca_model.joblib")
+    cluster_model = joblib.load(checkpoint_dir / "cluster_model.joblib")
+
+    return DeterministicCheckpoint(
+        topic_model=topic_model,
+        df_comments=df_comments,
+        df_reels=df_reels,
+        docs=docs,
+        pca_model=pca_model,
+        pca_feature_columns=metadata["pca_feature_columns"],
+        cluster_model=cluster_model,
+        cluster_config=metadata["cluster_config"],
+        cluster_score=metadata["cluster_score"],
+        cluster_algo_name=metadata["cluster_algo_name"],
+        embedding_model_name=metadata["embedding_model_name"],
+    )

--- a/src/modeling/config.py
+++ b/src/modeling/config.py
@@ -81,6 +81,7 @@ class ModelingConfig:
     topics: TopicModelConfig = field(default_factory=TopicModelConfig)
     gold_clusters_path: Path = settings.GOLD_CLUSTERS
     gold_sentiment_path: Path = settings.GOLD_SENTIMENT
+    checkpoints_dir: Path = settings.MODEL_CHECKPOINTS_DIR
 
 
 @dataclass

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -8,6 +8,7 @@ import pandas as pd
 from bertopic import BERTopic
 
 from src.features.gold.model_enricher import ModelEnricher
+from src.modeling.checkpoint import save_checkpoint
 from src.modeling.clustering import cluster_reels
 from src.modeling.config import GeminiRefinerConfig, ModelingConfig
 from src.modeling.gemini_refiner import apply_gemini_refinement
@@ -70,6 +71,25 @@ def run_deterministic_modeling(
     enricher = ModelEnricher()
     enricher.write_clusters(df_reels_clustered, config.gold_clusters_path, run_id)
     enricher.write_sentiment(df_comments_final, config.gold_sentiment_path, run_id)
+
+    # Checkpoint incondicional (ver ADR 0003): sem ele, o refinamento via
+    # Gemini só poderia rodar no mesmo processo que acabou de ajustar o
+    # topic_model — tornar isso opcional reintroduziria a dependência do
+    # notebook que essa separação existe para eliminar.
+    save_checkpoint(
+        run_id,
+        topic_model=topic_model,
+        df_comments=df_comments_final,
+        df_reels=df_reels_clustered,
+        pca_model=pca_model,
+        pca_feature_columns=config.pca.feature_columns,
+        cluster_model=cluster_model,
+        cluster_config=cluster_config,
+        cluster_score=cluster_score,
+        cluster_algo_name=cluster_algo_name,
+        embedding_model_name=config.topics.embedding_model,
+        checkpoints_dir=config.checkpoints_dir,
+    )
 
     return DeterministicModelingResult(
         df_reels=df_reels_clustered,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,163 @@
+from unittest.mock import MagicMock
+
+import hdbscan
+import numpy as np
+import pandas as pd
+import pytest
+from bertopic import BERTopic
+from bertopic.backend import BaseEmbedder
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+
+from src.modeling.checkpoint import load_checkpoint, save_checkpoint
+
+
+class _FakeEmbedder(BaseEmbedder):
+    def embed(self, documents, verbose: bool = False):
+        rng = np.random.default_rng(0)
+        return rng.normal(size=(len(documents), 5))
+
+
+def _fit_tiny_topic_model():
+    docs = [f"doc numero {i} sobre tema {i % 3}" for i in range(15)]
+    topic_model = BERTopic(
+        embedding_model=_FakeEmbedder(),
+        calculate_probabilities=False,
+        verbose=False,
+        hdbscan_model=hdbscan.HDBSCAN(min_cluster_size=3, min_samples=1),
+    )
+    topic_model.fit_transform(docs)
+    return topic_model, docs
+
+
+def _df_comments(docs, topic_model):
+    info = topic_model.get_document_info(docs)
+    df = pd.DataFrame({"text_demojized": docs, "id_comment": [str(i) for i in range(len(docs))]})
+    return pd.concat([df.reset_index(drop=True), info.reset_index(drop=True)], axis=1)
+
+
+def _df_reels():
+    return pd.DataFrame(
+        {
+            "id": ["r1", "r2"],
+            "ownerUsername": ["gov_a", "gov_b"],
+            "PC1_Engajamento_videoPlay": [0.1, 0.2],
+            "PC2_videoDuration": [1.0, 2.0],
+            "Clusters (AutoClusterHPO)": [0, 1],
+            # 'model'/'config' reproduzem o que cluster_reels realmente produz:
+            # objeto sklearn cru e dict, broadcast em toda linha.
+            "model": [None, None],
+            "config": [{"n_clusters": 2}, {"n_clusters": 2}],
+            "score": [0.5, 0.5],
+            "algo_name": ["KMeans", "KMeans"],
+        }
+    )
+
+
+def test_save_checkpoint_grava_todos_os_artefatos(tmp_path):
+    topic_model, docs = _fit_tiny_topic_model()
+    df_comments = _df_comments(docs, topic_model)
+    pca_model = PCA(n_components=2).fit(np.random.rand(10, 4))
+    cluster_model = KMeans(n_clusters=2, n_init="auto").fit(np.random.rand(10, 2))
+
+    checkpoint_dir = save_checkpoint(
+        "run_teste",
+        topic_model=topic_model,
+        df_comments=df_comments,
+        df_reels=_df_reels(),
+        pca_model=pca_model,
+        pca_feature_columns=["commentsCount", "likesCount", "videoPlayCount", "videoDuration"],
+        cluster_model=cluster_model,
+        cluster_config={"n_clusters": 2},
+        cluster_score=0.42,
+        cluster_algo_name="KMeans",
+        embedding_model_name="modelo-fake",
+        checkpoints_dir=tmp_path,
+    )
+
+    assert checkpoint_dir == tmp_path / "run_teste"
+    assert (checkpoint_dir / "topic_model").exists()
+    assert (checkpoint_dir / "df_comments.parquet").exists()
+    assert (checkpoint_dir / "df_reels.parquet").exists()
+    assert (checkpoint_dir / "pca_model.joblib").exists()
+    assert (checkpoint_dir / "cluster_model.joblib").exists()
+    assert (checkpoint_dir / "metadata.json").exists()
+
+
+def test_save_checkpoint_descarta_colunas_model_config_do_df_reels(tmp_path):
+    """'model'/'config' (de cluster_reels) carregam objeto sklearn/dict cru
+    -- não são serializáveis em parquet e são redundantes com
+    cluster_model.joblib/metadata.json."""
+    topic_model, docs = _fit_tiny_topic_model()
+    df_comments = _df_comments(docs, topic_model)
+
+    save_checkpoint(
+        "run_teste",
+        topic_model=topic_model,
+        df_comments=df_comments,
+        df_reels=_df_reels(),
+        pca_model=PCA(n_components=2).fit(np.random.rand(10, 4)),
+        pca_feature_columns=["a", "b", "c", "d"],
+        cluster_model=KMeans(n_clusters=2, n_init="auto").fit(np.random.rand(10, 2)),
+        cluster_config={},
+        cluster_score=0.1,
+        cluster_algo_name="KMeans",
+        embedding_model_name="modelo-fake",
+        checkpoints_dir=tmp_path,
+    )
+
+    df_reels_persistido = pd.read_parquet(tmp_path / "run_teste" / "df_reels.parquet")
+    assert "model" not in df_reels_persistido.columns
+    assert "config" not in df_reels_persistido.columns
+
+
+def test_load_checkpoint_reconstroi_docs_e_metadados(tmp_path, monkeypatch):
+    topic_model, docs = _fit_tiny_topic_model()
+    df_comments = _df_comments(docs, topic_model)
+
+    save_checkpoint(
+        "run_teste",
+        topic_model=topic_model,
+        df_comments=df_comments,
+        df_reels=_df_reels(),
+        pca_model=PCA(n_components=2).fit(np.random.rand(10, 4)),
+        pca_feature_columns=["commentsCount", "likesCount", "videoPlayCount", "videoDuration"],
+        cluster_model=KMeans(n_clusters=2, n_init="auto").fit(np.random.rand(10, 2)),
+        cluster_config={"n_clusters": 2},
+        cluster_score=0.42,
+        cluster_algo_name="KMeans",
+        embedding_model_name="modelo-fake",
+        checkpoints_dir=tmp_path,
+    )
+
+    # BERTopic.load tentaria baixar 'modelo-fake' do HuggingFace Hub -- não
+    # é um modelo real, então stubamos só essa reconstrução. O resto do
+    # load_checkpoint (parquet/joblib/json) roda de verdade.
+    fake_loaded_model = MagicMock(name="loaded_topic_model")
+    monkeypatch.setattr(
+        "src.modeling.checkpoint.BERTopic.load",
+        staticmethod(lambda path, embedding_model=None: fake_loaded_model),
+    )
+
+    checkpoint = load_checkpoint("run_teste", checkpoints_dir=tmp_path)
+
+    assert checkpoint.topic_model is fake_loaded_model
+    assert checkpoint.docs == docs
+    assert len(checkpoint.df_comments) == len(docs)
+    assert list(checkpoint.df_reels["id"]) == ["r1", "r2"]
+    assert checkpoint.pca_feature_columns == [
+        "commentsCount",
+        "likesCount",
+        "videoPlayCount",
+        "videoDuration",
+    ]
+    assert checkpoint.cluster_score == 0.42
+    assert checkpoint.cluster_algo_name == "KMeans"
+    assert checkpoint.embedding_model_name == "modelo-fake"
+    assert isinstance(checkpoint.pca_model, PCA)
+    assert isinstance(checkpoint.cluster_model, KMeans)
+
+
+def test_load_checkpoint_falha_com_mensagem_clara_se_run_id_nao_existe(tmp_path):
+    with pytest.raises(FileNotFoundError, match="run_id_inexistente"):
+        load_checkpoint("run_id_inexistente", checkpoints_dir=tmp_path)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -70,6 +70,7 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
 
     result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
@@ -81,6 +82,13 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
     assert (clusters_out["_run_id"] == result.run_id).all()
     assert (sentiment_out["_run_id"] == result.run_id).all()
     assert (sentiment_out["Name"] == "0_provisorio").all()
+
+    checkpoint_dir = config.checkpoints_dir / result.run_id
+    assert (checkpoint_dir / "metadata.json").exists()
+    assert (checkpoint_dir / "df_reels.parquet").exists()
+    assert (checkpoint_dir / "df_comments.parquet").exists()
+    assert (checkpoint_dir / "pca_model.joblib").exists()
+    assert (checkpoint_dir / "cluster_model.joblib").exists()
 
 
 def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
@@ -101,6 +109,7 @@ def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
+        checkpoints_dir=tmp_path / "checkpoints",
     )
     result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
 

--- a/tests/test_refine_topics_script.py
+++ b/tests/test_refine_topics_script.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_run_falha_sem_api_gemini(monkeypatch):
+    import scripts.refine_topics as refine_topics_script
+
+    monkeypatch.delenv("API_GEMINI", raising=False)
+    monkeypatch.setattr(
+        "scripts.refine_topics.load_checkpoint", lambda run_id: MagicMock()
+    )
+
+    with pytest.raises(ValueError, match="API_GEMINI"):
+        refine_topics_script.run(run_id="run_abc")
+
+
+def test_run_refina_e_resalva_checkpoint_no_run_id_original(monkeypatch):
+    import scripts.refine_topics as refine_topics_script
+
+    monkeypatch.setenv("API_GEMINI", "fake-key")
+
+    fake_checkpoint = MagicMock(
+        topic_model="topic_model_original",
+        docs=["doc1"],
+        df_comments="df_comments_original",
+        df_reels="df_reels_x",
+        pca_model="pca_x",
+        pca_feature_columns=["a"],
+        cluster_model="cluster_x",
+        cluster_config={},
+        cluster_score=0.1,
+        cluster_algo_name="KMeans",
+        embedding_model_name="modelo-fake",
+    )
+    monkeypatch.setattr(
+        "scripts.refine_topics.load_checkpoint", lambda run_id: fake_checkpoint
+    )
+
+    fake_refinement = MagicMock(
+        topic_model="topic_model_refinado",
+        df_comments="df_comments_refinado",
+        run_id="run_refinamento",
+    )
+    fake_refine = MagicMock(return_value=fake_refinement)
+    monkeypatch.setattr("scripts.refine_topics.refine_topics_with_gemini", fake_refine)
+
+    fake_save_checkpoint = MagicMock()
+    monkeypatch.setattr("scripts.refine_topics.save_checkpoint", fake_save_checkpoint)
+
+    result_run_id = refine_topics_script.run(run_id="run_original")
+
+    assert result_run_id == "run_refinamento"
+
+    fake_refine.assert_called_once()
+    call_args = fake_refine.call_args
+    assert call_args.args[0] == "topic_model_original"
+    assert call_args.args[1] == ["doc1"]
+    assert call_args.args[2] == "df_comments_original"
+    assert call_args.args[3].api_key == "fake-key"
+
+    fake_save_checkpoint.assert_called_once()
+    assert fake_save_checkpoint.call_args.args[0] == "run_original"
+    save_kwargs = fake_save_checkpoint.call_args.kwargs
+    assert save_kwargs["topic_model"] == "topic_model_refinado"
+    assert save_kwargs["df_comments"] == "df_comments_refinado"
+    assert save_kwargs["df_reels"] == "df_reels_x"
+    assert save_kwargs["pca_model"] == "pca_x"
+    assert save_kwargs["cluster_algo_name"] == "KMeans"
+    assert save_kwargs["embedding_model_name"] == "modelo-fake"

--- a/tests/test_run_modeling_script.py
+++ b/tests/test_run_modeling_script.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+
+def test_run_le_silver_e_chama_run_deterministic_modeling(monkeypatch):
+    import scripts.run_modeling as run_modeling_script
+
+    fake_repo = MagicMock()
+    fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
+    fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
+
+    fake_result = MagicMock(run_id="run_abc")
+    fake_run_deterministic_modeling = MagicMock(return_value=fake_result)
+    monkeypatch.setattr(
+        "scripts.run_modeling.run_deterministic_modeling", fake_run_deterministic_modeling
+    )
+
+    run_id = run_modeling_script.run(run_id="run_fixo")
+
+    assert run_id == "run_abc"
+    fake_run_deterministic_modeling.assert_called_once()
+    args, kwargs = fake_run_deterministic_modeling.call_args
+    assert args[0] is fake_repo.load_reels.return_value
+    assert args[1] is fake_repo.load_comments.return_value
+    assert kwargs["run_id"] == "run_fixo"
+
+
+def test_run_sem_run_id_deixa_orquestrador_gerar_um_novo(monkeypatch):
+    import scripts.run_modeling as run_modeling_script
+
+    fake_repo = MagicMock()
+    fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
+    fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
+
+    fake_run_deterministic_modeling = MagicMock(return_value=MagicMock(run_id="gerado"))
+    monkeypatch.setattr(
+        "scripts.run_modeling.run_deterministic_modeling", fake_run_deterministic_modeling
+    )
+
+    run_modeling_script.run()
+
+    kwargs = fake_run_deterministic_modeling.call_args.kwargs
+    assert kwargs["run_id"] is None


### PR DESCRIPTION
## Resumo

Implementa o [ADR 0003](docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md) (já mergeado): elimina a dependência do notebook 03 para disparar qualquer etapa de escrita da modelagem.

- **`scripts/run_modeling.py`** — lê a Silver via `DeltaRepository`, roda `run_deterministic_modeling(df_reels, df_comments, ModelingConfig())`. `--run-id` opcional, imprime o `run_id` ao final.
- **`scripts/refine_topics.py --run-id <ID>`** — carrega o checkpoint daquele `run_id` e roda `refine_topics_with_gemini(...)`. Depois de refinar, **resalva o checkpoint** com o `topic_model`/`df_comments` atualizados — sem isso, o `topic_model` em disco ficaria preso aos rótulos provisórios do estágio determinístico para sempre, mesmo depois do refinamento rodar (achei esse gap durante a implementação, ao desenhar as visualizações do notebook).
- **`src/modeling/checkpoint.py`** (novo) — `save_checkpoint`/`load_checkpoint`. `run_deterministic_modeling` passa a persistir, **incondicionalmente**, em `data/model_checkpoints/<run_id>/`: `topic_model/` (via `BERTopic.save(..., save_embedding_model=False)` — o embedding não é reserializado, é reconstruído pelo nome no load, pra não duplicar um artefato grande e compartilhado), `df_comments.parquet`, `df_reels.parquet`, `pca_model.joblib`, `cluster_model.joblib`, `metadata.json` (inclui `pca_feature_columns`, necessário porque o `PCA` é ajustado sobre um array numpy sem nomes de coluna).
- **`notebooks/03_modelagem_hibrida.ipynb`** — vira leitura pura: `df_comments` vem direto de `governor_sentiment` (Gold, já com o refinamento se tiver rodado); `checkpoint = load_checkpoint(RUN_ID)` alimenta as visualizações de PCA/validação de cluster/tópicos que não têm equivalente na Gold (schema do Gold não carrega PC1/PC2 nem as colunas ricas do BERTopic). Nenhuma célula chama `run_deterministic_modeling`/`refine_topics_with_gemini` mais.
- `pyproject.toml`/deps: nenhuma nova — `joblib` já vem transitivamente via `scikit-learn`.

## Ajustes descobertos durante a implementação (dentro do escopo do ADR, não pedem nova decisão)

- `ModelingConfig` ganhou `checkpoints_dir` (mesmo padrão de `gold_clusters_path`/`gold_sentiment_path`) — sem isso não haveria como os testes (nem callers futuros) redirecionar onde o checkpoint é escrito.
- O checkpoint também guarda `df_reels` (não só `df_comments`) — `governor_clusters` no Gold só tem `cluster_label`, não `PC1`/`PC2`, então sem persistir `df_reels` o notebook não conseguiria reproduzir o gráfico de validação do cluster. As colunas `model`/`config` (objeto sklearn cru e dict, broadcast em toda linha por `cluster_reels`) são descartadas antes do parquet — não são serializáveis e já são redundantes com `cluster_model.joblib`/`metadata.json`.
- `refine_topics.py` resalva o checkpoint (detalhe acima).

## Testes

- `tests/test_checkpoint.py` — round-trip completo de `save_checkpoint`/`load_checkpoint` com um `BERTopic` real (ajustado via embedder fake, sem baixar modelo), incluindo o descarte de `model`/`config`. Só a reconstrução do embedding real é stubada (`BERTopic.load`), já que passar um nome de modelo real bateria na rede.
- `tests/test_orchestration.py` — passou a afirmar que o checkpoint é criado com os artefatos esperados.
- `tests/test_run_modeling_script.py`, `tests/test_refine_topics_script.py` — lógica dos dois scripts (leitura da Silver, geração/reuso de `run_id`, falha clara sem `API_GEMINI`, resalvamento do checkpoint), tudo mocado.

- [x] `pytest tests/` — 66 passed, 3 skipped (pré-existentes, não relacionados)
- [x] `ruff check src/` — sem apontamentos (comando usado pela CI; `scripts/` tem alguns `E402` pré-existentes do padrão `sys.path.insert` + import, igual `migrate_to_medallion.py` já tinha — CI não linta `scripts/`)
- [x] Sem referências remanescentes a `result.df_reels`/`refinement.df_comments` fora do uso legítimo em `refine_topics.py`

## Fora de escopo

Não mexe em nomes de coluna, schema Gold, nem em política de retenção de checkpoints (fica manual, conforme o ADR).