### PR TITLE
fix(dashboard): atualiza instrucoes de modelagem para os scripts CLI

### DIFF
--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -87,7 +87,7 @@ else:
         else:
             st.info(
                 "Sentimento ainda não gerado para este governador. "
-                "Rode `notebooks/03_modelagem_hibrida.ipynb` para popular `governor_sentiment`."
+                "Rode `scripts/run_modeling.py` para popular `governor_sentiment`."
             )
 
     st.markdown("#### Tópicos mais frequentes")
@@ -105,14 +105,15 @@ else:
     else:
         st.info(
             "Tópicos ainda não gerados para este governador. "
-            "Rode `notebooks/03_modelagem_hibrida.ipynb` para popular `governor_sentiment`."
+            "Rode `scripts/run_modeling.py` (e opcionalmente `scripts/refine_topics.py "
+            "--run-id <ID>` para refinar os rótulos) para popular `governor_sentiment`."
         )
 
     st.markdown("#### Clusters dos reels (AutoClusterHPO)")
     if df_clusters.empty:
         st.info(
             "`governor_clusters` ainda não existe. "
-            "Rode `notebooks/03_modelagem_hibrida.ipynb` para gerá-la."
+            "Rode `scripts/run_modeling.py` para gerá-la."
         )
     else:
         df_reels_com_cluster = df_filtrado_reels.merge(


### PR DESCRIPTION
## Summary
- `pages/02_modeling.py` ainda instruía o usuário a rodar `notebooks/03_modelagem_hibrida.ipynb` para popular `governor_sentiment`/`governor_clusters`.
- Desde o ADR #0003 (mergeado em #10/#11), o notebook virou somente leitura — quem escreve essas tabelas agora é `scripts/run_modeling.py` (+ `scripts/refine_topics.py --run-id <ID>` para o refinamento de tópicos via Gemini).
- Atualiza as 3 mensagens de `st.info` para refletir o fluxo atual.

## Test plan
- [x] `ruff check pages/02_modeling.py` — passou
- [x] Diff revisado — só texto das mensagens, sem mudança de lógica