### PR TITLE
Fase 3: integra clustering de perfil por engajamento no dashboard

### DIFF
--- a/pages/01_exploratory.py
+++ b/pages/01_exploratory.py
@@ -15,7 +15,9 @@ from src.dashboard.filters import (
     apply_group_filters,
     build_cluster_membership,
     build_governor_directory,
+    build_profile_cluster_directory,
     enrich_with_governor_metadata,
+    enrich_with_profile_cluster,
     render_group_filters,
     render_unmatched_warning,
 )
@@ -36,9 +38,11 @@ st.set_page_config(
 
 governor_directory = build_governor_directory()
 cluster_membership = build_cluster_membership()
-filters = render_group_filters(governor_directory, cluster_membership)
+profile_cluster_directory = build_profile_cluster_directory()
+filters = render_group_filters(governor_directory, cluster_membership, profile_cluster_directory)
 
 df_profiles_enriched = enrich_with_governor_metadata(load_profiles())
+df_profiles_enriched = enrich_with_profile_cluster(df_profiles_enriched)
 render_unmatched_warning(df_profiles_enriched)
 df_profiles = apply_group_filters(df_profiles_enriched, filters, cluster_membership)
 

--- a/pages/02_modeling.py
+++ b/pages/02_modeling.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import pandas as pd
 import streamlit as st
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -14,7 +15,9 @@ from src.dashboard.filters import (
     apply_group_filters,
     build_cluster_membership,
     build_governor_directory,
+    build_profile_cluster_directory,
     enrich_with_governor_metadata,
+    enrich_with_profile_cluster,
     render_governor_selector,
     render_group_filters,
     render_unmatched_warning,
@@ -39,15 +42,18 @@ st.sidebar.header("Filtros do Dashboard")
 
 governor_directory = build_governor_directory()
 cluster_membership = build_cluster_membership()
-filters = render_group_filters(governor_directory, cluster_membership)
+profile_cluster_directory = build_profile_cluster_directory()
+filters = render_group_filters(governor_directory, cluster_membership, profile_cluster_directory)
 
 # O universo de opções do seletor vem do próprio inputUrl de df_comments (não
 # do xlsx) -- governor_sentiment/reels_clean gravam a URL sem barra final,
 # governors_metadata (xlsx) grava com barra final; usar o valor do xlsx aqui
 # faria `select_governor_rows` abaixo nunca encontrar nada. nome/uf/regiao/
-# partido continuam vindo do xlsx, só que via join normalizado.
+# partido/cluster_perfil_engajamento continuam vindo do xlsx/Gold, só que via
+# join normalizado.
 governor_universe = df_comments[["inputUrl"]].dropna().drop_duplicates()
 governor_universe_enriched = enrich_with_governor_metadata(governor_universe)
+governor_universe_enriched = enrich_with_profile_cluster(governor_universe_enriched)
 render_unmatched_warning(governor_universe_enriched)
 governor_universe_filtrado = apply_group_filters(
     governor_universe_enriched, filters, cluster_membership
@@ -183,6 +189,28 @@ else:
                 .agg(qtd_reels=("id_reel", "nunique"), algoritmo=("cluster_algo", "first"))
                 .reset_index()
             )
+
+    st.markdown("#### Cluster de Perfil por Engajamento (Fase 2)")
+    if profile_cluster_directory.empty:
+        st.info(
+            "`governor_profile_clusters_engagement` ainda não existe. "
+            "Rode `scripts/run_profile_clustering_engagement.py` para gerá-la."
+        )
+    elif governador_selecionado == TODOS_GOVERNADORES:
+        st.dataframe(
+            governor_universe_filtrado.groupby("cluster_perfil_engajamento")
+            .agg(qtd_governadores=("inputUrl", "nunique"))
+            .reset_index()
+        )
+    else:
+        linha = governor_universe_filtrado.loc[
+            governor_universe_filtrado["inputUrl"] == governador_selecionado
+        ]
+        cluster_valor = linha["cluster_perfil_engajamento"].iloc[0] if not linha.empty else None
+        if cluster_valor is None or pd.isna(cluster_valor):
+            st.info("Este governador não tem cluster de perfil atribuído.")
+        else:
+            st.metric("Cluster de Perfil", int(cluster_valor))
 
 # Para mostrar os dados brutos (opcional)
 if st.checkbox("Mostrar dados brutos filtrados"):

--- a/src/dashboard/filters.py
+++ b/src/dashboard/filters.py
@@ -11,12 +11,14 @@ Decisões de design (sessão de grilling de 2026-08-29, ver handoff):
 - "Região" filtra pela macrorregião (Norte/Nordeste/Centro-Oeste/Sudeste/Sul),
   não pela UF -- há sempre exatamente 1 governador por UF, então um filtro por
   UF nunca agrupa nada, só reimplementa o seletor individual de forma mais lenta.
-- O filtro de cluster é por "contém" (pelo menos 1 reel no cluster
+- O filtro de cluster de REELS é por "contém" (pelo menos 1 reel no cluster
   selecionado), não por "cluster dominante" (moda) -- outliers do DBSCAN
   (cluster -1) podem ser reels virais/atípicos, e a moda esconderia esse sinal
   num governador que só tem 1-2 reels fora do padrão.
-- É um dado de clustering *por reel*, não por perfil -- rotulado como tal na
-  UI. Clustering por perfil é uma frente futura separada (Fase 2).
+- O filtro de cluster de PERFIL (Fase 2, `governor_profile_clusters_engagement`)
+  é 1:1 -- cada governador pertence a exatamente 1 cluster de perfil, então
+  aqui basta um `.isin()` direto na coluna, sem a indireção de "contém" que
+  o cluster de reels precisa (que é N:1, vários reels por governador).
 """
 
 from __future__ import annotations
@@ -24,7 +26,12 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 
-from src.dashboard.loaders import load_clusters, load_governors_metadata, load_reels
+from src.dashboard.loaders import (
+    load_clusters,
+    load_governors_metadata,
+    load_profile_clusters_engagement,
+    load_reels,
+)
 
 TODOS_GOVERNADORES = "__todos_governadores__"
 
@@ -129,6 +136,43 @@ def build_cluster_membership() -> pd.DataFrame:
     return merged[["inputUrl", "cluster_label"]].drop_duplicates()
 
 
+@st.cache_data
+def build_profile_cluster_directory() -> pd.DataFrame:
+    """1 linha por governador: inputUrl, cluster_perfil_engajamento (Fase 2).
+    Vazio (mas com essas colunas) se `governor_profile_clusters_engagement`
+    ainda não existir -- `scripts/run_profile_clustering_engagement.py` não
+    rodado é "sem dado ainda", não erro, mesmo padrão do resto do módulo."""
+    df = load_profile_clusters_engagement()
+    if df.empty:
+        return pd.DataFrame(columns=["inputUrl", "cluster_perfil_engajamento"])
+    return df[["inputUrl", "cluster_label"]].rename(
+        columns={"cluster_label": "cluster_perfil_engajamento"}
+    )
+
+
+def enrich_with_profile_cluster(df: pd.DataFrame, url_col: str = "inputUrl") -> pd.DataFrame:
+    """Adiciona `cluster_perfil_engajamento` a `df` via join por `url_col`
+    normalizado. Left join -- preserva todas as linhas de `df`; sem match ou
+    tabela ainda não gerada vira NaN, sem quebrar a página.
+
+    Função pura (sem I/O de UI), mesmo padrão de `enrich_with_governor_metadata`."""
+    directory = build_profile_cluster_directory()
+    df = df.copy()
+    if url_col not in df.columns or directory.empty:
+        if "cluster_perfil_engajamento" not in df.columns:
+            df["cluster_perfil_engajamento"] = pd.NA
+        return df
+
+    df = _with_match_key(df, url_col)
+    directory = _with_match_key(directory, "inputUrl")
+    merged = df.merge(
+        directory[["_match_key", "cluster_perfil_engajamento"]],
+        on="_match_key",
+        how="left",
+    ).drop(columns="_match_key")
+    return merged
+
+
 def enrich_with_governor_metadata(df: pd.DataFrame, url_col: str = "inputUrl") -> pd.DataFrame:
     """Adiciona nome/uf/regiao/partido a `df` via join por `url_col` (URL
     normalizada -- ver `_normalize_url`). Preserva todas as linhas de `df`
@@ -171,14 +215,22 @@ def render_unmatched_warning(df_enriched: pd.DataFrame, url_col: str = "inputUrl
         )
 
 
-def render_group_filters(governor_directory: pd.DataFrame, cluster_membership: pd.DataFrame) -> dict:
-    """Renderiza os filtros de grupo (região, partido, cluster) na sidebar.
-    Compartilhados entre páginas via `key=` -- a seleção persiste ao navegar."""
+def render_group_filters(
+    governor_directory: pd.DataFrame,
+    cluster_membership: pd.DataFrame,
+    profile_cluster_directory: pd.DataFrame,
+) -> dict:
+    """Renderiza os filtros de grupo (região, partido, cluster de reels,
+    cluster de perfil) na sidebar. Compartilhados entre páginas via `key=` --
+    a seleção persiste ao navegar."""
     st.sidebar.header("Filtros de Grupo")
 
     regiao_options = sorted(governor_directory["regiao"].dropna().unique().tolist())
     partido_options = sorted(governor_directory["partido"].dropna().unique().tolist())
     cluster_options = sorted(cluster_membership["cluster_label"].dropna().unique().tolist())
+    profile_cluster_options = sorted(
+        profile_cluster_directory["cluster_perfil_engajamento"].dropna().unique().tolist()
+    )
 
     selected_regiao = st.sidebar.multiselect(
         "Região:", options=regiao_options, key="filter_regiao"
@@ -186,8 +238,20 @@ def render_group_filters(governor_directory: pd.DataFrame, cluster_membership: p
     selected_partido = st.sidebar.multiselect(
         "Partido:", options=partido_options, key="filter_partido"
     )
+    selected_cluster_perfil = st.sidebar.multiselect(
+        "Cluster de Perfil por Engajamento (Fase 2):",
+        options=profile_cluster_options,
+        key="filter_cluster_perfil",
+        help=(
+            "Agrupa governadores por padrão de comportamento -- % engajamento, "
+            "recência e frequência de postagem -- não por conteúdo de reel "
+            "específico. Cada governador pertence a exatamente 1 cluster aqui "
+            "(diferente do filtro de Cluster de Reels abaixo, que é 'contém "
+            "pelo menos 1 reel')."
+        ),
+    )
     selected_cluster = st.sidebar.multiselect(
-        "Cluster de Reels (dado atual, por reel):",
+        "Cluster de Reels (por reel):",
         options=cluster_options,
         key="filter_cluster",
         help=(
@@ -198,13 +262,18 @@ def render_group_filters(governor_directory: pd.DataFrame, cluster_membership: p
         ),
     )
 
-    if not regiao_options and not partido_options and not cluster_options:
+    if not regiao_options and not partido_options and not cluster_options and not profile_cluster_options:
         st.sidebar.caption(
             "Sem dados de região/partido/cluster ainda -- rode a pipeline "
             "(`uv run python pipeline.py`) para popular os filtros de grupo."
         )
 
-    return {"regiao": selected_regiao, "partido": selected_partido, "cluster": selected_cluster}
+    return {
+        "regiao": selected_regiao,
+        "partido": selected_partido,
+        "cluster": selected_cluster,
+        "cluster_perfil": selected_cluster_perfil,
+    }
 
 
 def apply_group_filters(
@@ -227,6 +296,8 @@ def apply_group_filters(
         df = df[df["regiao"].isin(filters["regiao"])]
     if filters["partido"]:
         df = df[df["partido"].isin(filters["partido"])]
+    if filters["cluster_perfil"]:
+        df = df[df["cluster_perfil_engajamento"].isin(filters["cluster_perfil"])]
     if filters["cluster"]:
         cm = _with_match_key(cluster_membership, "inputUrl")
         keys_in_clusters = set(

--- a/src/dashboard/loaders.py
+++ b/src/dashboard/loaders.py
@@ -53,3 +53,11 @@ def load_governors_metadata() -> pd.DataFrame:
         return get_delta_repository().load_governors_metadata()
     except FileNotFoundError:
         return pd.DataFrame()
+
+
+@st.cache_data
+def load_profile_clusters_engagement() -> pd.DataFrame:
+    try:
+        return get_delta_repository().load_profile_clusters_engagement()
+    except FileNotFoundError:
+        return pd.DataFrame()

--- a/src/repositories/delta_repository.py
+++ b/src/repositories/delta_repository.py
@@ -59,6 +59,9 @@ class DeltaRepository(DataRepository):
     def load_clusters(self) -> pd.DataFrame:
         return self._load(_join(self._gold_dir, "governor_clusters"))
 
+    def load_profile_clusters_engagement(self) -> pd.DataFrame:
+        return self._load(_join(self._gold_dir, "governor_profile_clusters_engagement"))
+
     def load_governors_metadata(self) -> pd.DataFrame:
         if self._silver_dir is None:
             raise ValueError("silver_dir não foi configurado neste repositório.")


### PR DESCRIPTION
## Resumo

Fecha o ciclo aberto na Fase 1: o filtro "Cluster de Reels" foi rotulado como provisório, esperando o clustering de perfil da Fase 2. Este PR consome a tabela `governor_profile_clusters_engagement` (gerada na Fase 2, já mergeada) e a integra no dashboard.

- Novo filtro de grupo "Cluster de Perfil por Engajamento" (compartilhado exploratory/modeling, como os demais) -- 1:1 por governador (`.isin()` direto), diferente do cluster de reels (N:1, semântica "contém").
- `build_profile_cluster_directory`/`enrich_with_profile_cluster` em `filters.py`, mesma degradação graciosa dos demais filtros (tabela ainda não gerada = filtro vazio, não erro).
- Nova seção em `modeling.py` mostrando o cluster de perfil do governador selecionado, ou o agregado de todos quando "Todos os Governadores" está ativo.
- `load_profile_clusters_engagement()` + `DeltaRepository.load_profile_clusters_engagement()`.

## Test plan

- [x] `ruff check src/` limpo
- [x] 87 testes passando
- [x] `streamlit.testing.v1.AppTest` com dados reais: filtro filtra corretamente (719k → 553k seguidores médios ao selecionar cluster -1), agregado "Todos" mostra a distribuição real (24/2/1), valor individual aparece como métrica

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UjAmx8ZXJwhs9XpTUHigfD