### PR TITLE
CD das imagens Lambda via GitHub Actions com OIDC (ADR-0009)

### DIFF
--- a/.github/workflows/build-lambdas.yml
+++ b/.github/workflows/build-lambdas.yml
@@ -1,0 +1,103 @@
+name: Build and Push Lambda Images
+
+# Publica as 4 imagens das Lambdas (extract, transform, load, orchestrator)
+# no ECR via OIDC. Não atualiza nenhuma Lambda em execução -- terraform
+# apply continua manual/intencional. Ver ADR 0009.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  changes:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.decide.outputs.build }}
+      sha: ${{ steps.decide.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 2 # precisa do commit pai para o diff do path-filter
+
+      - name: Path filter (só workflow_run; workflow_dispatch sempre builda)
+        id: filter
+        if: github.event_name == 'workflow_run'
+        uses: dorny/paths-filter@v3
+        with:
+          base: HEAD^
+          filters: |
+            lambdas:
+              - 'lambdas/**'
+              - 'src/**'
+
+      - name: Decide se builda
+        id: decide
+        run: |
+          echo "sha=${{ github.event.workflow_run.head_sha || github.sha }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=${{ steps.filter.outputs.lambdas }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lambda: [extract, transform, load, orchestrator]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.changes.outputs.sha }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ matrix.lambda }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: lambdas/${{ matrix.lambda }}/Dockerfile
+          push: true
+          tags: ${{ steps.login-ecr.outputs.registry }}/${{ vars.PROJECT_NAME || 'instagram-governadores' }}-${{ matrix.lambda }}:${{ needs.changes.outputs.sha }}
+          cache-from: type=gha,scope=${{ matrix.lambda }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.lambda }}
+
+  summary:
+    needs: [changes, build]
+    if: needs.changes.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write promotion summary
+        run: |
+          {
+            echo "## Imagens publicadas"
+            echo ""
+            echo "SHA: \`${{ needs.changes.outputs.sha }}\`"
+            echo ""
+            echo "Para promover (aplica nas Lambdas reais -- passo manual e consciente):"
+            echo ""
+            echo '```bash'
+            echo "TF_VAR_image_tag=${{ needs.changes.outputs.sha }} terraform apply"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md
+++ b/docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md
@@ -1,0 +1,118 @@
+---
+status: accepted
+---
+
+# Publicar as imagens das Lambdas via GitHub Actions, autenticando por OIDC, mantendo `terraform apply` manual
+
+## Contexto
+
+A ADR 0008 deixou o publicar as 4 imagens das Lambdas (`extract`, `transform`, `load`,
+`orchestrator`) como um passo inteiramente manual: `scripts/build_and_push_lambdas.sh`, rodado
+localmente, sempre que alguém decide atualizar as Lambdas. Nenhum gatilho automático foi
+configurado por decisão explícita daquela ADR ("sem uma cadência real definida, seria um recurso
+especulativo").
+
+O CI existente (`.github/workflows/python-app.yml`) já roda testes e `ruff check` a cada push/PR
+em `main`, mas não builda nem publica nada — é verificação de código, não produz artefato. Faltava
+decidir se, e como, estender isso para automatizar a publicação das imagens, sem abrir mão do
+controle consciente sobre quando a infraestrutura AWS real muda (motivo pelo qual `terraform
+apply` nunca roda sozinho hoje, dado o custo de conta AWS ativa).
+
+## Decisão
+
+1. **Escopo**: um novo workflow do GitHub Actions builda e publica as 4 imagens no ECR
+   automaticamente. `terraform apply` continua manual — publicar uma imagem nova no ECR não afeta
+   nenhuma Lambda em execução até alguém promover explicitamente.
+2. **Gatilho**: o novo workflow (`build-lambdas.yml`) dispara via `workflow_run`, condicionado ao
+   workflow `CI` ter concluído com `success` em `main` — mais `workflow_dispatch` para disparo
+   manual. Como `workflow_run` não suporta filtro nativo de `paths`, o primeiro step usa
+   `dorny/paths-filter` comparando `github.event.workflow_run.head_sha` contra o commit pai, e só
+   segue para o build se `lambdas/**` ou `src/**` mudaram.
+3. **Build**: as 4 imagens são sempre buildadas juntas (sem detecção seletiva por Lambda), via
+   `docker/build-push-action` com `cache-from`/`cache-to: type=gha` para reaproveitar as camadas
+   de instalação de dependências entre execuções.
+4. **Tag**: exclusivamente o SHA do commit. Nenhuma tag `latest` é publicada. `variables.tf` perde
+   o default `"latest"` de `image_tag`, exigindo valor explícito em todo `terraform apply`.
+5. **Autenticação**: OIDC — um `aws_iam_openid_connect_provider` + `aws_iam_role` novos em
+   `infra/main.tf`, com trust policy restrita a
+   `repo:Vini0606/Tecnicas-de-Ciencia-de-Dados-em-dados-do-Instagram:ref:refs/heads/main` (só
+   `main`, nunca PRs/forks) e policy limitada às ações ECR necessárias
+   (`GetAuthorizationToken`/`BatchCheckLayerAvailability`/`PutImage`/etc.) nos 4 repositórios. Sem
+   credenciais estáticas (`AWS_ACCESS_KEY_ID`/`SECRET`) armazenadas como secret.
+6. **Limpeza**: `aws_ecr_lifecycle_policy` em cada um dos 4 `aws_ecr_repository`, mantendo as
+   últimas 10 imagens — necessário porque, sem tag `latest` sobrescrita, cada merge relevante em
+   `main` passa a gerar 4 imagens novas e imutáveis.
+7. **Bootstrap**: a Role/Provider OIDC entram na mesma fase 1 do `terraform apply` que já cria só
+   os repositórios ECR (`terraform apply -target=aws_ecr_repository.lambdas
+   -target=aws_iam_role.github_actions_oidc -target=aws_iam_openid_connect_provider.github`) — têm
+   que existir antes da primeira execução da esteira.
+8. **Promoção**: ao final do workflow, o SHA publicado e o comando de promoção são escritos em
+   `$GITHUB_STEP_SUMMARY`. A convenção documentada é `TF_VAR_image_tag=$(git rev-parse
+   origin/main) terraform apply`. `scripts/build_and_push_lambdas.sh` continua existindo como
+   fallback manual local.
+
+## Por que
+
+**CD só até o ECR, não até a Lambda.** Automatizar `terraform apply` inteiro foi descartado desde
+o início da discussão: o projeto já trata a conta AWS com cautela por causa de custo (ver
+`infra/README.md`), e aplicar infraestrutura sozinho a cada merge tira exatamente o controle que
+motivou manter isso manual na ADR 0008. Parar no ECR dá o maior ganho prático — elimina o passo
+manual mais tedioso e propenso a erro, que é lembrar de buildar/publicar as 4 imagens certas — sem
+abrir mão da decisão consciente de quando a Lambda real muda.
+
+**Tag por SHA em vez de `latest`.** Lambda com `package_type = "Image"` fixa o digest no momento
+do deploy: publicar uma imagem nova sob a mesma tag `latest` não faz o Terraform detectar mudança
+nenhuma (a string `image_uri` não muda), então um `terraform apply` subsequente seria um no-op
+silencioso. Tag por SHA torna a promoção uma mudança explícita e detectável na string do
+`image_uri`, e casa com o padrão de rastreabilidade que o projeto já usa em outro lugar (`_run_id`,
+`as_of_version` no Delta Lake).
+
+**OIDC em vez de credenciais estáticas.** Elimina uma credencial de longa duração armazenada como
+GitHub Secret, que precisaria rotação manual e representa um risco de vazamento maior que uma role
+temporária federada. Mais trabalho inicial (mexe em `main.tf`), mas consistente com o cuidado que
+o resto do projeto já tem com a conta AWS.
+
+**Build das 4 imagens sempre juntas, sem detecção seletiva por Lambda.** O projeto tem um padrão
+recorrente de não generalizar/otimizar preventivamente sem necessidade real (ADR 0004, ADR 0005).
+Detecção seletiva por Lambda adicionaria lógica que é mais fonte de bug silencioso (esquecer de
+rebuildar algo que devia) do que ganho real, já que o cache de camadas Docker via `type=gha` já
+resolve a maior parte do custo de tempo de build repetido.
+
+**Lifecycle policy no ECR desde já, e não adiada.** Diferente da detecção seletiva acima, aqui a
+omissão tem custo real e crescente (armazenamento acumulando para sempre), não é especulação sobre
+uma necessidade futura incerta — por isso entra junto nesta mesma decisão, e não como item futuro.
+
+## Opções consideradas
+
+- **CD completo até `terraform apply`** — rejeitada: tira o controle consciente sobre quando a
+  infraestrutura AWS real muda, que é a premissa da ADR 0008.
+- **Só CI mais robusto, sem publicar imagem nenhuma** — rejeitada: não resolve o problema real, que
+  é o passo manual de build/push ser tedioso e propenso a erro.
+- **Credenciais estáticas (access key/secret) em vez de OIDC** — rejeitada: mais simples de
+  configurar, mas mantém uma credencial de longa duração como GitHub Secret, contrário à prática
+  recomendada pela própria AWS e ao cuidado que o projeto já tem com a conta.
+- **Tag `latest` mantida (sozinha ou junto com SHA)** — rejeitada: uma tag `latest` que nunca reflete
+  o que está de fato deployado (já que a promoção é sempre manual) é uma fonte de confusão sem
+  ganho real — o console do ECR já ordena por data de push.
+- **Gatilho `push` direto com `paths`, sem gate no CI** — rejeitada: abriria a possibilidade de
+  publicar uma imagem de um commit cujos testes falharam.
+- **Detecção seletiva de build por Lambda** (`dorny/paths-filter` por diretório) — rejeitada por
+  ora: complexidade que não se paga, dado que o cache de camadas Docker já reduz o custo de
+  rebuildar as 4 imagens sempre.
+- **Lifecycle policy adiada** — rejeitada: diferente da detecção seletiva, aqui a omissão tem custo
+  monetário real e crescente, não é especulação.
+
+## Consequências
+
+- Novo workflow `.github/workflows/build-lambdas.yml`, separado do `python-app.yml` existente.
+- `infra/main.tf` ganha `aws_iam_openid_connect_provider`, uma `aws_iam_role` para o GitHub
+  Actions, e `aws_ecr_lifecycle_policy` para os 4 repositórios ECR.
+- `infra/variables.tf`: `image_tag` perde o default `"latest"`.
+- `infra/README.md` é atualizado: o passo de bootstrap (fase 1) passa a incluir os `-target` da
+  Role/Provider OIDC, e um novo passo documenta a convenção de promoção via
+  `TF_VAR_image_tag=$(git rev-parse origin/main) terraform apply`.
+- `scripts/build_and_push_lambdas.sh` deixa de ser o caminho principal de publicação, mas continua
+  existindo como fallback manual local (ex.: para rodar fora do fluxo do GitHub Actions).
+- Limitação assumida: se um dia for necessário publicar a partir de outro branch que não `main`
+  (ex.: um ambiente de staging), a trust policy da Role OIDC precisa ser revista — hoje está restrita
+  a `ref:refs/heads/main`.

--- a/infra/README.md
+++ b/infra/README.md
@@ -3,7 +3,8 @@
 Provisiona os recursos para rodar o pipeline Medallion na nuvem: bucket S3 (data lake),
 repositórios ECR e as 4 funções Lambda (`extract`, `transform`, `load`, `orchestrator`) como
 imagens de container. Ver [ADR 0008](../docs/adr/0008-orquestrar-lambdas-via-orquestradora-unica-e-terraform.md)
-para o porquê dessas escolhas.
+para o porquê dessas escolhas, e [ADR 0009](../docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md)
+para a publicação automática das imagens via GitHub Actions.
 
 **Aviso de custo:** Lambda, S3 e ECR têm free tier, mas não são gratuitos indefinidamente —
 revise os preços atuais antes de aplicar isto numa conta com cobrança ativa. Nada aqui é aplicado
@@ -18,30 +19,44 @@ automaticamente; você decide quando rodar `terraform apply`.
 
 ## Passo a passo
 
-1. **Definir as variáveis obrigatórias.** Crie `infra/terraform.tfvars` (já está no `.gitignore` —
-   nunca commitar, tem o token da Apify) ou exporte como variáveis de ambiente:
+1. **Definir as variáveis obrigatórias.** Copie `infra/terraform.tfvars.example` para
+   `infra/terraform.tfvars` (já está no `.gitignore` — nunca commitar, tem o token da Apify) e
+   preencha, ou exporte como variáveis de ambiente:
 
    ```bash
    export TF_VAR_bucket_name="seu-bucket-unico-aqui"
    export TF_VAR_apify_api_token="seu-token-apify"
+   export TF_VAR_image_tag="latest"  # sem default -- ver ADR 0009
    ```
 
-2. **Provisionar os repositórios ECR e a infraestrutura base** (as Lambdas só conseguem ser
-   criadas depois que as imagens existirem no ECR, mas os repositórios em si podem/precisam ser
-   criados primeiro):
+2. **Provisionar os repositórios ECR e a Role/Provider OIDC do GitHub Actions** (as Lambdas só
+   conseguem ser criadas depois que as imagens existirem no ECR, mas os repositórios em si e a
+   Role OIDC podem/precisam ser criados primeiro — a Role precisa existir antes da primeira
+   publicação automática de imagem, ver seção "CD" abaixo):
 
    ```bash
    cd infra
    terraform init
-   terraform apply -target=aws_ecr_repository.lambdas
+   terraform apply \
+     -target=aws_ecr_repository.lambdas \
+     -target=aws_iam_openid_connect_provider.github \
+     -target=aws_iam_role.github_actions_oidc
    ```
+
+   Se isso falhar com `EntityAlreadyExists` no `aws_iam_openid_connect_provider.github` (a conta já
+   tem um provedor OIDC do GitHub Actions criado por outra infraestrutura — só pode existir um por
+   conta), rode de novo com `-var="create_github_oidc_provider=false"`.
 
 3. **Buildar e publicar as 4 imagens** usando os URLs de repositório do passo anterior:
 
    ```bash
    cd ..
-   ./scripts/build_and_push_lambdas.sh
+   ./scripts/build_and_push_lambdas.sh $(git rev-parse HEAD)
    ```
+
+   A partir daqui, depois de configurar o GitHub Actions (seção "CD" abaixo), esse passo passa a
+   rodar sozinho a cada merge relevante em `main` — este script continua existindo só como
+   fallback manual.
 
 4. **Provisionar o resto** (bucket S3, IAM, as 4 funções Lambda):
 
@@ -49,6 +64,35 @@ automaticamente; você decide quando rodar `terraform apply`.
    cd infra
    terraform apply
    ```
+
+## CD: publicação automática das imagens (GitHub Actions)
+
+Depois da fase 1 do bootstrap acima, configure o GitHub Actions para autenticar via OIDC:
+
+1. Pegue a ARN da role criada:
+
+   ```bash
+   terraform output -raw github_actions_role_arn
+   ```
+
+2. No GitHub, crie a repository variable `AWS_OIDC_ROLE_ARN` com esse valor (Settings > Secrets
+   and variables > Actions > Variables > New repository variable, ou
+   `gh variable set AWS_OIDC_ROLE_ARN --body "<arn>"`). Não é segredo — a trust policy da role já
+   restringe quem pode assumi-la a `main` deste repositório.
+3. Opcional: se `aws_region`/`project_name` não forem os defaults (`us-east-1` /
+   `instagram-governadores`), defina também as repository variables `AWS_REGION` e `PROJECT_NAME`.
+
+A partir daí, todo push em `main` que passar no CI e mexer em `lambdas/**` ou `src/**` publica as
+4 imagens no ECR automaticamente, tagueadas com o SHA do commit (ver
+`.github/workflows/build-lambdas.yml` e [ADR 0009](../docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md)).
+Isso **não** afeta as Lambdas em execução — promover continua sendo manual:
+
+```bash
+TF_VAR_image_tag=$(git rev-parse origin/main) terraform apply
+```
+
+(O SHA publicado e esse comando também aparecem no resumo de cada execução do workflow
+`build-lambdas.yml`, em `$GITHUB_STEP_SUMMARY`.)
 
 5. **Rodar o pipeline completo** invocando a Lambda orquestradora:
 
@@ -75,3 +119,7 @@ terraform destroy
   de 15 minutos de timeout de Lambda. Ver ADR 0008 para a alternativa rejeitada (Step Functions).
 - Não há gatilho agendado (EventBridge/cron) configurado — o pipeline roda só quando invocado
   manualmente. Adicionar um agendamento é uma mudança pequena e aditiva neste mesmo `main.tf`.
+- O workflow `build-lambdas.yml` builda as 4 imagens sempre juntas (sem detecção seletiva por
+  Lambda) — decisão deliberada, ver ADR 0009.
+- A trust policy da role OIDC do GitHub Actions está restrita a `ref:refs/heads/main` — publicar a
+  partir de outro branch (ex.: staging) exige revisar `infra/main.tf`.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -143,3 +143,115 @@ resource "aws_lambda_function" "orchestrator" {
     }
   }
 }
+
+# ── IAM/OIDC: GitHub Actions publica imagens no ECR sem credenciais estáticas ─
+# Ver ADR 0009. terraform apply continua manual -- isto só permite que a
+# esteira de CI publique imagens novas no ECR, nunca atualiza uma Lambda.
+
+locals {
+  github_repo = "Vini0606/Tecnicas-de-Ciencia-de-Dados-em-dados-do-Instagram"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_github_oidc_provider ? 1 : 0
+
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # Thumbprint público e amplamente documentado do certificado raiz usado por
+  # token.actions.githubusercontent.com. A AWS na prática ignora este valor
+  # para emissores cuja CA já está na lista de confiança da AWS (caso do
+  # GitHub Actions) -- o campo é obrigatório só pela forma (precisa de 40
+  # caracteres hex), não é usado para validar de fato. Ver
+  # https://docs.github.com/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.create_github_oidc_provider ? 0 : 1
+
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  github_oidc_provider_arn = var.create_github_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.github_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Só main -- nunca PRs/forks/outros branches. Rever se algum dia precisar
+    # publicar a partir de outro branch (ex.: staging).
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_oidc" {
+  name               = "${var.project_name}-github-actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_actions_ecr_push" {
+  statement {
+    sid       = "EcrAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"] # exigido pela API do ECR -- não é escopável por recurso
+  }
+
+  statement {
+    sid = "EcrPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:BatchGetImage",
+    ]
+    resources = [for repo in aws_ecr_repository.lambdas : repo.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_ecr_push" {
+  name   = "${var.project_name}-github-actions-ecr-push"
+  role   = aws_iam_role.github_actions_oidc.id
+  policy = data.aws_iam_policy_document.github_actions_ecr_push.json
+}
+
+# ── ECR: mantém só as 10 imagens mais recentes por repositório ───────────
+# Necessário porque, sem tag "latest" sobrescrita, cada merge relevante em
+# main gera 4 imagens novas e imutáveis (ADR 0009).
+
+resource "aws_ecr_lifecycle_policy" "lambdas" {
+  for_each = aws_ecr_repository.lambdas
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Manter só as 10 imagens mais recentes"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 10
+      }
+      action = { type = "expire" }
+    }]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -20,3 +20,8 @@ output "orchestrator_function_name" {
   description = "Nome da função a invocar para rodar o pipeline completo (aws lambda invoke)."
   value       = aws_lambda_function.orchestrator.function_name
 }
+
+output "github_actions_role_arn" {
+  description = "ARN da role OIDC assumida pelo GitHub Actions para publicar imagens no ECR. Configure como repository variable AWS_OIDC_ROLE_ARN no GitHub (Settings > Secrets and variables > Actions > Variables)."
+  value       = aws_iam_role.github_actions_oidc.arn
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copie para terraform.tfvars (ignorado pelo git) ou exporte como TF_VAR_*.
+
+bucket_name     = "seu-bucket-unico-aqui"
+apify_api_token = "seu-token-apify" # nunca commitar de verdade
+image_tag       = "latest"          # ou o SHA de um commit já publicado no ECR
+
+# Descomente se a conta AWS já tiver um provedor OIDC do GitHub Actions
+# (token.actions.githubusercontent.com) registrado por outra infraestrutura --
+# só pode existir um por conta/URL.
+# create_github_oidc_provider = false

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -22,7 +22,12 @@ variable "apify_api_token" {
 }
 
 variable "image_tag" {
-  description = "Tag das imagens de container publicadas no ECR (ex.: latest, ou um SHA de commit)."
+  description = "Tag das imagens de container publicadas no ECR (SHA de commit -- sem default 'latest', ver ADR 0009)."
   type        = string
-  default     = "latest"
+}
+
+variable "create_github_oidc_provider" {
+  description = "Se true, cria o aws_iam_openid_connect_provider do GitHub Actions. Uma conta AWS só pode ter um por URL -- se já existir (de outra infra), definir como false para reaproveitar via data source."
+  type        = bool
+  default     = true
 }

--- a/scripts/build_and_push_lambdas.sh
+++ b/scripts/build_and_push_lambdas.sh
@@ -7,8 +7,12 @@
 # (ver infra/README.md).
 #
 # Uso: ./scripts/build_and_push_lambdas.sh [tag]
-#   tag  -- tag da imagem a publicar (default: latest, deve bater com a
-#           variável image_tag do Terraform se for diferente do padrão).
+#   tag  -- tag da imagem a publicar (default: latest). Este script é o
+#           fallback manual -- a publicação normal roda via GitHub Actions
+#           (.github/workflows/build-lambdas.yml), que tagueia por SHA de
+#           commit. Se for aplicar via Terraform depois, passe uma tag que
+#           bata com TF_VAR_image_tag (ex.: $(git rev-parse HEAD)), seguindo
+#           a mesma convenção (ver ADR 0009).
 set -euo pipefail
 
 cd "$(dirname "$0")/.."  # raiz do repositório


### PR DESCRIPTION
## Resumo

Implementa a esteira de CD decidida em sessão de grilling: publica as 4 imagens Docker das
Lambdas (`extract`, `transform`, `load`, `orchestrator`) no ECR automaticamente, autenticando via
OIDC, sem tocar em `terraform apply` (que continua manual e intencional).

- `docs/adr/0009-...md` — decisão registrada
- `.github/workflows/build-lambdas.yml` — novo workflow: `workflow_run` gated no CI + `workflow_dispatch`, path-filter (`dorny/paths-filter`) para só buildar quando `lambdas/**`/`src/**` mudam, matrix das 4 imagens via `docker/build-push-action` com cache `type=gha`, tag por SHA de commit, resumo com comando de promoção em `$GITHUB_STEP_SUMMARY`
- `infra/main.tf` — `aws_iam_openid_connect_provider` (com toggle `create_github_oidc_provider` para conta que já tenha um), IAM role/policy restrita a `ref:refs/heads/main`, `aws_ecr_lifecycle_policy` (mantém últimas 10 imagens/repo)
- `infra/variables.tf` — `image_tag` perde o default `"latest"` (agora obrigatório)
- `infra/outputs.tf` — novo output `github_actions_role_arn`
- `infra/terraform.tfvars.example` — novo template
- `infra/README.md` — bootstrap fase 1 atualizado, nova seção de CD/promoção, limitações conhecidas

## Setup necessário antes de mergear/usar

1. `terraform apply -target=aws_ecr_repository.lambdas -target=aws_iam_openid_connect_provider.github -target=aws_iam_role.github_actions_oidc`
2. `terraform output -raw github_actions_role_arn` → configurar como repository variable `AWS_OIDC_ROLE_ARN` no GitHub
3. Testar primeiro via `workflow_dispatch` antes de depender do `workflow_run`

## Test plan

- [x] `terraform fmt -check -recursive` limpo
- [x] `terraform init && terraform validate` passa
- [x] YAML do workflow parseado sem erro
- [ ] `terraform plan` na fase 1 do bootstrap (precisa de credenciais AWS reais)
- [ ] Disparo manual via `workflow_dispatch` (precisa da repository variable configurada)
- [ ] Push tocando `lambdas/**` dispara o build automaticamente; push só em `docs/**` não dispara

Aberto como draft porque ainda depende de setup manual (passo 1-2 acima) numa conta AWS real antes
de poder validar o fluxo ponta a ponta.