### PR TITLE
fix: corrige dívida de lint pré-existente que quebrava o CI

### DIFF
--- a/src/modeling/gemini_refiner.py
+++ b/src/modeling/gemini_refiner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 import time
-from typing import List, Mapping, Tuple
+from collections.abc import Mapping
 
 import google.generativeai as genai
 import pandas as pd
@@ -40,8 +40,8 @@ class GeminiDocsRefiner(BaseRepresentation):
         topic_model,
         documents: pd.DataFrame,
         c_tf_idf: csr_matrix,
-        topics: Mapping[str, List[Tuple[str, float]]],
-    ) -> Mapping[str, List[Tuple[str, float]]]:
+        topics: Mapping[str, list[tuple[str, float]]],
+    ) -> Mapping[str, list[tuple[str, float]]]:
         updated_topics = {}
         docs_per_topic = documents.groupby(["Topic"])["Document"].apply(list)
 
@@ -65,7 +65,7 @@ class GeminiDocsRefiner(BaseRepresentation):
                     updated_topics[topic_id] = [(label, 1.0)] + keywords
                 else:
                     updated_topics[topic_id] = keywords
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 -- qualquer falha da API do Gemini cai no fallback abaixo
                 print(f"[GeminiDocsRefiner] Erro no tópico {topic_id}: {e}")
                 updated_topics[topic_id] = keywords
         return updated_topics

--- a/src/modeling/preprocessing.py
+++ b/src/modeling/preprocessing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 
 import emoji
 import nltk
@@ -11,7 +11,7 @@ import pandas as pd
 from src.modeling.config import PreprocessingConfig
 
 
-@lru_cache(maxsize=None)
+@cache
 def _stopwords(language: str) -> frozenset[str]:
     try:
         words = nltk.corpus.stopwords.words(language)

--- a/src/modeling/sentiment.py
+++ b/src/modeling/sentiment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import pandas as pd
 from transformers import pipeline
@@ -34,7 +34,7 @@ def analyze_sentiment(
             try:
                 resultado = analisador(texto, truncation=True, max_length=512)[0]
                 return pd.Series([resultado["label"], resultado["score"]])
-            except Exception:
+            except Exception:  # noqa: BLE001 -- qualquer falha do pipeline de inferência cai no fallback abaixo
                 return pd.Series([None, None])
         return pd.Series([None, None])
 


### PR DESCRIPTION
## Summary
O PR #20 foi mergeado com CI vermelho (a etapa de Lint falhou), pelo mesmo motivo em ambos os casos: o workflow `.github/workflows/python-app.yml` faz `pip install ruff` sem pin de versão, então uma versão mais nova do ruff passou a reprovar código já existente em `src/modeling/{gemini_refiner,preprocessing,sentiment}.py` (nenhum desses arquivos fazia parte do #20).

Este PR contém só a correção desse lint, já commitada na mesma branch do #20 (após o merge):
- `UP035`/`UP006`/`UP033`: sintaxe de tipagem desatualizada (`List`/`Tuple`/`Callable` → `list`/`tuple`/`collections.abc`, `lru_cache` → `functools.cache`) — via `ruff check --fix`
- `BLE001`: os dois `except Exception` genéricos (chamada à API do Gemini e ao pipeline de inferência de sentimento) são intencionais — qualquer falha externa deve cair no fallback — marcados com `# noqa: BLE001` explicando o motivo, em vez de estreitar o tipo da exceção e arriscar mudar esse comportamento

## Test plan
- [x] `ruff check src/` → All checks passed
- [x] `pytest` completo: 74 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rq2utBWbv7Ec9KNkZ1LjT