### PR TITLE
feat: script dedicado de backfill Apify (escreve na Bronze de producao)

### DIFF
--- a/scripts/apify_backfill_shared.py
+++ b/scripts/apify_backfill_shared.py
@@ -1,0 +1,78 @@
+"""
+Helpers compartilhados entre `scripts/run_apify_calibration_test.py` e
+`scripts/run_apify_backfill.py` -- estimativa de custo, limite de resultados
+escalavel e carregamento dos links dos governadores. Nao e um script
+executavel, so um modulo de import.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import pandas as pd
+
+from config import settings
+
+DEFAULT_DAYS = 90
+
+# Baseline calculado na sessao de 2026-08-29 a partir da amostra atual (30
+# itens mais recentes por governador) -- ver handoff. E o que o teste de
+# calibracao confirma ou corrige, independente da janela (--days) escolhida.
+BASELINE_REELS_PER_DAY = 1.65
+BASELINE_POSTS_PER_DAY = 2.60
+
+# resultsLimit e aplicado POR PERFIL pela Apify, nao no total do run -- se o
+# default fosse fixo (ex: 1000), uma janela grande (--days 365+) trunca
+# silenciosamente qualquer governador acima da media, subestimando a
+# calibracao/backfill sem avisar. Escala com --days usando uma margem de
+# seguranca bem acima do baseline conhecido (4.25 itens/dia/governador).
+RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY = 10
+RESULTS_LIMIT_FLOOR = 200
+
+# Plano Starter da Apify usado nas estimativas de custo do backfill.
+STARTER_PRICE_PER_1000_RESULTS = 2.30
+
+
+def default_results_limit(days: int) -> int:
+    return max(RESULTS_LIMIT_FLOOR, days * RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY)
+
+
+def profiles_hitting_limit(items: list[dict], results_limit: int) -> list[str]:
+    """Perfis cujo total de itens retornados bateu exatamente no resultsLimit
+    -- sinal de que o numero real e maior e o resultado foi truncado."""
+    counts: dict[str, int] = {}
+    for item in items:
+        key = item.get("inputUrl") or item.get("ownerUsername") or "desconhecido"
+        counts[key] = counts.get(key, 0) + 1
+    return sorted(key for key, count in counts.items() if count >= results_limit)
+
+
+def load_links() -> list[str]:
+    df_gov = pd.read_excel(settings.GOVERNADORES_FILE)
+    df_gov.columns = df_gov.columns.str.strip()
+    return list(df_gov[settings.LINK_COLUMN].str.strip().unique())
+
+
+def estimate_cost_usd(days: int, n_governors: int) -> float:
+    """Estimativa PRE-run baseada no baseline conhecido -- o resultado real so
+    sai depois de chamar a Apify. Usada so pro aviso de confirmacao do --yes."""
+    estimated_results = (BASELINE_REELS_PER_DAY + BASELINE_POSTS_PER_DAY) * days * n_governors
+    return round(estimated_results / 1000 * STARTER_PRICE_PER_1000_RESULTS, 2)
+
+
+def project_backfill_costs(total_results: int, days: int) -> dict[int, float]:
+    """Extrapola o total de resultados calibrado (na janela rodada) para
+    janelas de 1-4 anos e converte em custo estimado no plano Starter."""
+    daily_rate = total_results / days
+    projections = {}
+    for years in (1, 2, 3, 4):
+        year_days = 365 * years
+        total_results_year = daily_rate * year_days
+        cost = total_results_year / 1000 * STARTER_PRICE_PER_1000_RESULTS
+        projections[years] = round(cost, 2)
+    return projections

--- a/scripts/run_apify_backfill.py
+++ b/scripts/run_apify_backfill.py
@@ -1,0 +1,187 @@
+"""
+Backfill historico Apify: roda os scrapers de perfis/posts/reels com
+`onlyPostsNewerThan` para os 27 governadores e escreve DIRETO NA BRONZE DE
+PRODUCAO via `BronzeWriter` -- diferente de
+`scripts/run_apify_calibration_test.py`, que e isolado em
+`data/calibration/` e nunca toca a Bronze real.
+
+So roda depois que a janela do backfill (1-4 anos) ja foi decidida com base
+no teste de calibracao. --days e obrigatorio (sem default) para forcar uma
+escolha explicita a cada execucao -- nao existe "janela segura" default pra
+uma operacao que grava em producao.
+
+So faz a extracao (profiles + posts + reels sob o mesmo run_id, igual ao
+branch de extracao do `pipeline.py`) -- NAO roda Silver/Gold. Depois de
+rodar este script, execute `uv run python pipeline.py` normalmente: ele
+detecta a Bronze ja preenchida (`_bronze_has_data`) e cascateia Silver/Gold
+a partir dela, sem reextrair.
+
+NAO roda no import -- so via `uv run python scripts/run_apify_backfill.py
+--days N --yes`, disparado manualmente. Gera custo real na conta Apify.
+"""
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from apify_client import ApifyClient
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from config import settings
+from scripts.apify_backfill_shared import (
+    BASELINE_POSTS_PER_DAY,
+    BASELINE_REELS_PER_DAY,
+    RESULTS_LIMIT_FLOOR,
+    RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY,
+    default_results_limit,
+    estimate_cost_usd,
+    load_links,
+    profiles_hitting_limit,
+    project_backfill_costs,
+)
+from src.data_extract.bronze_writer import BronzeWriter
+from src.data_extract.scraper import InstagramScraper, ScraperConfig
+
+BACKFILL_REPORT_DIR = settings.DATA_DIR / "backfill"
+
+
+def run(apify_api_token: str, days: int, results_limit: int, run_id: str | None = None) -> dict:
+    run_id = run_id or str(uuid.uuid4())
+    links = load_links()
+    n_governors = len(links)
+    only_newer_than = f"{days} days"
+    print(f"[1/3] Rodando scrapers para {n_governors} governadores "
+          f"(onlyPostsNewerThan: '{only_newer_than}', resultsLimit: {results_limit}, "
+          f"run_id: {run_id})...")
+
+    scraper = InstagramScraper(
+        client=ApifyClient(apify_api_token),
+        config=ScraperConfig(results_limit=results_limit),
+    )
+    extra_run_input = {"onlyPostsNewerThan": only_newer_than}
+
+    profiles = scraper.scrape_profiles(links)
+    posts = scraper.scrape_posts(links, extra_run_input=extra_run_input)
+    reels = scraper.scrape_reels(links, extra_run_input=extra_run_input)
+
+    print(
+        f"[2/3] Resultado bruto: {len(profiles)} profiles, {len(posts)} posts, "
+        f"{len(reels)} reels. Escrevendo na Bronze de producao..."
+    )
+    truncated = {
+        "posts": profiles_hitting_limit(posts, results_limit),
+        "reels": profiles_hitting_limit(reels, results_limit),
+    }
+    if truncated["posts"] or truncated["reels"]:
+        print(
+            "[AVISO] resultsLimit provavelmente truncou o resultado real para "
+            f"estes perfis (bateram exatamente no teto de {results_limit}): "
+            f"posts={truncated['posts']} reels={truncated['reels']}. "
+            "Rode de novo com --results-limit maior para esses casos."
+        )
+
+    bronze = BronzeWriter(
+        bronze_profiles_path=settings.BRONZE_PROFILES,
+        bronze_posts_path=settings.BRONZE_POSTS,
+        bronze_reels_path=settings.BRONZE_REELS,
+    )
+    bronze.write_profiles(profiles, run_id=run_id)
+    bronze.write_posts(posts, run_id=run_id)
+    bronze.write_reels(reels, run_id=run_id)
+
+    actual_reels_per_day = len(reels) / days / n_governors
+    actual_posts_per_day = len(posts) / days / n_governors
+
+    print("[3/3] Gerando relatorio do backfill...")
+    report = {
+        "run_id": run_id,
+        "n_governors": n_governors,
+        "window_days": days,
+        "results_limit": results_limit,
+        "raw_counts": {"profiles": len(profiles), "posts": len(posts), "reels": len(reels)},
+        "rate_per_governor_per_day": {
+            "reels": {"baseline": BASELINE_REELS_PER_DAY, "calibrated": round(actual_reels_per_day, 3)},
+            "posts": {"baseline": BASELINE_POSTS_PER_DAY, "calibrated": round(actual_posts_per_day, 3)},
+        },
+        "backfill_cost_projection_usd_starter_plan": project_backfill_costs(
+            len(posts) + len(reels), days
+        ),
+        "truncated_profiles": truncated,
+    }
+
+    BACKFILL_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    report_path = BACKFILL_REPORT_DIR / f"backfill_report_{days}d_{stamp}.json"
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    print(f"[OK] Relatorio salvo em {report_path}")
+    print(
+        "[PROXIMO PASSO] Rode 'uv run python pipeline.py' para cascatear "
+        "Silver/Gold a partir da Bronze recem-preenchida (ele detecta os "
+        "dados novos e nao reextrai)."
+    )
+    return report
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill historico Apify -- escreve na Bronze DE PRODUCAO. "
+            "ATENCAO: gera custo real na conta Apify -- veja a estimativa "
+            "antes de confirmar com --yes."
+        )
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        required=True,
+        help="Janela em dias para onlyPostsNewerThan. Obrigatorio -- sem default seguro para producao.",
+    )
+    parser.add_argument(
+        "--results-limit",
+        type=int,
+        default=None,
+        help=(
+            "resultsLimit por run, por perfil (default: escala com --days, "
+            f"max({RESULTS_LIMIT_FLOOR}, days * {RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY}))."
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="run_id a usar para esta extracao (default: gerado automaticamente).",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirma que voce quer disparar o backfill (custo real na Apify, escreve em producao). Obrigatorio.",
+    )
+    args = parser.parse_args()
+    results_limit = args.results_limit or default_results_limit(args.days)
+
+    if not args.yes:
+        n_governors = len(load_links())
+        estimated_cost = estimate_cost_usd(args.days, n_governors)
+        print(
+            f"[ABORTADO] Este script escreve na BRONZE DE PRODUCAO e gera custo "
+            f"real na conta Apify (~${estimated_cost} estimado para {args.days} "
+            f"dias, {n_governors} governadores, baseado no baseline conhecido -- "
+            "o custo real pode variar). Rode de novo com --yes para confirmar."
+        )
+        raise SystemExit(1)
+
+    token = os.getenv("APIFY_API_TOKEN")
+    if not token:
+        raise SystemExit("[ERRO] APIFY_API_TOKEN nao encontrado no ambiente/.env.")
+
+    run(apify_api_token=token, days=args.days, results_limit=results_limit, run_id=args.run_id)
+    print("[OK] Backfill concluido.")

--- a/scripts/run_apify_calibration_test.py
+++ b/scripts/run_apify_calibration_test.py
@@ -6,12 +6,10 @@ mais recentes por governador, que cobre so ~2-3 semanas e pode estar
 refletindo um pico de atividade nao representativo).
 
 Janela (--days) e limite por perfil (--results-limit) sao parametrizaveis
-via CLI -- o default (90 dias) e o teste de calibracao barato, mas o mesmo
-script serve pra rodar o backfill real depois que a janela for decidida
-(ex: `--days 365`), sem precisar editar codigo. resultsLimit e aplicado
-POR PERFIL pela Apify (nao no total do run), entao o default de
---results-limit escala com --days para nao truncar governadores acima da
-media silenciosamente -- ver `_default_results_limit`.
+via CLI -- o default (90 dias) e o teste de calibracao barato. Constantes e
+formulas de custo/limite ficam em `scripts/apify_backfill_shared.py`, compartilhadas
+com `scripts/run_apify_backfill.py` (o script que roda o backfill de
+verdade, escrevendo na Bronze de producao -- ver esse arquivo).
 
 NAO roda no import nem em nenhum outro script -- so via `python -m
 scripts.run_apify_calibration_test` ou `uv run python
@@ -37,76 +35,26 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import pandas as pd
-
 from config import settings
+from scripts.apify_backfill_shared import (
+    BASELINE_POSTS_PER_DAY,
+    BASELINE_REELS_PER_DAY,
+    DEFAULT_DAYS,
+    RESULTS_LIMIT_FLOOR,
+    RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY,
+    default_results_limit,
+    estimate_cost_usd,
+    load_links,
+    profiles_hitting_limit,
+    project_backfill_costs,
+)
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
-
-DEFAULT_DAYS = 90
-
-# Baseline calculado na sessao de 2026-08-29 a partir da amostra atual (30
-# itens mais recentes por governador) -- ver handoff. E o que este teste
-# calibra/confirma ou corrige, independente da janela (--days) escolhida.
-BASELINE_REELS_PER_DAY = 1.65
-BASELINE_POSTS_PER_DAY = 2.60
-
-# resultsLimit e aplicado POR PERFIL pela Apify, nao no total do run -- se o
-# default fosse fixo (ex: 1000), uma janela grande (--days 365+) trunca
-# silenciosamente qualquer governador acima da media, subestimando a
-# calibracao sem avisar. Escala com --days usando uma margem de seguranca
-# bem acima do baseline conhecido (4.25 itens/dia/governador).
-RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY = 10
-RESULTS_LIMIT_FLOOR = 200
-
-
-def _default_results_limit(days: int) -> int:
-    return max(RESULTS_LIMIT_FLOOR, days * RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY)
-
-
-def _profiles_hitting_limit(items: list[dict], results_limit: int) -> list[str]:
-    """Perfis cujo total de itens retornados bateu exatamente no resultsLimit
-    -- sinal de que o numero real e maior e o resultado foi truncado."""
-    counts: dict[str, int] = {}
-    for item in items:
-        key = item.get("inputUrl") or item.get("ownerUsername") or "desconhecido"
-        counts[key] = counts.get(key, 0) + 1
-    return sorted(key for key, count in counts.items() if count >= results_limit)
-
-
-# Plano Starter da Apify usado nas estimativas de custo do backfill.
-STARTER_PRICE_PER_1000_RESULTS = 2.30
 
 CALIBRATION_DIR = settings.DATA_DIR / "calibration"
 
 
-def _load_links() -> list[str]:
-    df_gov = pd.read_excel(settings.GOVERNADORES_FILE)
-    df_gov.columns = df_gov.columns.str.strip()
-    return list(df_gov[settings.LINK_COLUMN].str.strip().unique())
-
-
-def _estimate_cost_usd(days: int, n_governors: int) -> float:
-    """Estimativa PRE-run baseada no baseline conhecido -- o resultado real so
-    sai depois de chamar a Apify. Usada so pro aviso de confirmacao do --yes."""
-    estimated_results = (BASELINE_REELS_PER_DAY + BASELINE_POSTS_PER_DAY) * days * n_governors
-    return round(estimated_results / 1000 * STARTER_PRICE_PER_1000_RESULTS, 2)
-
-
-def _project_backfill_costs(total_results: int, days: int) -> dict[int, float]:
-    """Extrapola o total de resultados calibrado (na janela rodada) para
-    janelas de 1-4 anos e converte em custo estimado no plano Starter."""
-    daily_rate = total_results / days
-    projections = {}
-    for years in (1, 2, 3, 4):
-        year_days = 365 * years
-        total_results_year = daily_rate * year_days
-        cost = total_results_year / 1000 * STARTER_PRICE_PER_1000_RESULTS
-        projections[years] = round(cost, 2)
-    return projections
-
-
 def run(apify_api_token: str, days: int, results_limit: int) -> dict:
-    links = _load_links()
+    links = load_links()
     n_governors = len(links)
     only_newer_than = f"{days} days"
     print(f"[1/3] Rodando scrapers para {n_governors} governadores "
@@ -123,8 +71,8 @@ def run(apify_api_token: str, days: int, results_limit: int) -> dict:
 
     print(f"[2/3] Resultado bruto: {len(posts)} posts, {len(reels)} reels.")
     truncated = {
-        "posts": _profiles_hitting_limit(posts, results_limit),
-        "reels": _profiles_hitting_limit(reels, results_limit),
+        "posts": profiles_hitting_limit(posts, results_limit),
+        "reels": profiles_hitting_limit(reels, results_limit),
     }
     if truncated["posts"] or truncated["reels"]:
         print(
@@ -154,7 +102,7 @@ def run(apify_api_token: str, days: int, results_limit: int) -> dict:
             "reels": {"baseline": BASELINE_REELS_PER_DAY, "calibrated": round(actual_reels_per_day, 3)},
             "posts": {"baseline": BASELINE_POSTS_PER_DAY, "calibrated": round(actual_posts_per_day, 3)},
         },
-        "backfill_cost_projection_usd_starter_plan": _project_backfill_costs(
+        "backfill_cost_projection_usd_starter_plan": project_backfill_costs(
             len(posts) + len(reels), days
         ),
         "truncated_profiles": truncated,
@@ -172,7 +120,7 @@ def run(apify_api_token: str, days: int, results_limit: int) -> dict:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
-            "Teste de calibracao/backfill Apify. ATENCAO: gera custo real "
+            "Teste de calibracao Apify. ATENCAO: gera custo real "
             "na conta Apify -- veja a estimativa antes de confirmar com --yes."
         )
     )
@@ -197,11 +145,11 @@ if __name__ == "__main__":
         help="Confirma que voce quer disparar o teste (custo real na Apify). Obrigatorio.",
     )
     args = parser.parse_args()
-    results_limit = args.results_limit or _default_results_limit(args.days)
+    results_limit = args.results_limit or default_results_limit(args.days)
 
     if not args.yes:
-        n_governors = len(_load_links())
-        estimated_cost = _estimate_cost_usd(args.days, n_governors)
+        n_governors = len(load_links())
+        estimated_cost = estimate_cost_usd(args.days, n_governors)
         print(
             f"[ABORTADO] Este script gera custo real na conta Apify (~${estimated_cost} "
             f"estimado para {args.days} dias, {n_governors} governadores, baseado no "

--- a/tests/test_apify_backfill_shared.py
+++ b/tests/test_apify_backfill_shared.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+from config import settings
+from scripts.apify_backfill_shared import (
+    RESULTS_LIMIT_FLOOR,
+    RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY,
+    default_results_limit,
+    estimate_cost_usd,
+    load_links,
+    profiles_hitting_limit,
+    project_backfill_costs,
+)
+
+
+def test_default_results_limit_usa_o_piso_para_janelas_curtas():
+    assert default_results_limit(1) == RESULTS_LIMIT_FLOOR
+
+
+def test_default_results_limit_escala_com_days():
+    dias = 365
+    assert default_results_limit(dias) == dias * RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY
+
+
+def test_profiles_hitting_limit_identifica_perfis_truncados():
+    items = [
+        {"inputUrl": "https://instagram.com/a"},
+        {"inputUrl": "https://instagram.com/a"},
+        {"inputUrl": "https://instagram.com/b"},
+    ]
+    assert profiles_hitting_limit(items, results_limit=2) == ["https://instagram.com/a"]
+
+
+def test_profiles_hitting_limit_sem_truncagem():
+    items = [{"inputUrl": "https://instagram.com/a"}]
+    assert profiles_hitting_limit(items, results_limit=10) == []
+
+
+def test_estimate_cost_usd_e_positivo_e_cresce_com_days():
+    custo_curto = estimate_cost_usd(days=30, n_governors=27)
+    custo_longo = estimate_cost_usd(days=90, n_governors=27)
+    assert custo_curto > 0
+    assert custo_longo > custo_curto
+
+
+def test_project_backfill_costs_retorna_as_quatro_janelas():
+    projections = project_backfill_costs(total_results=1000, days=90)
+    assert set(projections.keys()) == {1, 2, 3, 4}
+    assert projections[1] < projections[4]
+
+
+def test_load_links_le_e_normaliza_planilha(monkeypatch):
+    df_fake = pd.DataFrame(
+        {f" {settings.LINK_COLUMN} ": [" https://instagram.com/a ", " https://instagram.com/a "]}
+    )
+    monkeypatch.setattr("scripts.apify_backfill_shared.pd.read_excel", lambda *a, **k: df_fake)
+
+    links = load_links()
+
+    assert links == ["https://instagram.com/a"]

--- a/tests/test_run_apify_backfill_script.py
+++ b/tests/test_run_apify_backfill_script.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock
+
+
+class _FakeInstagramScraper:
+    def __init__(self, client, config):
+        self.client = client
+        self.config = config
+        self.posts_extra_run_input = None
+        self.reels_extra_run_input = None
+
+    def scrape_profiles(self, links):
+        return [{"inputUrl": "https://instagram.com/gov1", "username": "gov1"}]
+
+    def scrape_posts(self, links, extra_run_input=None):
+        self.posts_extra_run_input = extra_run_input
+        return [{"inputUrl": "https://instagram.com/gov1", "id": "p1"}]
+
+    def scrape_reels(self, links, extra_run_input=None):
+        self.reels_extra_run_input = extra_run_input
+        return [{"inputUrl": "https://instagram.com/gov1", "id": "r1"}]
+
+
+def _fake_bronze_writer_class(calls):
+    class FakeBronzeWriter:
+        def __init__(self, **kwargs):
+            pass
+
+        def write_profiles(self, raw_data, run_id=None):
+            calls.append(("profiles", raw_data, run_id))
+            return run_id
+
+        def write_posts(self, raw_data, run_id=None):
+            calls.append(("posts", raw_data, run_id))
+            return run_id
+
+        def write_reels(self, raw_data, run_id=None):
+            calls.append(("reels", raw_data, run_id))
+            return run_id
+
+    return FakeBronzeWriter
+
+
+def _patch_backfill_dependencies(monkeypatch, tmp_path, scraper_class=_FakeInstagramScraper):
+    calls = []
+    monkeypatch.setattr("scripts.run_apify_backfill.BronzeWriter", _fake_bronze_writer_class(calls))
+    monkeypatch.setattr("scripts.run_apify_backfill.InstagramScraper", scraper_class)
+    monkeypatch.setattr("scripts.run_apify_backfill.ApifyClient", lambda token: MagicMock())
+    monkeypatch.setattr(
+        "scripts.run_apify_backfill.load_links", lambda: ["https://instagram.com/gov1"]
+    )
+    monkeypatch.setattr("scripts.run_apify_backfill.BACKFILL_REPORT_DIR", tmp_path)
+    return calls
+
+
+def test_run_escreve_profiles_posts_reels_na_bronze_sob_o_mesmo_run_id(monkeypatch, tmp_path):
+    import scripts.run_apify_backfill as backfill_script
+
+    calls = _patch_backfill_dependencies(monkeypatch, tmp_path)
+
+    report = backfill_script.run(
+        apify_api_token="token", days=365, results_limit=5000, run_id="run_fixo"
+    )
+
+    assert report["run_id"] == "run_fixo"
+    assert len(calls) == 3
+    assert {kind for kind, _, _ in calls} == {"profiles", "posts", "reels"}
+    assert all(run_id == "run_fixo" for _, _, run_id in calls)
+
+
+def test_run_gera_run_id_quando_nao_informado(monkeypatch, tmp_path):
+    import scripts.run_apify_backfill as backfill_script
+
+    calls = _patch_backfill_dependencies(monkeypatch, tmp_path)
+
+    report = backfill_script.run(apify_api_token="token", days=90, results_limit=1000)
+
+    assert report["run_id"]
+    assert all(run_id == report["run_id"] for _, _, run_id in calls)
+
+
+def test_run_nao_grava_json_bruto_de_itens_so_o_relatorio(monkeypatch, tmp_path):
+    import scripts.run_apify_backfill as backfill_script
+
+    _patch_backfill_dependencies(monkeypatch, tmp_path)
+
+    backfill_script.run(apify_api_token="token", days=90, results_limit=1000)
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("backfill_report_")
+
+
+def test_run_propaga_only_posts_newer_than_para_posts_e_reels_nao_para_profiles(
+    monkeypatch, tmp_path
+):
+    import scripts.run_apify_backfill as backfill_script
+
+    scraper_instances = []
+
+    class _CapturingScraper(_FakeInstagramScraper):
+        def __init__(self, client, config):
+            super().__init__(client, config)
+            scraper_instances.append(self)
+
+    _patch_backfill_dependencies(monkeypatch, tmp_path, scraper_class=_CapturingScraper)
+
+    backfill_script.run(apify_api_token="token", days=180, results_limit=2000)
+
+    scraper = scraper_instances[0]
+    assert scraper.posts_extra_run_input == {"onlyPostsNewerThan": "180 days"}
+    assert scraper.reels_extra_run_input == {"onlyPostsNewerThan": "180 days"}


### PR DESCRIPTION
## Summary
Continuacao do PR #27 (ja mergeado) -- este PR foi pushado depois do merge, entao ficou de fora. Implementa o design fechado numa sessao de `/grilling` (2026-08-30) sobre como propagar o backfill historico Apify para producao:

- `scripts/apify_backfill_shared.py`: extrai as constantes/formulas compartilhadas (custo estimado, limite de `resultsLimit` escalavel, checagem de truncagem, carregamento de links) do script de calibracao para um modulo comum.
- `scripts/run_apify_backfill.py`: script novo e separado do de calibracao -- escreve `profiles`+`posts`+`reels` na **Bronze de producao** via `BronzeWriter` (mesma construcao que `pipeline.py` usa), sob um `run_id` compartilhado. Nao roda Silver/Gold -- `pipeline.py` ja cascateia isso sozinho numa execucao normal depois (`_bronze_has_data`). `--days` e obrigatorio (sem default seguro pra producao). Guarda `--yes` com aviso explicito de escrita em producao.
- `scripts/run_apify_calibration_test.py`: sem mudanca de comportamento, so passa a importar do modulo compartilhado.
- Separacao por arquivo (nao uma flag no script de calibracao) e deliberada -- evita rodar em producao por engano.

O modulo compartilhado se chama `apify_backfill_shared` (nao `apify_shared`) para nao colidir com o pacote `apify_shared` do PyPI (dependencia do `apify_client`) -- descoberto porque `run_apify_calibration_test.py` bate no padrao `*_test.py` do pytest, que insere `scripts/` no `sys.path` ao coletar o arquivo.

Propagacao para a lambda AWS fica de fora (infra ainda nao aplicada) -- registrada como decisao futura em memoria de projeto, nao neste PR.

## Test plan
- [x] `ruff check` limpo nos arquivos tocados
- [x] `pytest` completo: 95 passed, 3 skipped (84 anteriores + 11 novos)
- [x] Dry-run sem `--yes` de `run_apify_backfill.py --days 365`: aborta mostrando estimativa (~$96) e aviso explicito de escrita em producao, sem chamar a Apify
- [x] `--days` obrigatorio confirmado (argparse erro se omitido)
- [x] Dry-run de `run_apify_calibration_test.py --days 90` (regressao pos-refactor): continua identico
- [ ] Rodar o backfill de verdade (`--yes`) fica para quando a janela for decidida pelo usuario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5WdTCuZXAb8ktSL5uZHmr