### PR TITLE
feat: consolida extracao Apify num ponto unico + landing zone de JSON bruto

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -35,6 +35,11 @@ TEXT_COLUMN = os.environ.get("TEXT_COLUMN", "text")
 DATE_COLUMN = os.environ.get("DATE_COLUMN", "timestamp")
 LINK_COLUMN = os.environ.get("LINK_COLUMN", "Link")
 
+# Landing zone: JSON bruto por entidade/run_id, sem schema, anterior a
+# Bronze -- arquiva fidelidade total contra a Bronze descartar campos fora
+# do seu schema fixo (ver ADR 0011, decisao 1).
+LANDING_DIR = DATA_DIR / "landing"
+
 # ── Caminhos Medallion (Bronze / Silver / Gold)
 BRONZE_DIR = DATA_DIR / "bronze"
 BRONZE_PROFILES = BRONZE_DIR / "instagram_profiles"

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,9 +35,9 @@ TEXT_COLUMN = os.environ.get("TEXT_COLUMN", "text")
 DATE_COLUMN = os.environ.get("DATE_COLUMN", "timestamp")
 LINK_COLUMN = os.environ.get("LINK_COLUMN", "Link")
 
-# Landing zone: JSON bruto por entidade/run_id, sem schema, anterior a
-# Bronze -- arquiva fidelidade total contra a Bronze descartar campos fora
-# do seu schema fixo (ver ADR 0011, decisao 1).
+# Landing zone: JSON bruto por entidade/run_id, sem schema, anterior à
+# Bronze — arquiva fidelidade total contra a Bronze descartar campos fora
+# do seu schema fixo (ver ADR 0011, decisão 1).
 LANDING_DIR = DATA_DIR / "landing"
 
 # ── Caminhos Medallion (Bronze / Silver / Gold)

--- a/lambdas/extract/handler.py
+++ b/lambdas/extract/handler.py
@@ -5,12 +5,19 @@ import uuid
 from apify_client import ApifyClient
 
 from src.data_extract.bronze_writer import BronzeWriter
+from src.data_extract.ingestion import extract_and_land
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
 
 STORAGE_OPTIONS = {
     "AWS_REGION": os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
     "AWS_S3_ALLOW_UNSAFE_RENAME": "true",
 }
+
+# Landing zone ainda local/efemera (o /tmp gravavel da Lambda) -- suporte a
+# S3 para a landing zone e explicitamente fora de escopo ate a infra AWS ser
+# de fato aplicada (ver ADR 0011 e docs/agents -- LANDING_DIR pode apontar
+# para s3://.../landing/ no futuro sem mudar `extract_and_land`).
+LANDING_DIR = os.environ.get("LANDING_DIR", "/tmp/landing")
 
 
 def handler(event, context):
@@ -31,10 +38,6 @@ def handler(event, context):
         config=ScraperConfig(results_limit=int(os.environ.get("RESULTS_LIMIT", 30))),
     )
 
-    profiles = scraper.scrape_profiles(links)
-    posts = scraper.scrape_posts(links)
-    reels = scraper.scrape_reels(links)
-
     bronze_prefix = os.environ.get("S3_BRONZE_PREFIX", "bronze/")
     bronze = BronzeWriter(
         bronze_profiles_path=f"s3://{bucket}/{bronze_prefix}instagram_profiles",
@@ -43,18 +46,16 @@ def handler(event, context):
         storage_options=STORAGE_OPTIONS,
     )
 
-    bronze.write_profiles(profiles, run_id=run_id)
-    bronze.write_posts(posts, run_id=run_id)
-    bronze.write_reels(reels, run_id=run_id)
+    result = extract_and_land(scraper, bronze, LANDING_DIR, links, run_id=run_id)
 
     return {
         "statusCode": 200,
         "body": json.dumps(
             {
                 "run_id": run_id,
-                "profiles": len(profiles),
-                "posts": len(posts),
-                "reels": len(reels),
+                "profiles": len(result["profiles"]),
+                "posts": len(result["posts"]),
+                "reels": len(result["reels"]),
             }
         ),
     }

--- a/pipeline.py
+++ b/pipeline.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 from config import settings
 from src.data_extract.bronze_writer import BronzeWriter
+from src.data_extract.ingestion import extract_and_land
 from src.data_extract.readers import JsonDataReader
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
 from src.features.gold.engagement_aggregator import EngagementAggregator
@@ -90,13 +91,7 @@ def run_medallion_pipeline(
                 client=ApifyClient(apify_api_token),
                 config=ScraperConfig(results_limit=results_limit),
             )
-            profiles = scraper.scrape_profiles(links)
-            posts = scraper.scrape_posts(links)
-            reels = scraper.scrape_reels(links)
-
-            bronze.write_profiles(profiles, run_id=run_id)
-            bronze.write_posts(posts, run_id=run_id)
-            bronze.write_reels(reels, run_id=run_id)
+            extract_and_land(scraper, bronze, settings.LANDING_DIR, links, run_id=run_id)
 
             df_profiles = bronze.get_latest_profiles()
             df_posts = bronze.get_latest_posts()

--- a/scripts/run_apify_backfill.py
+++ b/scripts/run_apify_backfill.py
@@ -10,11 +10,13 @@ no teste de calibracao. --days e obrigatorio (sem default) para forcar uma
 escolha explicita a cada execucao -- nao existe "janela segura" default pra
 uma operacao que grava em producao.
 
-So faz a extracao (profiles + posts + reels sob o mesmo run_id, igual ao
-branch de extracao do `pipeline.py`) -- NAO roda Silver/Gold. Depois de
-rodar este script, execute `uv run python pipeline.py` normalmente: ele
-detecta a Bronze ja preenchida (`_bronze_has_data`) e cascateia Silver/Gold
-a partir dela, sem reextrair.
+So faz a extracao (profiles + posts + reels sob o mesmo run_id, via
+`src.data_extract.ingestion.extract_and_land` -- o mesmo ponto compartilhado
+que o branch de extracao do `pipeline.py` usa, que tambem arquiva o JSON
+bruto na landing zone antes de escrever na Bronze, ver ADR 0011) -- NAO roda
+Silver/Gold. Depois de rodar este script, execute `uv run python
+pipeline.py` normalmente: ele detecta a Bronze ja preenchida
+(`_bronze_has_data`) e cascateia Silver/Gold a partir dela, sem reextrair.
 
 NAO roda no import -- so via `uv run python scripts/run_apify_backfill.py
 --days N --yes`, disparado manualmente. Gera custo real na conta Apify.
@@ -48,6 +50,7 @@ from scripts.apify_backfill_shared import (
     project_backfill_costs,
 )
 from src.data_extract.bronze_writer import BronzeWriter
+from src.data_extract.ingestion import extract_and_land
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
 
 BACKFILL_REPORT_DIR = settings.DATA_DIR / "backfill"
@@ -67,14 +70,20 @@ def run(apify_api_token: str, days: int, results_limit: int, run_id: str | None 
         config=ScraperConfig(results_limit=results_limit),
     )
     extra_run_input = {"onlyPostsNewerThan": only_newer_than}
+    bronze = BronzeWriter(
+        bronze_profiles_path=settings.BRONZE_PROFILES,
+        bronze_posts_path=settings.BRONZE_POSTS,
+        bronze_reels_path=settings.BRONZE_REELS,
+    )
 
-    profiles = scraper.scrape_profiles(links)
-    posts = scraper.scrape_posts(links, extra_run_input=extra_run_input)
-    reels = scraper.scrape_reels(links, extra_run_input=extra_run_input)
+    result = extract_and_land(
+        scraper, bronze, settings.LANDING_DIR, links, run_id=run_id, extra_run_input=extra_run_input
+    )
+    profiles, posts, reels = result["profiles"], result["posts"], result["reels"]
 
     print(
         f"[2/3] Resultado bruto: {len(profiles)} profiles, {len(posts)} posts, "
-        f"{len(reels)} reels. Escrevendo na Bronze de producao..."
+        f"{len(reels)} reels. Escrito na Bronze de producao."
     )
     truncated = {
         "posts": profiles_hitting_limit(posts, results_limit),
@@ -87,15 +96,6 @@ def run(apify_api_token: str, days: int, results_limit: int, run_id: str | None 
             f"posts={truncated['posts']} reels={truncated['reels']}. "
             "Rode de novo com --results-limit maior para esses casos."
         )
-
-    bronze = BronzeWriter(
-        bronze_profiles_path=settings.BRONZE_PROFILES,
-        bronze_posts_path=settings.BRONZE_POSTS,
-        bronze_reels_path=settings.BRONZE_REELS,
-    )
-    bronze.write_profiles(profiles, run_id=run_id)
-    bronze.write_posts(posts, run_id=run_id)
-    bronze.write_reels(reels, run_id=run_id)
 
     actual_reels_per_day = len(reels) / days / n_governors
     actual_posts_per_day = len(posts) / days / n_governors

--- a/src/data_extract/ingestion.py
+++ b/src/data_extract/ingestion.py
@@ -1,0 +1,62 @@
+"""
+Ponto unico compartilhado de "raspar perfis+posts+reels e escrever na
+Bronze" -- usado por `pipeline.py`, `scripts/run_apify_backfill.py` e
+`lambdas/extract/handler.py`, que antes duplicavam essa sequencia sem
+nenhum compartilhamento (ver ADR 0011, decisao 2).
+
+Tambem responsavel por arquivar o JSON bruto retornado pela Apify numa
+landing zone, antes de qualquer projecao de schema acontecer (a Bronze
+descarta silenciosamente campos fora do seu schema fixo -- ver ADR 0011,
+decisao 1). O arquivamento acontece sempre antes da escrita na Bronze para
+cada entidade, entao uma falha na escrita da Bronze nao implica perda do
+dado bruto ja raspado (e ja pago) da Apify.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.data_extract.bronze_writer import BronzeWriter
+from src.data_extract.scraper import InstagramScraper
+
+
+def archive_raw_json(
+    landing_dir: Path | str, entity: str, raw_data: list[dict], run_id: str
+) -> Path:
+    """Grava a lista de itens brutos como veio da Apify, sem nenhuma
+    projecao de schema -- fidelidade total, para nao perder campos que a
+    Bronze ainda nao modela."""
+    entity_dir = Path(landing_dir) / entity
+    entity_dir.mkdir(parents=True, exist_ok=True)
+    path = entity_dir / f"{run_id}.json"
+    path.write_text(json.dumps(raw_data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def extract_and_land(
+    scraper: InstagramScraper,
+    bronze: BronzeWriter,
+    landing_dir: Path | str,
+    links: list[str],
+    run_id: str,
+    extra_run_input: dict | None = None,
+) -> dict[str, list[dict]]:
+    """Raspa perfis+posts+reels, arquiva cada entidade na landing zone e
+    escreve na Bronze, nessa ordem, entidade por entidade. `extra_run_input`
+    (ex: `onlyPostsNewerThan`) se aplica a posts/reels, nao a perfis -- o
+    ator de perfis da Apify nao aceita esse parametro. Retorna os itens
+    brutos raspados por entidade."""
+    profiles = scraper.scrape_profiles(links)
+    archive_raw_json(landing_dir, "profiles", profiles, run_id)
+    bronze.write_profiles(profiles, run_id=run_id)
+
+    posts = scraper.scrape_posts(links, extra_run_input=extra_run_input)
+    archive_raw_json(landing_dir, "posts", posts, run_id)
+    bronze.write_posts(posts, run_id=run_id)
+
+    reels = scraper.scrape_reels(links, extra_run_input=extra_run_input)
+    archive_raw_json(landing_dir, "reels", reels, run_id)
+    bronze.write_reels(reels, run_id=run_id)
+
+    return {"profiles": profiles, "posts": posts, "reels": reels}

--- a/src/data_extract/ingestion.py
+++ b/src/data_extract/ingestion.py
@@ -1,15 +1,15 @@
 """
-Ponto unico compartilhado de "raspar perfis+posts+reels e escrever na
-Bronze" -- usado por `pipeline.py`, `scripts/run_apify_backfill.py` e
-`lambdas/extract/handler.py`, que antes duplicavam essa sequencia sem
-nenhum compartilhamento (ver ADR 0011, decisao 2).
+Ponto único compartilhado de "raspar perfis+posts+reels e escrever na
+Bronze" — usado por `pipeline.py`, `scripts/run_apify_backfill.py` e
+`lambdas/extract/handler.py`, que antes duplicavam essa sequência sem
+nenhum compartilhamento (ver ADR 0011, decisão 2).
 
-Tambem responsavel por arquivar o JSON bruto retornado pela Apify numa
-landing zone, antes de qualquer projecao de schema acontecer (a Bronze
-descarta silenciosamente campos fora do seu schema fixo -- ver ADR 0011,
-decisao 1). O arquivamento acontece sempre antes da escrita na Bronze para
-cada entidade, entao uma falha na escrita da Bronze nao implica perda do
-dado bruto ja raspado (e ja pago) da Apify.
+Também responsável por arquivar o JSON bruto retornado pela Apify numa
+landing zone, antes de qualquer projeção de schema acontecer (a Bronze
+descarta silenciosamente campos fora do seu schema fixo — ver ADR 0011,
+decisão 1). O arquivamento acontece sempre antes da escrita na Bronze para
+cada entidade, então uma falha na escrita da Bronze não implica perda do
+dado bruto já raspado (e já pago) da Apify.
 """
 
 from __future__ import annotations
@@ -25,8 +25,8 @@ def archive_raw_json(
     landing_dir: Path | str, entity: str, raw_data: list[dict], run_id: str
 ) -> Path:
     """Grava a lista de itens brutos como veio da Apify, sem nenhuma
-    projecao de schema -- fidelidade total, para nao perder campos que a
-    Bronze ainda nao modela."""
+    projeção de schema — fidelidade total, para não perder campos que a
+    Bronze ainda não modela."""
     entity_dir = Path(landing_dir) / entity
     entity_dir.mkdir(parents=True, exist_ok=True)
     path = entity_dir / f"{run_id}.json"
@@ -44,8 +44,8 @@ def extract_and_land(
 ) -> dict[str, list[dict]]:
     """Raspa perfis+posts+reels, arquiva cada entidade na landing zone e
     escreve na Bronze, nessa ordem, entidade por entidade. `extra_run_input`
-    (ex: `onlyPostsNewerThan`) se aplica a posts/reels, nao a perfis -- o
-    ator de perfis da Apify nao aceita esse parametro. Retorna os itens
+    (ex: `onlyPostsNewerThan`) se aplica a posts/reels, não a perfis — o
+    ator de perfis da Apify não aceita esse parâmetro. Retorna os itens
     brutos raspados por entidade."""
     profiles = scraper.scrape_profiles(links)
     archive_raw_json(landing_dir, "profiles", profiles, run_id)

--- a/src/features/silver/governors_metadata_cleaner.py
+++ b/src/features/silver/governors_metadata_cleaner.py
@@ -9,6 +9,7 @@ o dashboard (nome/UF/partido) em vez de ler a planilha bruta a cada carregamento
 from __future__ import annotations
 
 from pathlib import Path
+from typing import ClassVar
 
 import pandas as pd
 
@@ -17,7 +18,7 @@ from src.schemas_delta import SILVER_GOVERNORS_METADATA_SCHEMA
 
 
 class GovernorsMetadataCleaner:
-    COLUMN_MAP: dict[str, str] = {
+    COLUMN_MAP: ClassVar[dict[str, str]] = {
         "Governador": "nome",
         "Unidade Federativa": "uf",
         "Partido": "partido",

--- a/tests/test_extract_lambda.py
+++ b/tests/test_extract_lambda.py
@@ -19,7 +19,7 @@ def _fake_bronze_writer_class():
     return FakeBronzeWriter
 
 
-def _patch_extract_dependencies(monkeypatch, profiles, posts, reels):
+def _patch_extract_dependencies(monkeypatch, tmp_path, profiles, posts, reels):
     fake_scraper = MagicMock()
     fake_scraper.scrape_profiles.return_value = profiles
     fake_scraper.scrape_posts.return_value = posts
@@ -31,16 +31,21 @@ def _patch_extract_dependencies(monkeypatch, profiles, posts, reels):
         lambda client, config: fake_scraper,
     )
     monkeypatch.setattr("lambdas.extract.handler.BronzeWriter", _fake_bronze_writer_class())
+    monkeypatch.setattr("lambdas.extract.handler.LANDING_DIR", tmp_path / "landing")
     return fake_scraper
 
 
-def test_extract_handler(monkeypatch):
+def test_extract_handler(monkeypatch, tmp_path):
     from lambdas.extract import handler as extract_handler
 
     monkeypatch.setenv("APIFY_API_TOKEN", "token")
     monkeypatch.setenv("S3_BUCKET", "dummy-bucket")
     _patch_extract_dependencies(
-        monkeypatch, profiles=[{"id": "1"}], posts=[{"id": "1"}], reels=[{"id": "1"}, {"id": "2"}]
+        monkeypatch,
+        tmp_path,
+        profiles=[{"id": "1"}],
+        posts=[{"id": "1"}],
+        reels=[{"id": "1"}, {"id": "2"}],
     )
 
     resp = extract_handler.handler(
@@ -50,14 +55,17 @@ def test_extract_handler(monkeypatch):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert body == {"run_id": "test-run", "profiles": 1, "posts": 1, "reels": 2}
+    assert (tmp_path / "landing" / "profiles" / "test-run.json").exists()
+    assert (tmp_path / "landing" / "posts" / "test-run.json").exists()
+    assert (tmp_path / "landing" / "reels" / "test-run.json").exists()
 
 
-def test_extract_handler_gera_run_id_quando_ausente(monkeypatch):
+def test_extract_handler_gera_run_id_quando_ausente(monkeypatch, tmp_path):
     from lambdas.extract import handler as extract_handler
 
     monkeypatch.setenv("APIFY_API_TOKEN", "token")
     monkeypatch.setenv("S3_BUCKET", "dummy-bucket")
-    _patch_extract_dependencies(monkeypatch, profiles=[], posts=[], reels=[])
+    _patch_extract_dependencies(monkeypatch, tmp_path, profiles=[], posts=[], reels=[])
 
     resp = extract_handler.handler({"links": ["https://www.instagram.com/exemplo/"]}, {})
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+from src.data_extract.ingestion import archive_raw_json, extract_and_land
+
+
+class _FakeScraper:
+    def __init__(self):
+        self.posts_calls = []
+        self.reels_calls = []
+
+    def scrape_profiles(self, links):
+        return [{"inputUrl": "https://instagram.com/gov1", "username": "gov1"}]
+
+    def scrape_posts(self, links, extra_run_input=None):
+        self.posts_calls.append((links, extra_run_input))
+        return [{"inputUrl": "https://instagram.com/gov1", "id": "p1"}]
+
+    def scrape_reels(self, links, extra_run_input=None):
+        self.reels_calls.append((links, extra_run_input))
+        return [{"inputUrl": "https://instagram.com/gov1", "id": "r1"}]
+
+
+class _FakeBronzeWriter:
+    def __init__(self):
+        self.calls = []
+
+    def write_profiles(self, raw_data, run_id=None):
+        self.calls.append(("profiles", raw_data, run_id))
+
+    def write_posts(self, raw_data, run_id=None):
+        self.calls.append(("posts", raw_data, run_id))
+
+    def write_reels(self, raw_data, run_id=None):
+        self.calls.append(("reels", raw_data, run_id))
+
+
+class _OrderCheckingBronzeWriter:
+    """Falha se a Bronze receber uma entidade antes dela existir na landing zone."""
+
+    def __init__(self, landing_dir):
+        self.landing_dir = Path(landing_dir)
+        self.write_order = []
+
+    def _assert_archived(self, entity, run_id):
+        assert (self.landing_dir / entity / f"{run_id}.json").exists(), (
+            f"{entity} foi escrito na Bronze antes de ser arquivado na landing zone"
+        )
+
+    def write_profiles(self, raw_data, run_id=None):
+        self._assert_archived("profiles", run_id)
+        self.write_order.append("profiles")
+
+    def write_posts(self, raw_data, run_id=None):
+        self._assert_archived("posts", run_id)
+        self.write_order.append("posts")
+
+    def write_reels(self, raw_data, run_id=None):
+        self._assert_archived("reels", run_id)
+        self.write_order.append("reels")
+
+
+def test_archive_raw_json_grava_json_bruto_por_entidade_e_run_id(tmp_path):
+    path = archive_raw_json(tmp_path, "posts", [{"id": "p1"}], run_id="run_1")
+
+    assert path == tmp_path / "posts" / "run_1.json"
+    assert path.exists()
+    assert '"id": "p1"' in path.read_text(encoding="utf-8")
+
+
+def test_extract_and_land_arquiva_e_escreve_as_tres_entidades_sob_o_mesmo_run_id(tmp_path):
+    scraper = _FakeScraper()
+    bronze = _FakeBronzeWriter()
+
+    result = extract_and_land(
+        scraper, bronze, tmp_path, links=["https://instagram.com/gov1"], run_id="run_fixo"
+    )
+
+    assert {kind for kind, _, _ in bronze.calls} == {"profiles", "posts", "reels"}
+    assert all(run_id == "run_fixo" for _, _, run_id in bronze.calls)
+    assert (tmp_path / "profiles" / "run_fixo.json").exists()
+    assert (tmp_path / "posts" / "run_fixo.json").exists()
+    assert (tmp_path / "reels" / "run_fixo.json").exists()
+    assert result["profiles"][0]["username"] == "gov1"
+    assert result["posts"][0]["id"] == "p1"
+    assert result["reels"][0]["id"] == "r1"
+
+
+def test_extract_and_land_propaga_extra_run_input_so_para_posts_e_reels(tmp_path):
+    scraper = _FakeScraper()
+    bronze = _FakeBronzeWriter()
+
+    extract_and_land(
+        scraper,
+        bronze,
+        tmp_path,
+        links=["https://instagram.com/gov1"],
+        run_id="run_1",
+        extra_run_input={"onlyPostsNewerThan": "90 days"},
+    )
+
+    assert scraper.posts_calls[0][1] == {"onlyPostsNewerThan": "90 days"}
+    assert scraper.reels_calls[0][1] == {"onlyPostsNewerThan": "90 days"}
+
+
+def test_extract_and_land_arquiva_cada_entidade_antes_de_escreve_la_na_bronze(tmp_path):
+    scraper = _FakeScraper()
+    bronze = _OrderCheckingBronzeWriter(tmp_path)
+
+    extract_and_land(scraper, bronze, tmp_path, links=["l"], run_id="run_1")
+
+    assert bronze.write_order == ["profiles", "posts", "reels"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from src.data_extract.ingestion import archive_raw_json, extract_and_land
 
 
@@ -109,3 +111,33 @@ def test_extract_and_land_arquiva_cada_entidade_antes_de_escreve_la_na_bronze(tm
     extract_and_land(scraper, bronze, tmp_path, links=["l"], run_id="run_1")
 
     assert bronze.write_order == ["profiles", "posts", "reels"]
+
+
+class _BronzeWriterFalhandoEmReels:
+    """Simula uma falha na escrita da Bronze pra reels, depois de
+    profiles/posts terem sido escritos com sucesso."""
+
+    def write_profiles(self, raw_data, run_id=None):
+        pass
+
+    def write_posts(self, raw_data, run_id=None):
+        pass
+
+    def write_reels(self, raw_data, run_id=None):
+        raise RuntimeError("falha simulada na escrita da Bronze")
+
+
+def test_extract_and_land_preserva_o_arquivado_mesmo_se_a_bronze_falhar(tmp_path):
+    """Cenario descrito no spec (issue #31): uma falha na escrita da Bronze
+    para uma entidade nao deve apagar o JSON bruto ja arquivado das
+    entidades anteriores (nem da propria entidade que falhou, ja arquivada
+    antes da tentativa de escrita)."""
+    scraper = _FakeScraper()
+    bronze = _BronzeWriterFalhandoEmReels()
+
+    with pytest.raises(RuntimeError, match="falha simulada"):
+        extract_and_land(scraper, bronze, tmp_path, links=["l"], run_id="run_1")
+
+    assert (tmp_path / "profiles" / "run_1.json").exists()
+    assert (tmp_path / "posts" / "run_1.json").exists()
+    assert (tmp_path / "reels" / "run_1.json").exists()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -103,3 +103,71 @@ def test_run_medallion_pipeline_nunca_chama_refinamento_via_gemini(monkeypatch):
     import pipeline
 
     assert not hasattr(pipeline, "refine_topics_with_gemini")
+
+
+def _fake_bronze_writer_class_recording(calls):
+    df_profiles = pd.DataFrame({"id": ["1"]})
+    df_posts = pd.DataFrame({"id": ["1"]})
+    df_reels = pd.DataFrame({"id": ["1"]})
+
+    class FakeBronzeWriter:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_latest_profiles(self):
+            return df_profiles
+
+        def get_latest_posts(self):
+            return df_posts
+
+        def get_latest_reels(self):
+            return df_reels
+
+        def write_profiles(self, raw_data, run_id=None):
+            calls.append(("profiles", raw_data, run_id))
+
+        def write_posts(self, raw_data, run_id=None):
+            calls.append(("posts", raw_data, run_id))
+
+        def write_reels(self, raw_data, run_id=None):
+            calls.append(("reels", raw_data, run_id))
+
+    return FakeBronzeWriter
+
+
+def test_run_medallion_pipeline_branch_de_extracao_usa_extract_and_land(
+    monkeypatch, tmp_path
+):
+    """force_extract=True (sem Bronze/JSON local) deve raspar via
+    extract_and_land -- que arquiva na landing zone antes de escrever na
+    Bronze (ver ADR 0011)."""
+    import pipeline
+
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+
+    bronze_calls = []
+    monkeypatch.setattr(
+        "pipeline.BronzeWriter", _fake_bronze_writer_class_recording(bronze_calls)
+    )
+
+    fake_scraper = MagicMock()
+    fake_scraper.scrape_profiles.return_value = [{"inputUrl": "u1", "username": "gov1"}]
+    fake_scraper.scrape_posts.return_value = [{"inputUrl": "u1", "id": "p1"}]
+    fake_scraper.scrape_reels.return_value = [{"inputUrl": "u1", "id": "r1"}]
+    monkeypatch.setattr("pipeline.ApifyClient", lambda token: MagicMock())
+    monkeypatch.setattr(
+        "pipeline.InstagramScraper", lambda client, config: fake_scraper
+    )
+    monkeypatch.setattr("pipeline.settings.LANDING_DIR", tmp_path / "landing")
+
+    pipeline.run_medallion_pipeline(
+        apify_api_token="token", links=["u1"], run_id="run_extract", force_extract=True
+    )
+
+    assert {kind for kind, _, _ in bronze_calls} == {"profiles", "posts", "reels"}
+    assert all(run_id == "run_extract" for _, _, run_id in bronze_calls)
+    assert (tmp_path / "landing" / "profiles" / "run_extract.json").exists()
+    assert (tmp_path / "landing" / "posts" / "run_extract.json").exists()
+    assert (tmp_path / "landing" / "reels" / "run_extract.json").exists()

--- a/tests/test_run_apify_backfill_script.py
+++ b/tests/test_run_apify_backfill_script.py
@@ -48,7 +48,8 @@ def _patch_backfill_dependencies(monkeypatch, tmp_path, scraper_class=_FakeInsta
     monkeypatch.setattr(
         "scripts.run_apify_backfill.load_links", lambda: ["https://instagram.com/gov1"]
     )
-    monkeypatch.setattr("scripts.run_apify_backfill.BACKFILL_REPORT_DIR", tmp_path)
+    monkeypatch.setattr("scripts.run_apify_backfill.BACKFILL_REPORT_DIR", tmp_path / "backfill")
+    monkeypatch.setattr("scripts.run_apify_backfill.settings.LANDING_DIR", tmp_path / "landing")
     return calls
 
 
@@ -85,7 +86,7 @@ def test_run_nao_grava_json_bruto_de_itens_so_o_relatorio(monkeypatch, tmp_path)
 
     backfill_script.run(apify_api_token="token", days=90, results_limit=1000)
 
-    files = list(tmp_path.iterdir())
+    files = list((tmp_path / "backfill").iterdir())
     assert len(files) == 1
     assert files[0].name.startswith("backfill_report_")
 


### PR DESCRIPTION
## Summary
Closes #31. Implementa as decisoes 1 e 2 do [ADR 0011](docs/adr/0011-preparar-medallion-para-monitor-continuo-landing-zone-extracao-unica-historico-gold.md).

- `src/data_extract/ingestion.py` (novo): `extract_and_land()` + `archive_raw_json()`. Ponto unico que raspa perfis+posts+reels, arquiva cada entidade na landing zone (JSON bruto, sem projecao de schema) ANTES de escrever na Bronze, e escreve na Bronze -- nessa ordem, entidade por entidade. Retorna os itens brutos raspados (nao so contagens -- desvio documentado do spec original: `scripts/run_apify_backfill.py` precisa dos itens pra checagem de truncagem por `resultsLimit`).
- `pipeline.py`, `scripts/run_apify_backfill.py`, `lambdas/extract/handler.py`: as tres sequencias antes duplicadas de "raspar + escrever Bronze" agora chamam `extract_and_land()`. Sem mudanca de comportamento externo.
- `config/settings.py`: `LANDING_DIR = DATA_DIR / "landing"`, seguindo a convencao de `BRONZE_DIR`/`SILVER_DIR`/`GOLD_DIR`.
- Lambda `extract`: `LANDING_DIR` aponta pro `/tmp` efemero por enquanto -- suporte a S3 fica fora de escopo ate a infra AWS ser aplicada (explicitamente fora de escopo na issue).
- `scripts/run_apify_calibration_test.py` intencionalmente NAO tocado (continua isolado em `data/calibration/`).

## Code review
Rodei `/code-review` (Standards + Spec em paralelo) antes de commitar. Achados aplicados:
- Alinhei o estilo de comentarios/docstrings de `ingestion.py` e do comentario novo em `settings.py` ao padrao acentuado do resto desses arquivos (nao ha `print()` em `ingestion.py`, entao nao havia motivo pra fugir do padrao).
- Adicionei o teste de resiliencia que faltava: `bronze.write_reels` levantando excecao, confirmando que profiles/posts/reels ja arquivados sobrevivem -- o teste anterior so provava a ordem, nao o cenario de falha que o spec descreveu.

## Test plan
- [x] TDD: `src/data_extract/ingestion.py` escrito depois de `tests/test_ingestion.py` (vermelho -> verde)
- [x] `ruff check` limpo em todos os arquivos tocados (4 erros pre-existentes em `config/settings.py`/`pipeline.py`/lambda `extract`, confirmados via stash contra `origin/main`, nao introduzidos por este PR)
- [x] Suite completa: 101 passed, 3 skipped (100 anteriores + 1 novo teste de resiliencia)
- [x] Achado durante a implementacao e corrigido: os testes vazavam arquivos reais pra `data/landing/` do projeto antes de `LANDING_DIR` ser isolado em `tmp_path` em todos os arquivos de teste afetados (`test_pipeline.py`, `test_run_apify_backfill_script.py`, `test_extract_lambda.py`)
- [x] Smoke test de import dos 4 modulos tocados + dry-run real do `--yes`-guard do `run_apify_backfill.py` (sem chamar a Apify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5WdTCuZXAb8ktSL5uZHmr