### PR TITLE
fix(pipeline): modelagem gera run_id proprio em vez de reaproveitar o da ingestao

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -142,9 +142,10 @@ def run_medallion_pipeline(
                 "[MODELAGEM] Rodando estágio determinístico "
                 "(PCA -> clustering -> sentimento -> tópicos)..."
             )
-            run_deterministic_modeling(
-                df_reels_silver, df_comments_silver, ModelingConfig(), run_id=run_id
+            result = run_deterministic_modeling(
+                df_reels_silver, df_comments_silver, ModelingConfig()
             )
+            print(f"[MODELAGEM] Concluída com run_id: {result.run_id}")
         except Exception as e:
             raise RuntimeError(f"[MODELAGEM] Falha no estágio determinístico: {e}") from e
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -85,7 +85,9 @@ def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(mo
     args, kwargs = fake_modeling.call_args
     assert args[0] is df_reels_silver
     assert args[1] is df_comments_silver
-    assert kwargs["run_id"] == "r1"
+    # ADR 0001: "um run_id = um estado imutável" -- a modelagem deve gerar o
+    # seu próprio run_id, nunca reaproveitar o run_id da ingestão.
+    assert kwargs.get("run_id") != "r1"
 
 
 def test_run_medallion_pipeline_nunca_chama_refinamento_via_gemini(monkeypatch):


### PR DESCRIPTION
## Resumo
- `run_medallion_pipeline()` reaproveitava o `run_id` de Bronze/Silver/Gold na chamada de `run_deterministic_modeling()`, que só gera um `run_id` novo quando nenhum é informado.
- Isso conflava o `run_id` de ingestão com o de modelagem, violando o invariante "um `run_id` = um estado imutável" estabelecido pela ADR 0001 para o restante do Medallion.
- A modelagem agora sempre gera seu próprio `run_id`, e o resultado é logado (`[MODELAGEM] Concluída com run_id: ...`) para não ficar invisível.

## Test plan
- [x] `uv run --extra dev ruff check pipeline.py tests/test_pipeline.py`
- [x] `uv run --extra dev pytest tests/test_pipeline.py -v` (3 passed) — ajustei a asserção que codificava o bug como comportamento esperado (`kwargs["run_id"] == "r1"` → `kwargs.get("run_id") != "r1"`)