### PR TITLE
fix(pipeline): expõe --run-modeling como flag de CLI real

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ repo_v3 = DeltaRepository(settings.GOLD_DIR, as_of_version=3)
 
 Passar `force_extract=True` pula direto para a API.
 
-`run_medallion_pipeline(..., run_modeling=True)` roda também o estágio determinístico de modelagem (`src.modeling.orchestration.run_deterministic_modeling`) ao final do Gold — desligado por padrão porque é pesado (o embedding do BERTopic sozinho leva ~14 min). O refinamento de tópicos via Gemini nunca é chamado daqui: continua manual, só via `scripts/refine_topics.py` (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
+`uv run python pipeline.py --run-modeling` (ou `run_medallion_pipeline(..., run_modeling=True)` chamado diretamente) roda também o estágio determinístico de modelagem (`src.modeling.orchestration.run_deterministic_modeling`) ao final do Gold — desligado por padrão porque é pesado (o embedding do BERTopic sozinho leva ~14 min). O refinamento de tópicos via Gemini nunca é chamado daqui: continua manual, só via `scripts/refine_topics.py` (ver [ADR 0001](docs/adr/0001-separar-modelagem-em-etapas-deterministicas-e-refinamento-manual.md)).
 
 ### Scripts de modelagem
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -152,8 +152,22 @@ def run_medallion_pipeline(
 
 
 if __name__ == "__main__":
+    import argparse
+
     load_dotenv()
     import pandas as pd
+
+    parser = argparse.ArgumentParser(description="Roda o pipeline Medallion (Bronze/Silver/Gold).")
+    parser.add_argument(
+        "--run-modeling",
+        action="store_true",
+        help=(
+            "Roda tambem o estagio deterministico de modelagem ao final do "
+            "Gold (pesado: ~14 min so o embedding do BERTopic). O "
+            "refinamento via Gemini nunca roda daqui -- ver scripts/refine_topics.py."
+        ),
+    )
+    args = parser.parse_args()
 
     df_gov = pd.read_excel(settings.GOVERNADORES_FILE)
     df_gov.columns = df_gov.columns.str.strip()
@@ -164,6 +178,7 @@ if __name__ == "__main__":
         apify_api_token=token,
         links=links,
         results_limit=settings.RESULTS_LIMIT,
+        run_modeling=args.run_modeling,
     )
     # Sem emoji: o console padrão do Windows usa cp1252 e levanta
     # UnicodeEncodeError ao imprimi-los.


### PR DESCRIPTION
## Resumo

`run_medallion_pipeline(..., run_modeling=True)` já existia desde a PR do flag opcional, mas o bloco `if __name__ == "__main__":` de `pipeline.py` nunca repassava esse parâmetro — chamar `uv run python pipeline.py --run-modeling` do terminal simplesmente ignorava a flag (nem existia parsing de argumentos ali, então o `--run-modeling` seria só um argumento posicional não reconhecido). O usuário percebeu a inconsistência ao comparar o que o README já descrevia (`pipeline.py --run-modeling`) com o comportamento real.

Adiciona `argparse` ao `__main__`, seguindo o mesmo padrão já usado em `scripts/run_modeling.py`/`scripts/refine_topics.py`. `run_medallion_pipeline()` em si não muda — só o entrypoint de CLI.

## Testes

`tests/test_pipeline.py` já cobre `run_medallion_pipeline(run_modeling=True/False)` diretamente (não passa pelo `__main__`), então continua válido sem mudanças. Verificação manual:

```
$ uv run python pipeline.py --help
usage: pipeline.py [-h] [--run-modeling]
...
```

- [x] `pytest tests/` — 66 passed, 3 skipped (pré-existentes, não relacionados)
- [x] `ruff check src/ pipeline.py tests/` — sem apontamentos