### PR TITLE
Fase 1: fixes do dashboard (filtros, links, layout, home)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,15 @@
+from __future__ import annotations
+
+import os
+import sys
+
 import streamlit as st
+
+ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from src.dashboard.loaders import load_comments, load_profiles, load_reels
 
 st.set_page_config(
     page_title="Instagram Analytics — Governadores",
@@ -7,4 +18,65 @@ st.set_page_config(
 )
 
 st.title("📊 Instagram Analytics — Governadores do Brasil")
-st.markdown("Use o menu lateral para navegar entre as análises.")
+st.markdown(
+    "TCC de Ciência de Dados e Inteligência Artificial (IESB) que propõe e valida uma "
+    "**metodologia híbrida de NLP** — sentimento, modelagem de tópicos (BERTopic) e "
+    "clusterização integrados, em vez de aplicados isoladamente — sobre os perfis de "
+    "Instagram dos **27 governadores do Brasil**."
+)
+
+df_profiles = load_profiles()
+df_reels = load_reels()
+df_comments = load_comments()
+
+col1, col2, col3, col4 = st.columns(4)
+with col1:
+    st.metric("Governadores", len(df_profiles) if not df_profiles.empty else "—")
+with col2:
+    st.metric("Reels analisados", len(df_reels) if not df_reels.empty else "—")
+with col3:
+    st.metric("Comentários analisados", len(df_comments) if not df_comments.empty else "—")
+with col4:
+    if not df_comments.empty and "sentiment_label" in df_comments.columns:
+        pct_positivo = (df_comments["sentiment_label"] == "positive").mean() * 100
+        st.metric("% Sentimento Positivo", f"{pct_positivo:.1f}%")
+    else:
+        st.metric("% Sentimento Positivo", "—")
+
+st.markdown("---")
+
+st.markdown(
+    """
+### Metodologia
+
+O pipeline aplica quatro técnicas em sequência, cada uma alimentando a seguinte:
+
+1. **PCA** reduz as métricas de engajamento e duração dos reels a dois componentes.
+2. **`AutoClusterHPO`** (peça original do trabalho) testa KMeans, DBSCAN e
+   Agglomerative Clustering automaticamente, escolhendo o melhor via um score
+   CVI combinado (Silhouette + Calinski-Harabasz + Davies-Bouldin).
+3. **Análise de sentimento** classifica os comentários em positivo, neutro ou
+   negativo (`cardiffnlp/twitter-xlm-roberta-base-sentiment`).
+4. **BERTopic** extrai os temas discutidos nos comentários.
+
+O achado central do trabalho, em uma frase: **o conteúdo padrão é aprovado, o
+viral é debatido, e o longo é ignorado** — uma leitura que nenhuma das três
+técnicas produz isoladamente. A metodologia completa e os resultados
+detalhados estão no `README.md` do repositório.
+"""
+)
+
+st.markdown("### Navegue pelas análises")
+nav1, nav2 = st.columns(2)
+with nav1:
+    st.page_link(
+        "pages/01_exploratory.py",
+        label="Exploratório — perfis, engajamento e correlações",
+        icon="📊",
+    )
+with nav2:
+    st.page_link(
+        "pages/02_modeling.py",
+        label="Modelagem — sentimento, tópicos e clusters",
+        icon="📈",
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,7 @@ SILVER_PROFILES = SILVER_DIR / "profiles_clean"
 SILVER_POSTS = SILVER_DIR / "posts_clean"
 SILVER_REELS = SILVER_DIR / "reels_clean"
 SILVER_COMMENTS = SILVER_DIR / "comments_clean"
+SILVER_GOVERNORS_METADATA = SILVER_DIR / "governors_metadata"
 
 GOLD_DIR = DATA_DIR / "gold"
 GOLD_ENGAGEMENT = GOLD_DIR / "governor_engagement"

--- a/pages/01_exploratory.py
+++ b/pages/01_exploratory.py
@@ -11,6 +11,13 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
+from src.dashboard.filters import (
+    apply_group_filters,
+    build_cluster_membership,
+    build_governor_directory,
+    enrich_with_governor_metadata,
+    render_group_filters,
+)
 from src.dashboard.loaders import load_profiles
 from src.visualization.charts import (
     plot_correlation_heatmap,
@@ -26,7 +33,16 @@ st.set_page_config(
 )
 
 
-df_profiles = load_profiles()
+directory = build_governor_directory()
+cluster_membership = build_cluster_membership()
+filters = render_group_filters(directory, cluster_membership)
+
+df_profiles_enriched = enrich_with_governor_metadata(load_profiles())
+df_profiles = apply_group_filters(df_profiles_enriched, filters, cluster_membership)
+
+if df_profiles.empty:
+    st.warning("Nenhum governador corresponde aos filtros de grupo selecionados.")
+    st.stop()
 
 
 def media(df: pd.DataFrame, coluna: str) -> float:
@@ -161,29 +177,29 @@ else:
         )
         st.stop()  # Interrompe a execução do script se não houver colunas suficientes
 
-    # Cria três colunas para organizar os widgets de seleção lado a lado
-    col1, col2 = st.columns(2)
+    # Gráfico à esquerda (75%), seletores de eixo à direita (25%)
+    col_scatter, col_selectors = st.columns([3, 1])
 
-    with col1:
+    with col_selectors:
         # Widget para selecionar a variável do Eixo X
         x_axis = st.selectbox(
-            "Selecione a variável para o Eixo X:",
+            "Eixo X:",
             options=numeric_cols,
             index=0,  # Define a primeira coluna numérica como padrão
         )
 
-    with col2:
         # Widget para selecionar a variável do Eixo Y
         y_axis = st.selectbox(
-            "Selecione a variável para o Eixo Y:",
+            "Eixo Y:",
             options=numeric_cols,
             index=1,  # Define a segunda coluna numérica como padrão
         )
 
-    # Gera o gráfico apenas se as variáveis dos eixos foram selecionadas
-    if x_axis and y_axis:
-        with st.spinner("Gerando seu gráfico..."):
-            fig = plot_scatter(df_profiles, x=x_axis, y=y_axis, height=1000, width=1000)
-            st.plotly_chart(fig, use_container_width=True)
-    else:
-        st.warning("Por favor, selecione as variáveis para os eixos X e Y.")
+    with col_scatter:
+        # Gera o gráfico apenas se as variáveis dos eixos foram selecionadas
+        if x_axis and y_axis:
+            with st.spinner("Gerando seu gráfico..."):
+                fig = plot_scatter(df_profiles, x=x_axis, y=y_axis, height=500)
+                st.plotly_chart(fig, use_container_width=True)
+        else:
+            st.warning("Por favor, selecione as variáveis para os eixos X e Y.")

--- a/pages/01_exploratory.py
+++ b/pages/01_exploratory.py
@@ -17,6 +17,7 @@ from src.dashboard.filters import (
     build_governor_directory,
     enrich_with_governor_metadata,
     render_group_filters,
+    render_unmatched_warning,
 )
 from src.dashboard.loaders import load_profiles
 from src.visualization.charts import (
@@ -33,11 +34,12 @@ st.set_page_config(
 )
 
 
-directory = build_governor_directory()
+governor_directory = build_governor_directory()
 cluster_membership = build_cluster_membership()
-filters = render_group_filters(directory, cluster_membership)
+filters = render_group_filters(governor_directory, cluster_membership)
 
 df_profiles_enriched = enrich_with_governor_metadata(load_profiles())
+render_unmatched_warning(df_profiles_enriched)
 df_profiles = apply_group_filters(df_profiles_enriched, filters, cluster_membership)
 
 if df_profiles.empty:

--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -10,12 +10,15 @@ if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
 from src.dashboard.filters import (
+    TODOS_GOVERNADORES,
     apply_group_filters,
     build_cluster_membership,
     build_governor_directory,
     enrich_with_governor_metadata,
     render_governor_selector,
     render_group_filters,
+    render_unmatched_warning,
+    select_governor_rows,
 )
 from src.dashboard.loaders import load_clusters, load_comments, load_reels
 from src.visualization.charts import plot_top_n_bar, plot_value_counts
@@ -34,23 +37,26 @@ tem_modelagem = "sentiment_label" in df_comments.columns
 # --- BARRA LATERAL (SIDEBAR) PARA FILTROS ---
 st.sidebar.header("Filtros do Dashboard")
 
-directory = build_governor_directory()
+governor_directory = build_governor_directory()
 cluster_membership = build_cluster_membership()
-filters = render_group_filters(directory, cluster_membership)
+filters = render_group_filters(governor_directory, cluster_membership)
 
 # O universo de opções do seletor vem do próprio inputUrl de df_comments (não
 # do xlsx) -- governor_sentiment/reels_clean gravam a URL sem barra final,
 # governors_metadata (xlsx) grava com barra final; usar o valor do xlsx aqui
-# faria o `.query("inputUrl == ...")` abaixo nunca encontrar nada. nome/uf/
+# faria `select_governor_rows` abaixo nunca encontrar nada. nome/uf/regiao/
 # partido continuam vindo do xlsx, só que via join normalizado.
 governor_universe = df_comments[["inputUrl"]].dropna().drop_duplicates()
 governor_universe_enriched = enrich_with_governor_metadata(governor_universe)
-universe_filtrado = apply_group_filters(governor_universe_enriched, filters, cluster_membership)
+render_unmatched_warning(governor_universe_enriched)
+governor_universe_filtrado = apply_group_filters(
+    governor_universe_enriched, filters, cluster_membership
+)
 
 st.sidebar.markdown("---")
 governador_selecionado = render_governor_selector(
-    universe_filtrado,
-    directory_exists=not directory.empty,
+    governor_universe_filtrado,
+    directory_exists=not governor_directory.empty,
     fallback_urls=df_comments["inputUrl"].dropna().unique().tolist(),
 )
 
@@ -58,9 +64,14 @@ if governador_selecionado is None:
     st.stop()
 
 # --- APLICAÇÃO DOS FILTROS NO DATAFRAME ---
-df_filtrado_comments = df_comments.query("inputUrl == @governador_selecionado")
-
-df_filtrado_reels = df_reels.query("inputUrl == @governador_selecionado")
+# inputUrl comparado normalizado (não `==`/`.query` direto) -- reels_clean e
+# governor_sentiment vêm do mesmo df_reels bruto sem transformação de URL
+# entre os dois, então hoje coincidem byte-a-byte, mas isso não é uma garantia
+# formal do pipeline, e já houve um bug real de formatação de URL divergente
+# entre tabelas nesta branch (ver governor_engagement vs reels_clean).
+universo_ativo = governor_universe_filtrado["inputUrl"].tolist()
+df_filtrado_comments = select_governor_rows(df_comments, governador_selecionado, universo_ativo)
+df_filtrado_reels = select_governor_rows(df_reels, governador_selecionado, universo_ativo)
 
 # --- PÁGINA PRINCIPAL ---
 st.title("📊 Comentários dos Governadores do Brasil")

--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -9,6 +9,14 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
+from src.dashboard.filters import (
+    apply_group_filters,
+    build_cluster_membership,
+    build_governor_directory,
+    enrich_with_governor_metadata,
+    render_governor_selector,
+    render_group_filters,
+)
 from src.dashboard.loaders import load_clusters, load_comments, load_reels
 from src.visualization.charts import plot_top_n_bar, plot_value_counts
 
@@ -26,10 +34,28 @@ tem_modelagem = "sentiment_label" in df_comments.columns
 # --- BARRA LATERAL (SIDEBAR) PARA FILTROS ---
 st.sidebar.header("Filtros do Dashboard")
 
-governador_selecionado = st.sidebar.selectbox(
-    "Selecione o Governador:",
-    options=df_comments["inputUrl"].dropna().unique(),
+directory = build_governor_directory()
+cluster_membership = build_cluster_membership()
+filters = render_group_filters(directory, cluster_membership)
+
+# O universo de opções do seletor vem do próprio inputUrl de df_comments (não
+# do xlsx) -- governor_sentiment/reels_clean gravam a URL sem barra final,
+# governors_metadata (xlsx) grava com barra final; usar o valor do xlsx aqui
+# faria o `.query("inputUrl == ...")` abaixo nunca encontrar nada. nome/uf/
+# partido continuam vindo do xlsx, só que via join normalizado.
+governor_universe = df_comments[["inputUrl"]].dropna().drop_duplicates()
+governor_universe_enriched = enrich_with_governor_metadata(governor_universe)
+universe_filtrado = apply_group_filters(governor_universe_enriched, filters, cluster_membership)
+
+st.sidebar.markdown("---")
+governador_selecionado = render_governor_selector(
+    universe_filtrado,
+    directory_exists=not directory.empty,
+    fallback_urls=df_comments["inputUrl"].dropna().unique().tolist(),
 )
+
+if governador_selecionado is None:
+    st.stop()
 
 # --- APLICAÇÃO DOS FILTROS NO DATAFRAME ---
 df_filtrado_comments = df_comments.query("inputUrl == @governador_selecionado")
@@ -70,6 +96,25 @@ else:
                 title="Top 10 Reels por Engajamento",
                 top_n=10,
             ),
+            width="stretch",
+        )
+
+        df_links = (
+            df_plot.dropna(subset=["shortCode"])
+            .sort_values("Total de Engajamento", ascending=False)
+            .head(10)
+            .copy()
+        )
+        df_links["Link"] = "https://www.instagram.com/reel/" + df_links["shortCode"] + "/"
+        st.dataframe(
+            df_links[["shortCode", "Total de Engajamento", "Link"]],
+            column_config={
+                "shortCode": "Código do Reel",
+                "Link": st.column_config.LinkColumn(
+                    "Link", display_text="Abrir no Instagram"
+                ),
+            },
+            hide_index=True,
             width="stretch",
         )
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,5 +1,6 @@
 import os
 
+import pandas as pd
 from apify_client import ApifyClient
 from dotenv import load_dotenv
 
@@ -9,6 +10,7 @@ from src.data_extract.readers import JsonDataReader
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
 from src.features.gold.engagement_aggregator import EngagementAggregator
 from src.features.silver.comment_cleaner import CommentCleaner
+from src.features.silver.governors_metadata_cleaner import GovernorsMetadataCleaner
 from src.features.silver.post_cleaner import PostCleaner
 from src.features.silver.profile_cleaner import ProfileCleaner
 from src.modeling.config import ModelingConfig
@@ -117,6 +119,16 @@ def run_medallion_pipeline(
         post_cleaner.write_posts(df_posts_silver, settings.SILVER_POSTS)
         post_cleaner.write_reels(df_reels_silver, settings.SILVER_REELS)
         comment_cleaner.write(df_comments_silver, settings.SILVER_COMMENTS)
+
+        # Dimensão de metadados dos governadores (nome/UF/partido), ingerida
+        # de `governadores.xlsx` -- não vem do scraper, então não passa por
+        # Bronze (ver decisão de design: planilha mantida manualmente, já
+        # relativamente limpa de origem, não precisa do estágio de proteção
+        # contra reprocessamento que a Bronze existe para dar aos dados do Apify).
+        governors_cleaner = GovernorsMetadataCleaner()
+        df_governors_raw = pd.read_excel(settings.GOVERNADORES_FILE)
+        df_governors_silver = governors_cleaner.clean(df_governors_raw, run_id)
+        governors_cleaner.write(df_governors_silver, settings.SILVER_GOVERNORS_METADATA)
     except Exception as e:
         raise RuntimeError(
             f"[SILVER] Falha na limpeza e conformação dos dados: {e}"
@@ -156,7 +168,6 @@ if __name__ == "__main__":
     import argparse
 
     load_dotenv()
-    import pandas as pd
 
     parser = argparse.ArgumentParser(description="Roda o pipeline Medallion (Bronze/Silver/Gold).")
     parser.add_argument(

--- a/src/dashboard/filters.py
+++ b/src/dashboard/filters.py
@@ -8,6 +8,9 @@ Decisões de design (sessão de grilling de 2026-08-29, ver handoff):
   `governadores.xlsx`) -- se a tabela ainda não existir (pipeline não rodado
   após esta mudança), tudo aqui degrada graciosamente: filtros ficam sem
   opções e o seletor individual cai para URLs brutas, em vez de quebrar a página.
+- "Região" filtra pela macrorregião (Norte/Nordeste/Centro-Oeste/Sudeste/Sul),
+  não pela UF -- há sempre exatamente 1 governador por UF, então um filtro por
+  UF nunca agrupa nada, só reimplementa o seletor individual de forma mais lenta.
 - O filtro de cluster é por "contém" (pelo menos 1 reel no cluster
   selecionado), não por "cluster dominante" (moda) -- outliers do DBSCAN
   (cluster -1) podem ser reels virais/atípicos, e a moda esconderia esse sinal
@@ -22,6 +25,38 @@ import pandas as pd
 import streamlit as st
 
 from src.dashboard.loaders import load_clusters, load_governors_metadata, load_reels
+
+TODOS_GOVERNADORES = "__todos_governadores__"
+
+UF_PARA_REGIAO: dict[str, str] = {
+    "Acre": "Norte",
+    "Amapá": "Norte",
+    "Amazonas": "Norte",
+    "Pará": "Norte",
+    "Rondônia": "Norte",
+    "Roraima": "Norte",
+    "Tocantins": "Norte",
+    "Alagoas": "Nordeste",
+    "Bahia": "Nordeste",
+    "Ceará": "Nordeste",
+    "Maranhão": "Nordeste",
+    "Paraíba": "Nordeste",
+    "Pernambuco": "Nordeste",
+    "Piauí": "Nordeste",
+    "Rio Grande do Norte": "Nordeste",
+    "Sergipe": "Nordeste",
+    "Distrito Federal": "Centro-Oeste",
+    "Goiás": "Centro-Oeste",
+    "Mato Grosso": "Centro-Oeste",
+    "Mato Grosso do Sul": "Centro-Oeste",
+    "Espírito Santo": "Sudeste",
+    "Minas Gerais": "Sudeste",
+    "Rio de Janeiro": "Sudeste",
+    "São Paulo": "Sudeste",
+    "Paraná": "Sul",
+    "Rio Grande do Sul": "Sul",
+    "Santa Catarina": "Sul",
+}
 
 
 def _normalize_url(series: pd.Series) -> pd.Series:
@@ -39,9 +74,29 @@ def _normalize_url(series: pd.Series) -> pd.Series:
     )
 
 
+def _with_match_key(df: pd.DataFrame, url_col: str = "inputUrl") -> pd.DataFrame:
+    """Copia `df` e adiciona `_match_key` (URL normalizada de `url_col`) --
+    passo repetido em todo cruzamento de tabelas por inputUrl neste módulo,
+    já que tabelas diferentes gravam a mesma URL com formatação diferente
+    (`governor_engagement` com barra final, `reels_clean`/`governor_sentiment`
+    sem, por exemplo)."""
+    df = df.copy()
+    df["_match_key"] = _normalize_url(df[url_col])
+    return df
+
+
+def _add_regiao(df: pd.DataFrame) -> pd.DataFrame:
+    """Deriva `regiao` (macrorregião) a partir de `uf`. Nomes de UF fora do
+    mapeamento (não deveria acontecer com os 27 estados atuais) viram 'Outra'
+    em vez de quebrar."""
+    df = df.copy()
+    df["regiao"] = df["uf"].map(UF_PARA_REGIAO).fillna("Outra")
+    return df
+
+
 @st.cache_data
 def build_governor_directory() -> pd.DataFrame:
-    """Diretório com 1 linha por governador: inputUrl, nome, uf, partido.
+    """Diretório com 1 linha por governador: inputUrl, nome, uf, regiao, partido.
 
     DataFrame vazio (mas com essas colunas) se `governors_metadata` ainda não
     existir -- chamadores devem tratar isso como "pipeline não rodado ainda",
@@ -49,15 +104,24 @@ def build_governor_directory() -> pd.DataFrame:
     """
     df_meta = load_governors_metadata()
     if df_meta.empty:
-        return pd.DataFrame(columns=["inputUrl", "nome", "uf", "partido"])
-    return df_meta[["inputUrl", "nome", "uf", "partido"]].copy()
+        return pd.DataFrame(columns=["inputUrl", "nome", "uf", "regiao", "partido"])
+    directory = df_meta[["inputUrl", "nome", "uf", "partido"]].copy()
+    return _add_regiao(directory)
 
 
 @st.cache_data
 def build_cluster_membership() -> pd.DataFrame:
     """Uma linha por (inputUrl, cluster_label) -- quais clusters de reel cada
-    governador tem pelo menos 1 reel. Base do filtro "contém cluster X"."""
-    df_reels = load_reels()
+    governador tem pelo menos 1 reel. Base do filtro "contém cluster X".
+
+    `reels_clean` (Silver) é uma tabela "core" do pipeline (existe desde que
+    o Silver tenha rodado alguma vez), mas o filtro de cluster é opcional --
+    então tratamos a ausência dela aqui como "sem dado ainda", não como erro,
+    para não derrubar `exploratory`/`modeling` por causa de um filtro opcional."""
+    try:
+        df_reels = load_reels()
+    except FileNotFoundError:
+        return pd.DataFrame(columns=["inputUrl", "cluster_label"])
     df_clusters = load_clusters()
     if df_reels.empty or df_clusters.empty:
         return pd.DataFrame(columns=["inputUrl", "cluster_label"])
@@ -66,49 +130,58 @@ def build_cluster_membership() -> pd.DataFrame:
 
 
 def enrich_with_governor_metadata(df: pd.DataFrame, url_col: str = "inputUrl") -> pd.DataFrame:
-    """Adiciona nome/uf/partido a `df` via join por `url_col` (normalizado:
-    strip + sem barra final + minúsculo, já que `governadores.xlsx` tem
-    espaços em branco ao redor dos links). Preserva todas as linhas de `df`
-    (left join); linhas sem match ficam com nome/uf/partido nulos e geram um
-    aviso visível (dado sujo é melhor sinalizado que escondido)."""
+    """Adiciona nome/uf/regiao/partido a `df` via join por `url_col` (URL
+    normalizada -- ver `_normalize_url`). Preserva todas as linhas de `df`
+    (left join); linhas sem match ficam com essas colunas nulas.
+
+    Função pura (sem I/O de UI) -- chame `render_unmatched_warning` depois se
+    quiser avisar visivelmente sobre perfis sem match."""
     directory = build_governor_directory()
     df = df.copy()
     if url_col not in df.columns or directory.empty:
-        for col in ("nome", "uf", "partido"):
+        for col in ("nome", "uf", "regiao", "partido"):
             if col not in df.columns:
                 df[col] = pd.NA
         return df
 
-    df["_match_key"] = _normalize_url(df[url_col])
-    directory = directory.copy()
-    directory["_match_key"] = _normalize_url(directory["inputUrl"])
+    df = _with_match_key(df, url_col)
+    directory = _with_match_key(directory, "inputUrl")
 
     merged = df.merge(
-        directory[["_match_key", "nome", "uf", "partido"]],
+        directory[["_match_key", "nome", "uf", "regiao", "partido"]],
         on="_match_key",
         how="left",
     ).drop(columns="_match_key")
+    return merged
 
-    unmatched = merged.loc[merged["nome"].isna(), url_col].dropna().unique().tolist()
+
+def render_unmatched_warning(df_enriched: pd.DataFrame, url_col: str = "inputUrl") -> None:
+    """Mostra um `st.warning` visível se alguma linha de `df_enriched` (já
+    passado por `enrich_with_governor_metadata`) não casou com `governadores.xlsx`
+    -- dado sujo é melhor sinalizado que escondido. Separado de
+    `enrich_with_governor_metadata` para manter aquela função pura (só dado,
+    sem I/O de UI), seguindo a convenção `render_*` = mexe em UI deste módulo."""
+    if "nome" not in df_enriched.columns:
+        return
+    unmatched = df_enriched.loc[df_enriched["nome"].isna(), url_col].dropna().unique().tolist()
     if unmatched:
         st.warning(
             "Não foi possível casar estes perfis com `governadores.xlsx` "
             f"(nome/UF/partido ficarão vazios): {', '.join(unmatched)}"
         )
-    return merged
 
 
-def render_group_filters(directory: pd.DataFrame, cluster_membership: pd.DataFrame) -> dict:
+def render_group_filters(governor_directory: pd.DataFrame, cluster_membership: pd.DataFrame) -> dict:
     """Renderiza os filtros de grupo (região, partido, cluster) na sidebar.
     Compartilhados entre páginas via `key=` -- a seleção persiste ao navegar."""
     st.sidebar.header("Filtros de Grupo")
 
-    uf_options = sorted(directory["uf"].dropna().unique().tolist())
-    partido_options = sorted(directory["partido"].dropna().unique().tolist())
+    regiao_options = sorted(governor_directory["regiao"].dropna().unique().tolist())
+    partido_options = sorted(governor_directory["partido"].dropna().unique().tolist())
     cluster_options = sorted(cluster_membership["cluster_label"].dropna().unique().tolist())
 
-    selected_uf = st.sidebar.multiselect(
-        "Região (UF):", options=uf_options, key="filter_uf"
+    selected_regiao = st.sidebar.multiselect(
+        "Região:", options=regiao_options, key="filter_regiao"
     )
     selected_partido = st.sidebar.multiselect(
         "Partido:", options=partido_options, key="filter_partido"
@@ -125,13 +198,13 @@ def render_group_filters(directory: pd.DataFrame, cluster_membership: pd.DataFra
         ),
     )
 
-    if not uf_options and not partido_options and not cluster_options:
+    if not regiao_options and not partido_options and not cluster_options:
         st.sidebar.caption(
             "Sem dados de região/partido/cluster ainda -- rode a pipeline "
             "(`uv run python pipeline.py`) para popular os filtros de grupo."
         )
 
-    return {"uf": selected_uf, "partido": selected_partido, "cluster": selected_cluster}
+    return {"regiao": selected_regiao, "partido": selected_partido, "cluster": selected_cluster}
 
 
 def apply_group_filters(
@@ -141,28 +214,47 @@ def apply_group_filters(
     url_col: str = "inputUrl",
 ) -> pd.DataFrame:
     """Aplica os filtros de `render_group_filters` sobre um DataFrame que já
-    tenha as colunas `uf`/`partido`/`url_col` (ex: via `enrich_with_governor_metadata`
-    ou `build_governor_directory`). Seleção vazia em um filtro = não filtra por ele.
+    tenha as colunas `regiao`/`partido`/`url_col` (ex: via
+    `enrich_with_governor_metadata` ou `build_governor_directory`). Seleção
+    vazia em um filtro = não filtra por ele.
 
-    O casamento do filtro de cluster usa `inputUrl` normalizado (não `==` direto):
-    `governor_engagement` grava a URL com barra final, mas `reels_clean` e
-    `governor_sentiment` gravam sem -- comparar sem normalizar faz o filtro de
-    cluster nunca casar nada em `exploratory`."""
+    O casamento do filtro de cluster usa `inputUrl` normalizado (não `==`
+    direto): `governor_engagement` grava a URL com barra final, mas
+    `reels_clean` e `governor_sentiment` gravam sem -- comparar sem normalizar
+    faz o filtro de cluster nunca casar nada em `exploratory`."""
     df = df_enriched
-    if filters["uf"]:
-        df = df[df["uf"].isin(filters["uf"])]
+    if filters["regiao"]:
+        df = df[df["regiao"].isin(filters["regiao"])]
     if filters["partido"]:
         df = df[df["partido"].isin(filters["partido"])]
     if filters["cluster"]:
-        cm = cluster_membership.copy()
-        cm["_match_key"] = _normalize_url(cm["inputUrl"])
+        cm = _with_match_key(cluster_membership, "inputUrl")
         keys_in_clusters = set(
             cm.loc[cm["cluster_label"].isin(filters["cluster"]), "_match_key"]
         )
-        df = df.copy()
-        df["_match_key"] = _normalize_url(df[url_col])
+        df = _with_match_key(df, url_col)
         df = df[df["_match_key"].isin(keys_in_clusters)].drop(columns="_match_key")
     return df
+
+
+def select_governor_rows(
+    df: pd.DataFrame,
+    selected: str | None,
+    universe_urls: list[str],
+    url_col: str = "inputUrl",
+) -> pd.DataFrame:
+    """Filtra `df` pelo governador selecionado, usando `inputUrl` normalizado
+    (não `==` direto) -- mesmo cuidado do resto do módulo, já que duas tabelas
+    do mesmo pipeline (`reels_clean`/`governor_sentiment`) não têm garantia
+    formal de gravar a URL byte-a-byte igual.
+
+    `selected == TODOS_GOVERNADORES` filtra por todo `universe_urls` (o
+    universo de governadores já filtrado pelos filtros de grupo ativos), em
+    vez de um único governador."""
+    urls = universe_urls if selected == TODOS_GOVERNADORES else [selected]
+    keys = set(_normalize_url(pd.Series(urls)))
+    df = _with_match_key(df, url_col)
+    return df[df["_match_key"].isin(keys)].drop(columns="_match_key")
 
 
 def render_governor_selector(
@@ -172,31 +264,46 @@ def render_governor_selector(
 ) -> str | None:
     """Seletor individual de governador (por nome), exclusivo de `modeling`,
     em cascata com os filtros de grupo (`directory_filtered` já vem filtrado).
+    Sempre oferece "Todos os Governadores" (`TODOS_GOVERNADORES`) como primeira
+    opção, além dos governadores individuais.
 
     Se `governors_metadata` ainda não existir, cai para uma lista de URLs
     brutas (`fallback_urls`, tipicamente `df_comments["inputUrl"].unique()`)
-    em vez de quebrar a página -- comportamento idêntico ao seletor anterior."""
+    em vez de quebrar a página -- comportamento idêntico ao seletor anterior.
+
+    Retorna `None` só quando não há nenhum governador disponível (filtro de
+    grupo restritivo demais, ou nenhum dado carregado) -- chamadores devem
+    tratar `None` como "pare a página", e `TODOS_GOVERNADORES` como um valor
+    de seleção válido, não como ausência de seleção."""
     if directory_exists:
         if directory_filtered.empty:
             st.sidebar.warning(
                 "Nenhum governador corresponde aos filtros de grupo selecionados."
             )
             return None
-        options = directory_filtered["inputUrl"].dropna().unique().tolist()
         label_by_url = dict(
             zip(
                 directory_filtered["inputUrl"],
                 directory_filtered["nome"].fillna(directory_filtered["inputUrl"]),
             )
         )
-        format_func = lambda url: label_by_url.get(url, url)  # noqa: E731
+        label_by_url[TODOS_GOVERNADORES] = "Todos os Governadores"
+        options = [TODOS_GOVERNADORES] + directory_filtered["inputUrl"].dropna().unique().tolist()
+
+        def format_func(url: str) -> str:
+            return label_by_url.get(url, url)
+
     elif fallback_urls:
         st.sidebar.info(
             "Tabela `governors_metadata` ainda não existe -- mostrando por "
             "URL do perfil. Rode a pipeline para ver nomes."
         )
-        options = fallback_urls
-        format_func = lambda url: url  # noqa: E731
+        label_by_url = {TODOS_GOVERNADORES: "Todos os Governadores"}
+        options = [TODOS_GOVERNADORES] + fallback_urls
+
+        def format_func(url: str) -> str:
+            return label_by_url.get(url, url)
+
     else:
         st.sidebar.warning("Nenhum governador disponível.")
         return None

--- a/src/dashboard/filters.py
+++ b/src/dashboard/filters.py
@@ -1,0 +1,206 @@
+"""
+Filtros de grupo (região/partido/cluster) e seletor individual de governador,
+compartilhados entre as páginas `exploratory` e `modeling` via `st.session_state`
+(através das `key=` dos widgets abaixo).
+
+Decisões de design (sessão de grilling de 2026-08-29, ver handoff):
+- Região/partido/nome vêm de `governors_metadata` (Silver, ingerida de
+  `governadores.xlsx`) -- se a tabela ainda não existir (pipeline não rodado
+  após esta mudança), tudo aqui degrada graciosamente: filtros ficam sem
+  opções e o seletor individual cai para URLs brutas, em vez de quebrar a página.
+- O filtro de cluster é por "contém" (pelo menos 1 reel no cluster
+  selecionado), não por "cluster dominante" (moda) -- outliers do DBSCAN
+  (cluster -1) podem ser reels virais/atípicos, e a moda esconderia esse sinal
+  num governador que só tem 1-2 reels fora do padrão.
+- É um dado de clustering *por reel*, não por perfil -- rotulado como tal na
+  UI. Clustering por perfil é uma frente futura separada (Fase 2).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+from src.dashboard.loaders import load_clusters, load_governors_metadata, load_reels
+
+
+def _normalize_url(series: pd.Series) -> pd.Series:
+    """Normaliza URL de perfil para join: remove espaços, query string/fragmento
+    (ex: `?hl=en`), barra final e caixa -- `inputUrl` nos dados raspados é uma
+    cópia literal do `Link` do xlsx e hoje carrega o mesmo `?hl=en` quando
+    presente, mas a normalização não deve depender dessa coincidência."""
+    return (
+        series.astype(str)
+        .str.strip()
+        .str.split("?", n=1).str[0]
+        .str.split("#", n=1).str[0]
+        .str.rstrip("/")
+        .str.lower()
+    )
+
+
+@st.cache_data
+def build_governor_directory() -> pd.DataFrame:
+    """Diretório com 1 linha por governador: inputUrl, nome, uf, partido.
+
+    DataFrame vazio (mas com essas colunas) se `governors_metadata` ainda não
+    existir -- chamadores devem tratar isso como "pipeline não rodado ainda",
+    não como erro.
+    """
+    df_meta = load_governors_metadata()
+    if df_meta.empty:
+        return pd.DataFrame(columns=["inputUrl", "nome", "uf", "partido"])
+    return df_meta[["inputUrl", "nome", "uf", "partido"]].copy()
+
+
+@st.cache_data
+def build_cluster_membership() -> pd.DataFrame:
+    """Uma linha por (inputUrl, cluster_label) -- quais clusters de reel cada
+    governador tem pelo menos 1 reel. Base do filtro "contém cluster X"."""
+    df_reels = load_reels()
+    df_clusters = load_clusters()
+    if df_reels.empty or df_clusters.empty:
+        return pd.DataFrame(columns=["inputUrl", "cluster_label"])
+    merged = df_reels.merge(df_clusters, left_on="id", right_on="id_reel", how="inner")
+    return merged[["inputUrl", "cluster_label"]].drop_duplicates()
+
+
+def enrich_with_governor_metadata(df: pd.DataFrame, url_col: str = "inputUrl") -> pd.DataFrame:
+    """Adiciona nome/uf/partido a `df` via join por `url_col` (normalizado:
+    strip + sem barra final + minúsculo, já que `governadores.xlsx` tem
+    espaços em branco ao redor dos links). Preserva todas as linhas de `df`
+    (left join); linhas sem match ficam com nome/uf/partido nulos e geram um
+    aviso visível (dado sujo é melhor sinalizado que escondido)."""
+    directory = build_governor_directory()
+    df = df.copy()
+    if url_col not in df.columns or directory.empty:
+        for col in ("nome", "uf", "partido"):
+            if col not in df.columns:
+                df[col] = pd.NA
+        return df
+
+    df["_match_key"] = _normalize_url(df[url_col])
+    directory = directory.copy()
+    directory["_match_key"] = _normalize_url(directory["inputUrl"])
+
+    merged = df.merge(
+        directory[["_match_key", "nome", "uf", "partido"]],
+        on="_match_key",
+        how="left",
+    ).drop(columns="_match_key")
+
+    unmatched = merged.loc[merged["nome"].isna(), url_col].dropna().unique().tolist()
+    if unmatched:
+        st.warning(
+            "Não foi possível casar estes perfis com `governadores.xlsx` "
+            f"(nome/UF/partido ficarão vazios): {', '.join(unmatched)}"
+        )
+    return merged
+
+
+def render_group_filters(directory: pd.DataFrame, cluster_membership: pd.DataFrame) -> dict:
+    """Renderiza os filtros de grupo (região, partido, cluster) na sidebar.
+    Compartilhados entre páginas via `key=` -- a seleção persiste ao navegar."""
+    st.sidebar.header("Filtros de Grupo")
+
+    uf_options = sorted(directory["uf"].dropna().unique().tolist())
+    partido_options = sorted(directory["partido"].dropna().unique().tolist())
+    cluster_options = sorted(cluster_membership["cluster_label"].dropna().unique().tolist())
+
+    selected_uf = st.sidebar.multiselect(
+        "Região (UF):", options=uf_options, key="filter_uf"
+    )
+    selected_partido = st.sidebar.multiselect(
+        "Partido:", options=partido_options, key="filter_partido"
+    )
+    selected_cluster = st.sidebar.multiselect(
+        "Cluster de Reels (dado atual, por reel):",
+        options=cluster_options,
+        key="filter_cluster",
+        help=(
+            "Mostra governadores com pelo menos um reel no(s) cluster(s) "
+            "selecionado(s). `-1` é o rótulo de ruído/outlier do DBSCAN -- "
+            "pode ser reel viral ou de audiência atípica, não é 'lixo'. "
+            "Este clustering é por reel, não por perfil de governador."
+        ),
+    )
+
+    if not uf_options and not partido_options and not cluster_options:
+        st.sidebar.caption(
+            "Sem dados de região/partido/cluster ainda -- rode a pipeline "
+            "(`uv run python pipeline.py`) para popular os filtros de grupo."
+        )
+
+    return {"uf": selected_uf, "partido": selected_partido, "cluster": selected_cluster}
+
+
+def apply_group_filters(
+    df_enriched: pd.DataFrame,
+    filters: dict,
+    cluster_membership: pd.DataFrame,
+    url_col: str = "inputUrl",
+) -> pd.DataFrame:
+    """Aplica os filtros de `render_group_filters` sobre um DataFrame que já
+    tenha as colunas `uf`/`partido`/`url_col` (ex: via `enrich_with_governor_metadata`
+    ou `build_governor_directory`). Seleção vazia em um filtro = não filtra por ele.
+
+    O casamento do filtro de cluster usa `inputUrl` normalizado (não `==` direto):
+    `governor_engagement` grava a URL com barra final, mas `reels_clean` e
+    `governor_sentiment` gravam sem -- comparar sem normalizar faz o filtro de
+    cluster nunca casar nada em `exploratory`."""
+    df = df_enriched
+    if filters["uf"]:
+        df = df[df["uf"].isin(filters["uf"])]
+    if filters["partido"]:
+        df = df[df["partido"].isin(filters["partido"])]
+    if filters["cluster"]:
+        cm = cluster_membership.copy()
+        cm["_match_key"] = _normalize_url(cm["inputUrl"])
+        keys_in_clusters = set(
+            cm.loc[cm["cluster_label"].isin(filters["cluster"]), "_match_key"]
+        )
+        df = df.copy()
+        df["_match_key"] = _normalize_url(df[url_col])
+        df = df[df["_match_key"].isin(keys_in_clusters)].drop(columns="_match_key")
+    return df
+
+
+def render_governor_selector(
+    directory_filtered: pd.DataFrame,
+    directory_exists: bool,
+    fallback_urls: list[str] | None = None,
+) -> str | None:
+    """Seletor individual de governador (por nome), exclusivo de `modeling`,
+    em cascata com os filtros de grupo (`directory_filtered` já vem filtrado).
+
+    Se `governors_metadata` ainda não existir, cai para uma lista de URLs
+    brutas (`fallback_urls`, tipicamente `df_comments["inputUrl"].unique()`)
+    em vez de quebrar a página -- comportamento idêntico ao seletor anterior."""
+    if directory_exists:
+        if directory_filtered.empty:
+            st.sidebar.warning(
+                "Nenhum governador corresponde aos filtros de grupo selecionados."
+            )
+            return None
+        options = directory_filtered["inputUrl"].dropna().unique().tolist()
+        label_by_url = dict(
+            zip(
+                directory_filtered["inputUrl"],
+                directory_filtered["nome"].fillna(directory_filtered["inputUrl"]),
+            )
+        )
+        format_func = lambda url: label_by_url.get(url, url)  # noqa: E731
+    elif fallback_urls:
+        st.sidebar.info(
+            "Tabela `governors_metadata` ainda não existe -- mostrando por "
+            "URL do perfil. Rode a pipeline para ver nomes."
+        )
+        options = fallback_urls
+        format_func = lambda url: url  # noqa: E731
+    else:
+        st.sidebar.warning("Nenhum governador disponível.")
+        return None
+
+    return st.sidebar.selectbox(
+        "Selecione o Governador:", options=options, format_func=format_func
+    )

--- a/src/dashboard/loaders.py
+++ b/src/dashboard/loaders.py
@@ -45,3 +45,11 @@ def load_clusters() -> pd.DataFrame:
         return get_delta_repository().load_clusters()
     except FileNotFoundError:
         return pd.DataFrame()
+
+
+@st.cache_data
+def load_governors_metadata() -> pd.DataFrame:
+    try:
+        return get_delta_repository().load_governors_metadata()
+    except FileNotFoundError:
+        return pd.DataFrame()

--- a/src/features/silver/governors_metadata_cleaner.py
+++ b/src/features/silver/governors_metadata_cleaner.py
@@ -1,0 +1,52 @@
+"""
+Silver governors metadata cleaner.
+
+Ingere `data/raw/governadores.xlsx` (nome, UF, partido, link do perfil) como
+tabela de dimensão no Delta Lake, para servir de fonte única de verdade para
+o dashboard (nome/UF/partido) em vez de ler a planilha bruta a cada carregamento.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from src.delta_io import write_delta
+from src.schemas_delta import SILVER_GOVERNORS_METADATA_SCHEMA
+
+
+class GovernorsMetadataCleaner:
+    COLUMN_MAP: dict[str, str] = {
+        "Governador": "nome",
+        "Unidade Federativa": "uf",
+        "Partido": "partido",
+        "Link": "inputUrl",
+    }
+
+    def clean(self, df_raw: pd.DataFrame, run_id: str) -> pd.DataFrame:
+        df = df_raw.copy()
+        df.columns = df.columns.str.strip()
+
+        missing = [c for c in self.COLUMN_MAP if c not in df.columns]
+        if missing:
+            raise ValueError(
+                f"Colunas esperadas ausentes em governadores.xlsx: {missing}"
+            )
+
+        df = df[list(self.COLUMN_MAP)].rename(columns=self.COLUMN_MAP)
+        for col in ("nome", "uf", "partido", "inputUrl"):
+            df[col] = df[col].astype(str).str.strip()
+
+        # A planilha é mantida manualmente e pode repetir uma linha (edição
+        # duplicada, cópia de outro ano) -- mantém só a primeira ocorrência.
+        df = df.drop_duplicates(subset=["inputUrl"], keep="first")
+
+        df["_ingested_at"] = pd.Timestamp.now(tz="UTC")
+        df["_run_id"] = run_id
+        df["_source_layer"] = "raw_xlsx"
+
+        return df
+
+    def write(self, df_silver: pd.DataFrame, path: Path | str) -> None:
+        write_delta(path, df_silver, SILVER_GOVERNORS_METADATA_SCHEMA)

--- a/src/features/silver/post_cleaner.py
+++ b/src/features/silver/post_cleaner.py
@@ -26,6 +26,7 @@ class PostCleaner:
 
     def clean_posts(self, df_bronze: pd.DataFrame) -> pd.DataFrame:
         df = df_bronze.copy()
+        df = self._drop_null_id(df)
         df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
         df["Tipo"] = "FEED"
@@ -36,6 +37,7 @@ class PostCleaner:
 
     def clean_reels(self, df_bronze: pd.DataFrame) -> pd.DataFrame:
         df = df_bronze.copy()
+        df = self._drop_null_id(df)
         df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
         df["Tipo"] = "REELS"
@@ -83,3 +85,12 @@ class PostCleaner:
     def _drop_noise_columns(self, df: pd.DataFrame) -> pd.DataFrame:
         cols = [c for c in self.POSTS_COLUMNS_TO_DROP if c in df.columns]
         return df.drop(columns=cols)
+
+    def _drop_null_id(self, df: pd.DataFrame) -> pd.DataFrame:
+        # Apify ocasionalmente retorna um post/reel sem `id` (item indisponível/
+        # erro parcial no scrape) -- SILVER_POSTS_SCHEMA/SILVER_REELS_SCHEMA
+        # exigem `id` não nulo, então uma linha assim quebraria a escrita da
+        # Silver inteira em vez de só descartar o registro inválido.
+        if "id" in df.columns:
+            df = df[df["id"].notna()]
+        return df

--- a/src/features/silver/profile_cleaner.py
+++ b/src/features/silver/profile_cleaner.py
@@ -37,6 +37,14 @@ class ProfileCleaner:
 
     def clean(self, df_bronze: pd.DataFrame, run_id: str) -> pd.DataFrame:
         df = df_bronze.copy()
+
+        # Apify ocasionalmente retorna um resultado de scrape sem `id` (perfil
+        # indisponível/erro parcial) -- SILVER_PROFILES_SCHEMA exige `id` não
+        # nulo, então uma linha assim quebraria a escrita da Silver inteira
+        # em vez de só descartar o registro inválido.
+        if "id" in df.columns:
+            df = df[df["id"].notna()]
+
         cols_to_drop = [c for c in self.COLUMNS_TO_DROP if c in df.columns]
         if cols_to_drop:
             df = df.drop(columns=cols_to_drop)

--- a/src/repositories/delta_repository.py
+++ b/src/repositories/delta_repository.py
@@ -59,6 +59,11 @@ class DeltaRepository(DataRepository):
     def load_clusters(self) -> pd.DataFrame:
         return self._load(_join(self._gold_dir, "governor_clusters"))
 
+    def load_governors_metadata(self) -> pd.DataFrame:
+        if self._silver_dir is None:
+            raise ValueError("silver_dir não foi configurado neste repositório.")
+        return self._load(_join(self._silver_dir, "governors_metadata"))
+
     def save(self, dataframes: dict[str, pd.DataFrame]) -> None:
         raise NotImplementedError(
             "DeltaRepository é somente leitura. Use os writers para escrever."

--- a/src/schemas_delta.py
+++ b/src/schemas_delta.py
@@ -153,6 +153,18 @@ SILVER_COMMENTS_SCHEMA = pa.schema(
     ]
 )
 
+SILVER_GOVERNORS_METADATA_SCHEMA = pa.schema(
+    [
+        pa.field("inputUrl", pa.string(), nullable=False),
+        pa.field("nome", pa.string(), nullable=False),
+        pa.field("uf", pa.string(), nullable=True),
+        pa.field("partido", pa.string(), nullable=True),
+        pa.field("_ingested_at", pa.timestamp("us", tz="UTC"), nullable=False),
+        pa.field("_run_id", pa.string(), nullable=False),
+        pa.field("_source_layer", pa.string(), nullable=False),
+    ]
+)
+
 # GOLD
 GOLD_ENGAGEMENT_SCHEMA = pa.schema(
     [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -48,10 +48,17 @@ def _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silv
     aggregator = MagicMock()
     aggregator.aggregate.return_value = pd.DataFrame({"id": ["1"]})
 
+    governors_cleaner = MagicMock()
+    governors_cleaner.clean.return_value = pd.DataFrame({"inputUrl": ["u1"]})
+
     monkeypatch.setattr("pipeline.ProfileCleaner", lambda: profile_cleaner)
     monkeypatch.setattr("pipeline.PostCleaner", lambda: post_cleaner)
     monkeypatch.setattr("pipeline.CommentCleaner", lambda: comment_cleaner)
     monkeypatch.setattr("pipeline.EngagementAggregator", lambda: aggregator)
+    monkeypatch.setattr("pipeline.GovernorsMetadataCleaner", lambda: governors_cleaner)
+    monkeypatch.setattr(
+        "pipeline.pd.read_excel", lambda *a, **k: pd.DataFrame({"Link": ["u1"]})
+    )
 
     fake_run_deterministic_modeling = MagicMock()
     monkeypatch.setattr("pipeline.run_deterministic_modeling", fake_run_deterministic_modeling)

--- a/tests/test_silver_cleaners.py
+++ b/tests/test_silver_cleaners.py
@@ -36,6 +36,27 @@ def test_profile_cleaner_adds_fullname_when_missing():
     assert out.loc[0, "fullName"] == "g"
 
 
+def test_profile_cleaner_descarta_linhas_com_id_nulo():
+    """
+    A Apify ocasionalmente retorna um resultado de scrape sem `id` (perfil
+    indisponível/erro parcial). SILVER_PROFILES_SCHEMA exige `id` não nulo --
+    sem descartar essas linhas, a escrita da Silver inteira quebraria.
+    """
+    df = pd.DataFrame(
+        {
+            "id": ["1", None],
+            "username": ["g", "sem_id"],
+            "followersCount": [100, 50],
+            "_ingested_at": pd.to_datetime(["2026-05-01", "2026-05-01"], utc=True),
+            "_run_id": ["r1", "r1"],
+        }
+    )
+    cleaner = ProfileCleaner()
+    out = cleaner.clean(df, run_id="r1")
+    assert len(out) == 1
+    assert out.iloc[0]["id"] == "1"
+
+
 def test_post_cleaner_feed_and_reel():
     df_posts = pd.DataFrame(
         {

--- a/tests/test_silver_cleaners.py
+++ b/tests/test_silver_cleaners.py
@@ -100,6 +100,32 @@ def test_comment_cleaner_explode():
     assert not out.empty
 
 
+def test_post_cleaner_descarta_linhas_com_id_nulo():
+    """Mesmo cenário de dado sujo do ProfileCleaner (ver teste equivalente),
+    só que para posts/reels: um item sem `id` quebraria SILVER_POSTS_SCHEMA/
+    SILVER_REELS_SCHEMA (id não-nulo) se não fosse descartado antes."""
+    df = pd.DataFrame(
+        {
+            "id": ["p1", None],
+            "ownerId": ["1", "1"],
+            "ownerUsername": ["g", "g"],
+            "commentsCount": [1, 2],
+            "likesCount": [2, 3],
+            "timestamp": ["2026-05-01T00:00:00+00:00", "2026-05-01T00:00:00+00:00"],
+            "_ingested_at": pd.to_datetime(["2026-05-01", "2026-05-01"], utc=True),
+            "_run_id": ["r1", "r1"],
+        }
+    )
+    pc = PostCleaner()
+    outp = pc.clean_posts(df)
+    assert len(outp) == 1
+    assert outp.iloc[0]["id"] == "p1"
+
+    outr = pc.clean_reels(df.assign(latestComments=["[]", "[]"]))
+    assert len(outr) == 1
+    assert outr.iloc[0]["id"] == "p1"
+
+
 def test_post_cleaner_deduplica_execucoes_acumuladas():
     """
     A Bronze é append-only. Sem deduplicação, reprocessar o pipeline


### PR DESCRIPTION
## Resumo

Fase 1 dos fixes de dashboard pedidos, desenhados numa sessão de grilling e refinados com code review dedicado à lógica de filtros.

- Novo seletor "Selecione o Governador" (modeling) por **nome**, com "Todos os Governadores" e fallback pra URL bruta se `governors_metadata` não existir ainda.
- Nova dimensão Delta `silver/governors_metadata` (nome/UF/partido), ingerida de `governadores.xlsx` -- nova etapa em `pipeline.py`.
- Filtros de grupo compartilhados (Região -- 5 macrorregiões, Partido, Cluster de Reels) entre `exploratory` e `modeling`, em cascata com o seletor individual.
- Filtro de cluster por "contém" (não "dominante/moda") -- outliers do DBSCAN (-1) continuam filtráveis, já que podem ser reels virais/atípicos.
- Tabela de reels com link clicável pro Instagram, abaixo do "Top 10 Reels".
- Layout do scatter em `exploratory`: 75% gráfico / 25% seletores de eixo, altura 1000→500.
- `app.py` virou home/intro com métricas ao vivo + resumo da metodologia.
- 2 fixes de robustez em `ProfileCleaner`/`PostCleaner` (descarta linhas com `id` nulo -- bloqueavam a pipeline inteira).

## Test plan

- [x] `ruff check src/` limpo
- [x] 79 testes (`pytest tests/`) passando
- [x] `streamlit.testing.v1.AppTest` -- as 3 páginas carregam sem exceção, filtros de região/partido/cluster alteram os dados corretamente, seletor em cascata funciona, "Todos os Governadores" agrega corretamente, tabela de link renderiza
- [x] Revisão visual no Chrome pelo usuário
- [ ] Rodar `scripts/run_modeling.py` para realinhar `governor_clusters`/`governor_sentiment` com os dados frescos (achado desta sessão, não bloqueia o merge -- é sobre dados, não código)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UjAmx8ZXJwhs9XpTUHigfD