### PR TITLE
Fase 2: clustering de perfil de governador por Engajamento (backend + prep serverless)

### DIFF
--- a/.github/workflows/build-lambdas.yml
+++ b/.github/workflows/build-lambdas.yml
@@ -1,7 +1,7 @@
 name: Build and Push Lambda Images
 
-# Publica as 4 imagens das Lambdas (extract, transform, load, orchestrator)
-# no ECR via OIDC. Não atualiza nenhuma Lambda em execução -- terraform
+# Publica as 5 imagens das Lambdas (extract, transform, load, orchestrator,
+# model) no ECR via OIDC. Não atualiza nenhuma Lambda em execução -- terraform
 # apply continua manual/intencional. Ver ADR 0009.
 
 on:
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        lambda: [extract, transform, load, orchestrator]
+        lambda: [extract, transform, load, orchestrator, model]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/config/settings.py
+++ b/config/settings.py
@@ -52,6 +52,7 @@ GOLD_DIR = DATA_DIR / "gold"
 GOLD_ENGAGEMENT = GOLD_DIR / "governor_engagement"
 GOLD_SENTIMENT = GOLD_DIR / "governor_sentiment"
 GOLD_CLUSTERS = GOLD_DIR / "governor_clusters"
+GOLD_PROFILE_CLUSTERS_ENGAGEMENT = GOLD_DIR / "governor_profile_clusters_engagement"
 
 # Checkpoints locais do estágio determinístico de modelagem (ver ADR 0003) —
 # não são Delta, ficam fora do git.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,10 +1,14 @@
 # Infraestrutura AWS (Terraform)
 
 Provisiona os recursos para rodar o pipeline Medallion na nuvem: bucket S3 (data lake),
-repositórios ECR e as 4 funções Lambda (`extract`, `transform`, `load`, `orchestrator`) como
+repositórios ECR e as 5 funções Lambda (`extract`, `transform`, `load`, `orchestrator`, `model`) como
 imagens de container. Ver [ADR 0008](../docs/adr/0008-orquestrar-lambdas-via-orquestradora-unica-e-terraform.md)
 para o porquê dessas escolhas, e [ADR 0009](../docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md)
 para a publicação automática das imagens via GitHub Actions.
+
+`model` (clustering de perfil de governador por Engajamento, Fase 2) fica **fora** da cadeia da
+orquestradora de propósito -- é invocada manualmente, como a modelagem local também é opt-in (ver
+"Rodar o clustering de perfil" abaixo e ADR 0001).
 
 **Aviso de custo:** Lambda, S3 e ECR têm free tier, mas não são gratuitos indefinidamente —
 revise os preços atuais antes de aplicar isto numa conta com cobrança ativa. Nada aqui é aplicado
@@ -47,7 +51,7 @@ automaticamente; você decide quando rodar `terraform apply`.
    tem um provedor OIDC do GitHub Actions criado por outra infraestrutura — só pode existir um por
    conta), rode de novo com `-var="create_github_oidc_provider=false"`.
 
-3. **Buildar e publicar as 4 imagens** usando os URLs de repositório do passo anterior:
+3. **Buildar e publicar as 5 imagens** usando os URLs de repositório do passo anterior:
 
    ```bash
    cd ..
@@ -58,7 +62,7 @@ automaticamente; você decide quando rodar `terraform apply`.
    rodar sozinho a cada merge relevante em `main` — este script continua existindo só como
    fallback manual.
 
-4. **Provisionar o resto** (bucket S3, IAM, as 4 funções Lambda):
+4. **Provisionar o resto** (bucket S3, IAM, as 5 funções Lambda):
 
    ```bash
    cd infra
@@ -83,7 +87,7 @@ Depois da fase 1 do bootstrap acima, configure o GitHub Actions para autenticar 
    `instagram-governadores`), defina também as repository variables `AWS_REGION` e `PROJECT_NAME`.
 
 A partir daí, todo push em `main` que passar no CI e mexer em `lambdas/**` ou `src/**` publica as
-4 imagens no ECR automaticamente, tagueadas com o SHA do commit (ver
+5 imagens no ECR automaticamente, tagueadas com o SHA do commit (ver
 `.github/workflows/build-lambdas.yml` e [ADR 0009](../docs/adr/0009-publicar-imagens-das-lambdas-via-github-actions-com-oidc.md)).
 Isso **não** afeta as Lambdas em execução — promover continua sendo manual:
 
@@ -105,6 +109,19 @@ TF_VAR_image_tag=$(git rev-parse origin/main) terraform apply
    cat response.json
    ```
 
+6. **(Opcional, manual) Rodar o clustering de perfil por Engajamento** invocando `model`
+   diretamente -- não faz parte da cadeia acima, precisa de um `run_id` (reaproveite o de uma
+   execução anterior da orquestradora, ou gere um novo):
+
+   ```bash
+   aws lambda invoke \
+     --function-name "$(terraform output -raw model_function_name)" \
+     --payload '{"run_id": "20260829_120000_abcdef12"}' \
+     --cli-binary-format raw-in-base64-out \
+     response.json
+   cat response.json
+   ```
+
 ## Destruir tudo
 
 ```bash
@@ -119,7 +136,9 @@ terraform destroy
   de 15 minutos de timeout de Lambda. Ver ADR 0008 para a alternativa rejeitada (Step Functions).
 - Não há gatilho agendado (EventBridge/cron) configurado — o pipeline roda só quando invocado
   manualmente. Adicionar um agendamento é uma mudança pequena e aditiva neste mesmo `main.tf`.
-- O workflow `build-lambdas.yml` builda as 4 imagens sempre juntas (sem detecção seletiva por
+- O workflow `build-lambdas.yml` builda as 5 imagens sempre juntas (sem detecção seletiva por
   Lambda) — decisão deliberada, ver ADR 0009.
+- `model` não tem retry/DLQ configurado (mesmo padrão simples das outras Lambdas) -- uma falha na
+  invocação manual não deixa rastro além do próprio `response.json`/logs do CloudWatch.
 - A trust policy da role OIDC do GitHub Actions está restrita a `ref:refs/heads/main` — publicar a
   partir de outro branch (ex.: staging) exige revisar `infra/main.tf`.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,15 +1,22 @@
 locals {
-  # As 3 Lambdas que fazem I/O real no data lake (Bronze/Silver/Gold).
+  # As 3 Lambdas que fazem I/O real no data lake (Bronze/Silver/Gold),
+  # encadeadas automaticamente pela orquestradora.
   data_lambdas = toset(["extract", "transform", "load"])
 
   # Timeout/memória por Lambda -- extract pode demorar dependendo do
   # RESULTS_LIMIT (scraping via Apify); orchestrator precisa cobrir a soma
-  # das 3 etapas, até o teto de 15 min (900s) do Lambda.
+  # das 3 etapas, até o teto de 15 min (900s) do Lambda. `model` (Fase 2 --
+  # clustering de perfil de governador) fica FORA da cadeia da orquestradora
+  # de propósito: modelagem é opt-in, não parte da ingestão obrigatória
+  # (mesmo princípio da modelagem local, ver ADR 0001) -- por isso não conta
+  # pro orçamento de tempo do orchestrator, e não entra em `data_lambdas`/
+  # na policy `invoke_data_lambdas` abaixo.
   lambda_settings = {
     extract      = { timeout = 300, memory = 512 }
     transform    = { timeout = 120, memory = 1024 }
     load         = { timeout = 120, memory = 1024 }
     orchestrator = { timeout = 900, memory = 256 }
+    model        = { timeout = 120, memory = 1024 }
   }
 }
 
@@ -22,7 +29,7 @@ resource "aws_s3_bucket" "data_lake" {
 # ── Repositórios ECR (um por Lambda, incluindo a orquestradora) ──────────
 
 resource "aws_ecr_repository" "lambdas" {
-  for_each = toset(["extract", "transform", "load", "orchestrator"])
+  for_each = toset(["extract", "transform", "load", "orchestrator", "model"])
 
   name         = "${var.project_name}-${each.key}"
   force_delete = true
@@ -122,6 +129,47 @@ resource "aws_lambda_function" "data_lambda" {
       },
       each.key == "extract" ? { APIFY_API_TOKEN = var.apify_api_token } : {}
     )
+  }
+}
+
+# ── IAM: model lê/escreve só na camada Gold do data lake ──────────────────
+# Fora de `data_lambdas` de propósito (ver comentário em `lambda_settings`
+# acima) -- role e Lambda próprios, não entra na cadeia da orquestradora.
+
+resource "aws_iam_role" "model_lambda" {
+  name               = "${var.project_name}-model-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "model_lambda_basic_execution" {
+  role       = aws_iam_role.model_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "model_lambda_s3_access" {
+  name   = "${var.project_name}-model-s3-access"
+  role   = aws_iam_role.model_lambda.id
+  policy = data.aws_iam_policy_document.data_lake_access.json
+}
+
+# ── Lambda: model (clustering de perfil de governador por Engajamento,
+# Fase 2) ──────────────────────────────────────────────────────────────────
+# Invocada manualmente (aws lambda invoke --function-name ...), nunca pela
+# orquestradora -- ver decisão em `lambda_settings`.
+
+resource "aws_lambda_function" "model" {
+  function_name = "${var.project_name}-model"
+  role          = aws_iam_role.model_lambda.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.lambdas["model"].repository_url}:${var.image_tag}"
+  timeout       = local.lambda_settings.model.timeout
+  memory_size   = local.lambda_settings.model.memory
+
+  environment {
+    variables = {
+      S3_BUCKET      = aws_s3_bucket.data_lake.bucket
+      S3_GOLD_PREFIX = "gold/"
+    }
   }
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -12,13 +12,21 @@ output "lambda_function_names" {
   description = "Nomes das funções Lambda provisionadas."
   value = merge(
     { for name, fn in aws_lambda_function.data_lambda : name => fn.function_name },
-    { orchestrator = aws_lambda_function.orchestrator.function_name }
+    {
+      orchestrator = aws_lambda_function.orchestrator.function_name
+      model        = aws_lambda_function.model.function_name
+    }
   )
 }
 
 output "orchestrator_function_name" {
   description = "Nome da função a invocar para rodar o pipeline completo (aws lambda invoke)."
   value       = aws_lambda_function.orchestrator.function_name
+}
+
+output "model_function_name" {
+  description = "Nome da função de clustering de perfil por engajamento (Fase 2) -- invocação manual, aws lambda invoke --function-name <isto> --payload '{\"run_id\": \"...\"}'. Não faz parte da cadeia da orquestradora."
+  value       = aws_lambda_function.model.function_name
 }
 
 output "github_actions_role_arn" {

--- a/lambdas/model/Dockerfile
+++ b/lambdas/model/Dockerfile
@@ -1,0 +1,17 @@
+# Contexto de build: raiz do repositório (não este diretório) -- o handler
+# importa de src/, ex.: src.modeling.profile_clustering.
+# docker build -f lambdas/model/Dockerfile -t model .
+#
+# Sem torch/transformers/bertopic de propósito: o clustering de PERFIL por
+# Engajamento (Fase 2) só consome métricas já agregadas em governor_engagement
+# -- scikit-learn/hyperopt bastam (AutoClusterHPO), nada de inferência de NLP
+# nesta Lambda.
+FROM public.ecr.aws/lambda/python:3.12
+
+COPY lambdas/model/requirements.txt ${LAMBDA_TASK_ROOT}/
+RUN pip install --no-cache-dir -r ${LAMBDA_TASK_ROOT}/requirements.txt
+
+COPY src/ ${LAMBDA_TASK_ROOT}/src/
+COPY lambdas/model/handler.py ${LAMBDA_TASK_ROOT}/
+
+CMD ["handler.handler"]

--- a/lambdas/model/handler.py
+++ b/lambdas/model/handler.py
@@ -1,0 +1,52 @@
+import json
+import os
+
+from deltalake import DeltaTable
+
+from src.features.gold.model_enricher import ModelEnricher
+from src.modeling.config import ClusterConfig
+from src.modeling.profile_clustering import cluster_governor_profiles
+
+STORAGE_OPTIONS = {
+    "AWS_REGION": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+    "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
+}
+
+# Mesmas features/limite usados em scripts/run_profile_clustering_engagement.py
+# (validado localmente antes desta Lambda existir) -- ver sessão de design da
+# Fase 2: métricas relativas/comportamentais, não volume bruto; max_n_clusters
+# pequeno porque só há 27 governadores.
+FEATURE_COLUMNS = ["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"]
+MAX_N_CLUSTERS = 6
+
+
+def handler(event, context):
+    bucket = os.environ.get("S3_BUCKET", "")
+    gold_pfx = os.environ.get("S3_GOLD_PREFIX", "gold/")
+
+    run_id = event.get("run_id")
+    if not bucket:
+        return {"statusCode": 400, "body": "Missing S3_BUCKET"}
+    if not run_id:
+        return {"statusCode": 400, "body": "Missing run_id in event"}
+
+    gold_base = f"s3://{bucket}/{gold_pfx}"
+
+    df_profiles = DeltaTable(
+        f"{gold_base}governor_engagement", storage_options=STORAGE_OPTIONS
+    ).to_pandas()
+
+    config = ClusterConfig(feature_columns=FEATURE_COLUMNS, max_n_clusters=MAX_N_CLUSTERS)
+    df_clustered, _model, _cluster_config, _score, _algo_name = cluster_governor_profiles(
+        df_profiles, config
+    )
+
+    enricher = ModelEnricher()
+    enricher.write_profile_clusters_engagement(
+        df_clustered, f"{gold_base}governor_profile_clusters_engagement", run_id
+    )
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({"run_id": run_id, "status": "profile_clusters_engagement_complete"}),
+    }

--- a/lambdas/model/requirements.txt
+++ b/lambdas/model/requirements.txt
@@ -1,0 +1,6 @@
+boto3
+pandas
+pyarrow
+deltalake>=1.0
+scikit-learn
+hyperopt

--- a/scripts/build_and_push_lambdas.sh
+++ b/scripts/build_and_push_lambdas.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Builda e publica as 4 imagens das Lambdas (extract, transform, load,
-# orchestrator) nos repositórios ECR criados pelo Terraform em infra/.
+# Builda e publica as 5 imagens das Lambdas (extract, transform, load,
+# orchestrator, model) nos repositórios ECR criados pelo Terraform em infra/.
 #
 # Pré-requisito: já ter rodado, em infra/, pelo menos
 #   terraform apply -target=aws_ecr_repository.lambdas
@@ -18,7 +18,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."  # raiz do repositório
 
 TAG="${1:-latest}"
-LAMBDAS=(extract transform load orchestrator)
+LAMBDAS=(extract transform load orchestrator model)
 
 REPO_URLS_JSON="$(cd infra && terraform output -json ecr_repository_urls)"
 

--- a/scripts/run_profile_clustering_engagement.py
+++ b/scripts/run_profile_clustering_engagement.py
@@ -1,0 +1,71 @@
+"""
+Roda o clustering de PERFIL de governador por Engajamento (Fase 2) sobre o
+Gold `governor_engagement` já existente -- não reprocessa Bronze/Silver/
+Gold-engagement. Distinto de `scripts/run_modeling.py`, que clusteriza reels.
+
+Features: % ENGAJAMENTO, RECENCIA, FREQUENCIA -- métricas relativas/
+comportamentais, não volume bruto (followersCount/commentsSum/likesSum
+correlacionam quase só com tamanho de audiência, não com comportamento; ver
+sessão de design da Fase 2).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from config import settings
+from src.features.gold.model_enricher import ModelEnricher
+from src.modeling.config import ClusterConfig
+from src.modeling.profile_clustering import cluster_governor_profiles
+from src.repositories.delta_repository import DeltaRepository
+from src.run_id import build_run_id
+
+FEATURE_COLUMNS = ["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"]
+
+# Só 27 governadores -- o default de ClusterConfig.max_n_clusters (folgado o
+# bastante para reels, na casa das centenas/milhares) permitiria clusters
+# quase do tamanho da amostra. 6 já é generoso para 27 pontos.
+MAX_N_CLUSTERS = 6
+
+
+def run(run_id: str | None = None) -> str:
+    run_id = build_run_id(run_id)
+    repo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
+    df_profiles = repo.load_profiles()
+
+    config = ClusterConfig(feature_columns=FEATURE_COLUMNS, max_n_clusters=MAX_N_CLUSTERS)
+    df_clustered, model, cluster_config, score, algo_name = cluster_governor_profiles(
+        df_profiles, config
+    )
+
+    enricher = ModelEnricher()
+    enricher.write_profile_clusters_engagement(
+        df_clustered, settings.GOLD_PROFILE_CLUSTERS_ENGAGEMENT, run_id
+    )
+
+    print(f"[OK] Algoritmo vencedor: {algo_name} (score CVI combinado: {score:.4f})")
+    print(f"[OK] Distribuição de clusters:\n{df_clustered['Clusters (AutoClusterHPO)'].value_counts().sort_index()}")
+    return run_id
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Roda o clustering de perfil de governador por Engajamento (Fase 2)."
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="run_id a usar para esta execucao (default: gerado automaticamente).",
+    )
+    args = parser.parse_args()
+
+    run_id = run(run_id=args.run_id)
+    # Sem emoji: o console padrao do Windows usa cp1252 e levanta
+    # UnicodeEncodeError ao imprimi-los.
+    print(f"[OK] Clustering de perfil por engajamento concluido com run_id: {run_id}")

--- a/src/features/gold/model_enricher.py
+++ b/src/features/gold/model_enricher.py
@@ -10,7 +10,11 @@ from pathlib import Path
 import pandas as pd
 
 from src.delta_io import write_delta
-from src.schemas_delta import GOLD_CLUSTERS_SCHEMA, GOLD_SENTIMENT_SCHEMA
+from src.schemas_delta import (
+    GOLD_CLUSTERS_SCHEMA,
+    GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA,
+    GOLD_SENTIMENT_SCHEMA,
+)
 
 
 class ModelEnricher:
@@ -52,3 +56,35 @@ class ModelEnricher:
             }
         )
         write_delta(path, df_clusters, GOLD_CLUSTERS_SCHEMA)
+
+    def write_profile_clusters_engagement(
+        self,
+        df_profiles_clustered: pd.DataFrame,
+        path: Path | str,
+        run_id: str,
+    ) -> None:
+        """Grava clusters de PERFIL de governador por Engajamento (Fase 2).
+        Espera as mesmas colunas de saída de `run_autocluster`/
+        `cluster_governor_profiles`: inputUrl, 'Clusters (AutoClusterHPO)',
+        algo_name, score. Granularidade de governador, não de reel -- schema
+        e path são deliberadamente separados de `write_clusters`."""
+        required = {"inputUrl", "Clusters (AutoClusterHPO)", "algo_name", "score"}
+        missing = required - set(df_profiles_clustered.columns)
+        if missing:
+            raise ValueError(
+                f"df_profiles_clustered não tem as colunas esperadas: {sorted(missing)}"
+            )
+
+        df_clusters = pd.DataFrame(
+            {
+                "inputUrl": df_profiles_clustered["inputUrl"].values,
+                "cluster_label": df_profiles_clustered["Clusters (AutoClusterHPO)"]
+                .astype("int64")
+                .values,
+                "cluster_algo": df_profiles_clustered["algo_name"].astype(str).values,
+                "cluster_score": df_profiles_clustered["score"].astype(float).values,
+                "_run_id": run_id,
+                "_generated_at": datetime.now(timezone.utc),
+            }
+        )
+        write_delta(path, df_clusters, GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA)

--- a/src/modeling/clustering.py
+++ b/src/modeling/clustering.py
@@ -245,18 +245,22 @@ class AutoClusterHPO:
             return (self.best_overall_labels, None, None, -np.inf, None)
 
 
-def cluster_reels(
-    df_reels: pd.DataFrame, config: ClusterConfig
+def run_autocluster(
+    df: pd.DataFrame, config: ClusterConfig
 ) -> tuple[pd.DataFrame, object, dict | None, float, str | None]:
     """Aplica `AutoClusterHPO` sobre `config.feature_columns` e anexa o resultado ao DataFrame.
 
     `model`/`cluster_config`/`score`/`algo_name` são escalares — um único
     modelo vencedor, não um valor por linha — e por isso ficam
-    broadcastados nas colunas `model`/`config`/`score`/`algo_name`,
-    reproduzindo o comportamento já esperado pelos testes de
-    `ModelEnricher.write_clusters`.
+    broadcastados nas colunas `model`/`config`/`score`/`algo_name`.
+
+    Genérico quanto à granularidade das linhas de `df` (reel, perfil de
+    governador, etc.) — só depende de `config.feature_columns` serem
+    numéricas. `cluster_reels` (abaixo) e `cluster_governor_profiles`
+    (`src/modeling/profile_clustering.py`) são wrappers com nome específico
+    sobre esta mesma função, para não duplicar a lógica.
     """
-    df = df_reels.copy()
+    df = df.copy()
 
     autocluster = AutoClusterHPO(
         max_evals_per_algo=config.max_evals_per_algo,
@@ -274,3 +278,11 @@ def cluster_reels(
     df["algo_name"] = algo_name
 
     return df, model, cluster_config, score, algo_name
+
+
+def cluster_reels(
+    df_reels: pd.DataFrame, config: ClusterConfig
+) -> tuple[pd.DataFrame, object, dict | None, float, str | None]:
+    """Aplica `run_autocluster` a reels. Reproduz o comportamento já esperado
+    pelos testes de `ModelEnricher.write_clusters`."""
+    return run_autocluster(df_reels, config)

--- a/src/modeling/profile_clustering.py
+++ b/src/modeling/profile_clustering.py
@@ -1,0 +1,21 @@
+"""
+Clusterização de PERFIL de governador (Fase 2), distinta da clusterização de
+reel existente em `src/modeling/clustering.py::cluster_reels`. Só 27 linhas
+(uma por governador) -- ver `ClusterConfig.max_n_clusters` no chamador para
+evitar espaços de busca folgados demais para esse tamanho de amostra.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.modeling.clustering import run_autocluster
+from src.modeling.config import ClusterConfig
+
+
+def cluster_governor_profiles(
+    df_profiles: pd.DataFrame, config: ClusterConfig
+) -> tuple[pd.DataFrame, object, dict | None, float, str | None]:
+    """Aplica `run_autocluster` a `df_profiles` (1 linha por governador, ex.
+    `governor_engagement`). Ver `run_autocluster` para o formato do retorno."""
+    return run_autocluster(df_profiles, config)

--- a/src/schemas_delta.py
+++ b/src/schemas_delta.py
@@ -219,3 +219,19 @@ GOLD_CLUSTERS_SCHEMA = pa.schema(
         pa.field("_generated_at", pa.timestamp("us", tz="UTC"), nullable=False),
     ]
 )
+
+# Clusterização de PERFIL de governador (Fase 2, por Engajamento) -- 1 linha
+# por governador, não por reel. Tabela separada de GOLD_CLUSTERS_SCHEMA de
+# propósito (ver ADR 0004/0005: não generalizar schema até existir motivo
+# real) -- futuros tipos (sentimento, tópico) ganham cada um sua própria
+# tabela/schema, em vez de uma coluna "cluster_type" genérica aqui.
+GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA = pa.schema(
+    [
+        pa.field("inputUrl", pa.string(), nullable=False),
+        pa.field("cluster_label", pa.int64(), nullable=False),
+        pa.field("cluster_algo", pa.string(), nullable=False),
+        pa.field("cluster_score", pa.float64(), nullable=True),
+        pa.field("_run_id", pa.string(), nullable=False),
+        pa.field("_generated_at", pa.timestamp("us", tz="UTC"), nullable=False),
+    ]
+)

--- a/tests/test_model_enricher.py
+++ b/tests/test_model_enricher.py
@@ -47,9 +47,10 @@ def test_write_sentiment_grava_topico_junto_do_sentimento(tmp_path):
 
 def test_write_clusters_usa_granularidade_de_reel(tmp_path):
     """
-    A clusterização do AutoClusterHPO é por reel (PCA de engajamento/duração
-    do vídeo), não por perfil — não há clusterização de governadores no
-    projeto. O schema e a escrita precisam refletir isso.
+    `write_clusters` é especificamente para a clusterização de reel do
+    AutoClusterHPO (PCA de engajamento/duração do vídeo) -- granularidade
+    de reel, não de perfil de governador (essa é `write_profile_clusters_engagement`,
+    ver testes abaixo). O schema e a escrita precisam refletir isso.
     """
     path = tmp_path / "governor_clusters"
     ModelEnricher().write_clusters(_reels_clusterizados(), path, run_id="r1")
@@ -65,3 +66,46 @@ def test_write_clusters_falha_com_mensagem_clara_se_faltar_coluna(tmp_path):
 
     with pytest.raises(ValueError, match="algo_name"):
         ModelEnricher().write_clusters(df_incompleto, tmp_path / "governor_clusters", run_id="r1")
+
+
+def _perfis_clusterizados():
+    # Colunas produzidas por cluster_governor_profiles/run_autocluster:
+    # 'Clusters (AutoClusterHPO)', 'algo_name' e 'score' vêm de um único
+    # modelo vencedor, por isso são constantes entre as linhas.
+    return pd.DataFrame(
+        {
+            "inputUrl": [
+                "https://www.instagram.com/governador_a/",
+                "https://www.instagram.com/governador_b/",
+            ],
+            "Clusters (AutoClusterHPO)": [0, -1],
+            "algo_name": ["KMeans", "KMeans"],
+            "score": [0.55, 0.55],
+        }
+    )
+
+
+def test_write_profile_clusters_engagement_usa_granularidade_de_perfil(tmp_path):
+    """
+    Fase 2: clusterização de PERFIL de governador por Engajamento -- 1 linha
+    por governador (`inputUrl`), diferente de `write_clusters` (1 linha por
+    reel). Tabela/schema separados de propósito, ver ADR 0004/0005.
+    """
+    path = tmp_path / "governor_profile_clusters_engagement"
+    ModelEnricher().write_profile_clusters_engagement(_perfis_clusterizados(), path, run_id="r1")
+
+    out = DeltaTable(str(path)).to_pandas()
+    assert len(out) == 2
+    assert set(out.columns) >= {"inputUrl", "cluster_label"}
+    assert out.loc[
+        out["inputUrl"] == "https://www.instagram.com/governador_b/", "cluster_label"
+    ].iloc[0] == -1
+
+
+def test_write_profile_clusters_engagement_falha_com_mensagem_clara_se_faltar_coluna(tmp_path):
+    df_incompleto = _perfis_clusterizados().drop(columns=["algo_name"])
+
+    with pytest.raises(ValueError, match="algo_name"):
+        ModelEnricher().write_profile_clusters_engagement(
+            df_incompleto, tmp_path / "governor_profile_clusters_engagement", run_id="r1"
+        )

--- a/tests/test_model_lambda.py
+++ b/tests/test_model_lambda.py
@@ -1,0 +1,61 @@
+import json
+
+import numpy as np
+import pandas as pd
+
+
+def _perfis_com_dois_grupos_separados():
+    rng = np.random.default_rng(0)
+    grupo_a = rng.normal(loc=0.0, scale=0.1, size=(4, 3))
+    grupo_b = rng.normal(loc=5.0, scale=0.1, size=(4, 3))
+    pontos = np.vstack([grupo_a, grupo_b])
+    df = pd.DataFrame(pontos, columns=["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"])
+    df["inputUrl"] = [f"https://www.instagram.com/g{i}/" for i in range(len(df))]
+    return df
+
+
+def test_model_handler(monkeypatch):
+    monkeypatch.setenv("S3_BUCKET", "dummy-bucket")
+
+    class DummyDT:
+        def __init__(self, table_uri, *a, **k):
+            self.table_uri = str(table_uri)
+
+        def to_pandas(self):
+            assert "governor_engagement" in self.table_uri
+            return _perfis_com_dois_grupos_separados()
+
+    monkeypatch.setattr("deltalake.DeltaTable", DummyDT)
+
+    # Stub gold writer para evitar escrita real no S3/Delta.
+    monkeypatch.setattr(
+        "src.features.gold.model_enricher.write_delta", lambda *a, **k: None
+    )
+
+    from lambdas.model import handler as model_handler
+
+    resp = model_handler.handler({"run_id": "test-run"}, {})
+    assert resp["statusCode"] == 200
+    body = json.loads(resp["body"])
+    assert body.get("run_id") == "test-run"
+    assert body.get("status") == "profile_clusters_engagement_complete"
+
+
+def test_model_handler_missing_bucket(monkeypatch):
+    monkeypatch.delenv("S3_BUCKET", raising=False)
+
+    from lambdas.model import handler as model_handler
+
+    resp = model_handler.handler({"run_id": "test-run"}, {})
+    assert resp["statusCode"] == 400
+    assert "body" in resp
+
+
+def test_model_handler_missing_run_id(monkeypatch):
+    monkeypatch.setenv("S3_BUCKET", "dummy-bucket")
+
+    from lambdas.model import handler as model_handler
+
+    resp = model_handler.handler({}, {})
+    assert resp["statusCode"] == 400
+    assert "body" in resp

--- a/tests/test_profile_clustering.py
+++ b/tests/test_profile_clustering.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pandas as pd
+
+from src.modeling.clustering import cluster_reels
+from src.modeling.config import ClusterConfig
+from src.modeling.profile_clustering import cluster_governor_profiles
+
+
+def _perfis_com_dois_grupos_separados():
+    rng = np.random.default_rng(0)
+    grupo_a = rng.normal(loc=0.0, scale=0.1, size=(4, 3))
+    grupo_b = rng.normal(loc=5.0, scale=0.1, size=(4, 3))
+    pontos = np.vstack([grupo_a, grupo_b])
+    df = pd.DataFrame(pontos, columns=["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"])
+    df["inputUrl"] = [f"https://www.instagram.com/g{i}/" for i in range(len(df))]
+    return df
+
+
+def test_cluster_governor_profiles_adiciona_colunas_esperadas():
+    df_profiles = _perfis_com_dois_grupos_separados()
+    config = ClusterConfig(
+        feature_columns=["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"],
+        max_evals_per_algo=15,
+        random_state=42,
+        max_n_clusters=4,
+    )
+
+    df_out, model, cluster_config, score, algo_name = cluster_governor_profiles(
+        df_profiles, config
+    )
+
+    expected = {"Clusters (AutoClusterHPO)", "model", "config", "score", "algo_name"}
+    assert expected <= set(df_out.columns)
+    assert len(df_out) == len(df_profiles)
+    assert "inputUrl" in df_out.columns  # preservada para o writer da Gold
+    assert algo_name is not None
+    assert score > -np.inf
+
+
+def test_cluster_governor_profiles_encontra_dois_grupos_bem_separados():
+    df_profiles = _perfis_com_dois_grupos_separados()
+    config = ClusterConfig(
+        feature_columns=["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"],
+        max_evals_per_algo=15,
+        random_state=42,
+        max_n_clusters=4,
+    )
+
+    df_out, *_ = cluster_governor_profiles(df_profiles, config)
+
+    labels = df_out["Clusters (AutoClusterHPO)"]
+    assert labels.nunique() >= 2
+
+
+def test_cluster_governor_profiles_e_cluster_reels_compartilham_a_mesma_logica():
+    """`cluster_reels` e `cluster_governor_profiles` são wrappers com nome
+    específico sobre `run_autocluster` -- não devem divergir em
+    comportamento para o mesmo DataFrame/config."""
+    df_profiles = _perfis_com_dois_grupos_separados()
+    config = ClusterConfig(
+        feature_columns=["% ENGAJAMENTO", "RECENCIA", "FREQUENCIA"],
+        max_evals_per_algo=15,
+        random_state=42,
+        max_n_clusters=4,
+    )
+
+    df_via_profiles, *_ = cluster_governor_profiles(df_profiles, config)
+    df_via_reels, *_ = cluster_reels(df_profiles, config)
+
+    pd.testing.assert_series_equal(
+        df_via_profiles["Clusters (AutoClusterHPO)"],
+        df_via_reels["Clusters (AutoClusterHPO)"],
+    )


### PR DESCRIPTION
## Resumo

Fase 2 do trabalho de modelagem: clustering de **perfil** de governador (27 linhas), distinto do clustering existente por **reel** (`governor_clusters`, 810 linhas). Desenhado numa sessão de grilling dedicada com foco no lado serverless. Escopo: só **Engajamento** (sentimento/tópico ficam para uma iteração futura com o mesmo padrão) e só **backend/pipeline** (integração no dashboard fica para uma Fase 3 separada).

### Local
- `src/modeling/profile_clustering.py::cluster_governor_profiles` -- reusa `AutoClusterHPO` via `run_autocluster` (extraído de `cluster_reels`, sem duplicar lógica).
- Features: `% ENGAJAMENTO`, `RECENCIA`, `FREQUENCIA` -- métricas comportamentais/relativas, não volume bruto (evita que o cluster só reproduza "estado grande vs. pequeno").
- Nova tabela Gold `governor_profile_clusters_engagement`, schema e path próprios (não generaliza com `governor_clusters` -- ver ADR 0004/0005).
- `scripts/run_profile_clustering_engagement.py`, mesmo padrão de `scripts/run_modeling.py`.
- **Validado com dados reais**: DBSCAN venceu, score CVI 0.552, distribuição 24/2/1 governadores nos 3 clusters.

### Serverless (código pronto, infra NÃO aplicada na AWS)
- 5ª Lambda `lambdas/model/` -- imagem só com `pandas`/`pyarrow`/`deltalake`/`scikit-learn`/`hyperopt`/`boto3`, sem `torch`/`transformers`/`bertopic` (não precisa de inferência de NLP nova).
- **Fora** da cadeia automática do orquestrador -- invocação manual (`aws lambda invoke`), mesmo princípio da ADR 0001 (modelagem é opt-in, não parte da ingestão obrigatória). Evita consumir o orçamento de 900s já sem folga do `orchestrator`.
- Terraform: novo ECR repo + IAM role + `aws_lambda_function.model`, `lambda_settings.model` (timeout 120s/1024MB).
- CD (`build-lambdas.yml`) e `scripts/build_and_push_lambdas.sh` atualizados para as 5 imagens.
- `infra/README.md` documenta como invocar `model` manualmente.

## Test plan

- [x] `ruff check src/` limpo
- [x] 85 testes (`pytest tests/`) passando -- incluindo os novos de `profile_clustering` e da Lambda `model` (mockados, sem chamada real à AWS)
- [x] `terraform validate` + `terraform fmt -check` limpos (sem `apply` -- infra intencionalmente não aplicada ainda)
- [x] Script local rodado contra dados reais de `governor_engagement`, resultado inspecionado manualmente
- [ ] Aplicar a infra na AWS (decisão consciente e futura do usuário -- ver sessão de design; requer orçar custo antes)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UjAmx8ZXJwhs9XpTUHigfD