### PR TITLE
refactor(landing): organiza landing zone por run_id, nao por entidade

### DIFF
--- a/docs/adr/0014-landing-zone-organizada-por-run-id-nao-por-entidade.md
+++ b/docs/adr/0014-landing-zone-organizada-por-run-id-nao-por-entidade.md
@@ -34,6 +34,13 @@ O único run já arquivado no esquema antigo (do teste E2E real da ADR 0012,
 `data/landing/{profiles,posts,reels}/a8f36a6f-....json`) não é migrado -- fica como está, dado de um
 teste de validação, não de produção contínua.
 
+Junto, corrige uma inconsistência encontrada na mesma investigação: `scripts/run_apify_backfill.py`
+gerava `run_id` com `uuid.uuid4()` puro, sem timestamp, diferente de `build_run_id()` (`src/run_id.py`,
+já usado por `pipeline.py` e pelas lambdas), que prefixa `YYYYMMDD_HHMMSS_`. Isso fazia `data/landing/`
+acumular uma mistura de pastas ordenáveis cronologicamente por nome e pastas que não são -- o mesmo
+problema de usabilidade que motivou esta ADR. `run_apify_backfill.py` passa a usar `build_run_id()`
+também, unificando o formato em todos os pontos de entrada que escrevem na landing zone.
+
 ## Por que
 
 **Apagar/arquivar por execução é a necessidade real, e só o layout novo resolve isso.** Cruzar por
@@ -69,3 +76,6 @@ não há assimetria real entre os dois esquemas para leitura/correlação, só p
 - Apagar/arquivar uma execução específica vira uma operação de filesystem de um passo
   (`rm -rf data/landing/<run_id>/`), sem automação nenhuma por trás -- fica como trabalho futuro
   quando o monitor contínuo (ADR 0011) tiver volume real de runs acumulado.
+- `scripts/run_apify_backfill.py` passa a importar `build_run_id` de `src/run_id.py` em vez de
+  `uuid` diretamente. O `run_id` do teste E2E da ADR 0012 (`a8f36a6f-...`, sem timestamp) fica como
+  o único exemplo do formato antigo -- não é migrado, mesmo raciocínio do item acima.

--- a/docs/adr/0014-landing-zone-organizada-por-run-id-nao-por-entidade.md
+++ b/docs/adr/0014-landing-zone-organizada-por-run-id-nao-por-entidade.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+---
+
+# Organizar a landing zone por `run_id`, não por entidade
+
+## Contexto
+
+A ADR 0011 introduziu a landing zone (JSON bruto por `run_id`, sem schema, anterior à Bronze) mas
+não especificou a ordem de aninhamento de pastas. A implementação (PR #32,
+`src/data_extract/ingestion.py::archive_raw_json`) escolheu `<landing_dir>/<entidade>/<run_id>.json`
+-- uma pasta por entidade (`profiles/`, `posts/`, `reels/`), com o `run_id` só no nome do arquivo.
+
+Numa sessão de `/grill-with-docs`, surgiu a pergunta de se esse layout atende a necessidade real de
+"cruzar" os três arquivos de uma mesma execução depois. Investigando: o `run_id` já está presente no
+nome de cada um dos três arquivos, então cruzar por nome (`find data/landing -name "$RUN_ID*"`) já
+funciona hoje, independente da ordem de aninhamento. A necessidade real identificada foi outra:
+poder **apagar ou arquivar tudo de uma execução com uma operação só** (ex: `rm -rf
+landing/<run_id>/`) -- isso o esquema atual não permite, porque os três arquivos de uma run ficam
+espalhados em três pastas de entidade diferentes.
+
+## Decisão
+
+Trocar o layout da landing zone para `<landing_dir>/<run_id>/<entidade>.json` -- pasta por `run_id`,
+arquivo por entidade dentro dela.
+
+A limpeza/arquivamento de runs antigas continua **manual e ocasional** por enquanto -- nenhum
+mecanismo de retenção automática (manter só os últimos N runs, expirar por idade) é implementado
+nesta decisão. Segue o mesmo raciocínio que a ADR 0011 já usou para adiar outras peças (histórico de
+Gold, propagação de parâmetros para a lambda): a landing zone ainda não rodou num regime contínuo de
+produção, então uma política de retenção automática agora seria design especulativo.
+
+O único run já arquivado no esquema antigo (do teste E2E real da ADR 0012,
+`data/landing/{profiles,posts,reels}/a8f36a6f-....json`) não é migrado -- fica como está, dado de um
+teste de validação, não de produção contínua.
+
+## Por que
+
+**Apagar/arquivar por execução é a necessidade real, e só o layout novo resolve isso.** Cruzar por
+`run_id` já funcionava com o layout antigo (via nome de arquivo); reorganizar só por causa disso não
+adicionaria capacidade nova. Tratar "uma execução" como a unidade atômica de limpeza/arquivamento --
+alinhado com o `run_id` já ser o conceito central em todo o resto do projeto (Bronze carimba
+`_run_id` em cada linha, os checkpoints de modelagem são uma pasta por `run_id`) -- é o que
+justifica a mudança.
+
+**Nenhuma capacidade existente é perdida.** Listar todos os `profiles.json` históricos ao longo do
+tempo continua igualmente simples com o layout novo (`find data/landing -name profiles.json`) --
+não há assimetria real entre os dois esquemas para leitura/correlação, só para apagar.
+
+## Opções consideradas
+
+- **Manter o layout por entidade** (`<entidade>/<run_id>.json`) -- rejeitada: não atende a
+  necessidade real (apagar/arquivar uma run inteira exige acertar três pastas, não uma).
+- **Implementar já uma política de retenção automática** junto com a reorganização -- rejeitada por
+  ora: nenhum uso real em regime contínuo ainda existe para informar os parâmetros dessa política
+  (quantas runs manter, por quanto tempo); decisão especulativa demais nesta fase.
+- **Migrar o run já arquivado no esquema antigo** -- rejeitada: é dado de um teste de validação
+  pontual, não de produção; forçar consistência retroativa aqui é escopo extra sem necessidade
+  concreta.
+
+## Consequências
+
+- `archive_raw_json` passa a construir `<landing_dir>/<run_id>/<entidade>.json` em vez de
+  `<landing_dir>/<entidade>/<run_id>.json`. Testes (`test_ingestion.py`, `test_pipeline.py`,
+  `test_extract_lambda.py`) atualizados para o novo layout.
+- O único run já arquivado no esquema antigo (`data/landing/{profiles,posts,reels}/a8f36a6f-....json`,
+  do teste E2E da ADR 0012) fica órfão do padrão novo -- não é um problema funcional (nenhum código
+  lê a landing zone de volta), só uma inconsistência histórica esperada e documentada aqui.
+- Apagar/arquivar uma execução específica vira uma operação de filesystem de um passo
+  (`rm -rf data/landing/<run_id>/`), sem automação nenhuma por trás -- fica como trabalho futuro
+  quando o monitor contínuo (ADR 0011) tiver volume real de runs acumulado.

--- a/scripts/run_apify_backfill.py
+++ b/scripts/run_apify_backfill.py
@@ -26,7 +26,6 @@ import argparse
 import json
 import os
 import sys
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -52,12 +51,13 @@ from scripts.apify_backfill_shared import (
 from src.data_extract.bronze_writer import BronzeWriter
 from src.data_extract.ingestion import extract_and_land
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
+from src.run_id import build_run_id
 
 BACKFILL_REPORT_DIR = settings.DATA_DIR / "backfill"
 
 
 def run(apify_api_token: str, days: int, results_limit: int, run_id: str | None = None) -> dict:
-    run_id = run_id or str(uuid.uuid4())
+    run_id = build_run_id(run_id)
     links = load_links()
     n_governors = len(links)
     only_newer_than = f"{days} days"

--- a/src/data_extract/ingestion.py
+++ b/src/data_extract/ingestion.py
@@ -26,10 +26,16 @@ def archive_raw_json(
 ) -> Path:
     """Grava a lista de itens brutos como veio da Apify, sem nenhuma
     projeção de schema — fidelidade total, para não perder campos que a
-    Bronze ainda não modela."""
-    entity_dir = Path(landing_dir) / entity
-    entity_dir.mkdir(parents=True, exist_ok=True)
-    path = entity_dir / f"{run_id}.json"
+    Bronze ainda não modela.
+
+    Layout `<landing_dir>/<run_id>/<entity>.json` — pasta por `run_id`, não
+    por entidade — para que arquivar/apagar tudo de uma execução seja uma
+    operação de filesystem só (`rm -rf landing/<run_id>/`), sem precisar
+    acertar uma pasta por entidade. Cruzar por `run_id` continua igual de
+    fácil nos dois esquemas (é o nome da pasta em vez do nome do arquivo)."""
+    run_dir = Path(landing_dir) / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / f"{entity}.json"
     path.write_text(json.dumps(raw_data, ensure_ascii=False, indent=2), encoding="utf-8")
     return path
 

--- a/tests/test_extract_lambda.py
+++ b/tests/test_extract_lambda.py
@@ -55,9 +55,9 @@ def test_extract_handler(monkeypatch, tmp_path):
     assert resp["statusCode"] == 200
     body = json.loads(resp["body"])
     assert body == {"run_id": "test-run", "profiles": 1, "posts": 1, "reels": 2}
-    assert (tmp_path / "landing" / "profiles" / "test-run.json").exists()
-    assert (tmp_path / "landing" / "posts" / "test-run.json").exists()
-    assert (tmp_path / "landing" / "reels" / "test-run.json").exists()
+    assert (tmp_path / "landing" / "test-run" / "profiles.json").exists()
+    assert (tmp_path / "landing" / "test-run" / "posts.json").exists()
+    assert (tmp_path / "landing" / "test-run" / "reels.json").exists()
 
 
 def test_extract_handler_gera_run_id_quando_ausente(monkeypatch, tmp_path):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -44,7 +44,7 @@ class _OrderCheckingBronzeWriter:
         self.write_order = []
 
     def _assert_archived(self, entity, run_id):
-        assert (self.landing_dir / entity / f"{run_id}.json").exists(), (
+        assert (self.landing_dir / run_id / f"{entity}.json").exists(), (
             f"{entity} foi escrito na Bronze antes de ser arquivado na landing zone"
         )
 
@@ -61,10 +61,10 @@ class _OrderCheckingBronzeWriter:
         self.write_order.append("reels")
 
 
-def test_archive_raw_json_grava_json_bruto_por_entidade_e_run_id(tmp_path):
+def test_archive_raw_json_grava_json_bruto_por_run_id_e_entidade(tmp_path):
     path = archive_raw_json(tmp_path, "posts", [{"id": "p1"}], run_id="run_1")
 
-    assert path == tmp_path / "posts" / "run_1.json"
+    assert path == tmp_path / "run_1" / "posts.json"
     assert path.exists()
     assert '"id": "p1"' in path.read_text(encoding="utf-8")
 
@@ -79,9 +79,9 @@ def test_extract_and_land_arquiva_e_escreve_as_tres_entidades_sob_o_mesmo_run_id
 
     assert {kind for kind, _, _ in bronze.calls} == {"profiles", "posts", "reels"}
     assert all(run_id == "run_fixo" for _, _, run_id in bronze.calls)
-    assert (tmp_path / "profiles" / "run_fixo.json").exists()
-    assert (tmp_path / "posts" / "run_fixo.json").exists()
-    assert (tmp_path / "reels" / "run_fixo.json").exists()
+    assert (tmp_path / "run_fixo" / "profiles.json").exists()
+    assert (tmp_path / "run_fixo" / "posts.json").exists()
+    assert (tmp_path / "run_fixo" / "reels.json").exists()
     assert result["profiles"][0]["username"] == "gov1"
     assert result["posts"][0]["id"] == "p1"
     assert result["reels"][0]["id"] == "r1"
@@ -138,6 +138,6 @@ def test_extract_and_land_preserva_o_arquivado_mesmo_se_a_bronze_falhar(tmp_path
     with pytest.raises(RuntimeError, match="falha simulada"):
         extract_and_land(scraper, bronze, tmp_path, links=["l"], run_id="run_1")
 
-    assert (tmp_path / "profiles" / "run_1.json").exists()
-    assert (tmp_path / "posts" / "run_1.json").exists()
-    assert (tmp_path / "reels" / "run_1.json").exists()
+    assert (tmp_path / "run_1" / "profiles.json").exists()
+    assert (tmp_path / "run_1" / "posts.json").exists()
+    assert (tmp_path / "run_1" / "reels.json").exists()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -168,6 +168,6 @@ def test_run_medallion_pipeline_branch_de_extracao_usa_extract_and_land(
 
     assert {kind for kind, _, _ in bronze_calls} == {"profiles", "posts", "reels"}
     assert all(run_id == "run_extract" for _, _, run_id in bronze_calls)
-    assert (tmp_path / "landing" / "profiles" / "run_extract.json").exists()
-    assert (tmp_path / "landing" / "posts" / "run_extract.json").exists()
-    assert (tmp_path / "landing" / "reels" / "run_extract.json").exists()
+    assert (tmp_path / "landing" / "run_extract" / "profiles.json").exists()
+    assert (tmp_path / "landing" / "run_extract" / "posts.json").exists()
+    assert (tmp_path / "landing" / "run_extract" / "reels.json").exists()


### PR DESCRIPTION
## Summary
- `archive_raw_json` (`src/data_extract/ingestion.py`) passa a gravar `<landing_dir>/<run_id>/<entidade>.json` em vez de `<landing_dir>/<entidade>/<run_id>.json`.
- Motivacao (discutida em sessao de `/grill-with-docs`): a ADR 0011 introduziu a landing zone mas nao especificou a ordem de aninhamento. A necessidade real e poder apagar/arquivar tudo de uma execucao com uma operacao so (`rm -rf landing/<run_id>/`) -- o layout por entidade espalhava os 3 arquivos de uma run em 3 pastas diferentes. Cruzar por `run_id` ja funcionava igual nos dois esquemas (via nome de arquivo), entao a troca nao adiciona nem remove capacidade de leitura/correlacao, so ganha a conveniencia de apagar.
- Retencao/limpeza continua manual e ocasional por decisao explicita -- nenhuma automacao de retencao nesta mudanca.
- O run ja arquivado no esquema antigo (teste E2E real da ADR 0012) nao e migrado -- fica como historico do esquema anterior.
- **`scripts/run_apify_backfill.py` unificado para usar `build_run_id()`** em vez de `uuid.uuid4()` puro -- inconsistencia encontrada na mesma investigacao: sem isso, `data/landing/` acumularia pastas ordenaveis cronologicamente (via `pipeline.py`/lambda) misturadas com pastas nao-ordenaveis (via backfill), o mesmo problema de usabilidade que motivou esta ADR.
- **`.gitignore` ganha `data/landing/`, `data/backfill/` e `data/calibration/`** -- lacuna encontrada na mesma investigacao: nenhuma das tres tinha entrada propria, ao contrario de `data/raw/`/`data/bronze/`/`data/silver/`/`data/gold/`/`data/model_checkpoints/`. So nao tinha causado problema porque nenhuma execucao real desses scripts tinha gerado dado de verdade pra vazar antes desta sessao.
- Registra ADR 0014, cobrindo as tres mudancas acima como uma decisao so.

## Test plan
- [x] `tests/test_ingestion.py`, `tests/test_pipeline.py`, `tests/test_extract_lambda.py` atualizados para o novo layout de path.
- [x] `tests/test_run_apify_backfill_script.py`: sem mudanca necessaria (nenhum teste fixava o formato do `run_id` gerado automaticamente).
- [x] `uv run python -m pytest -q`: 101 passed, 3 skipped -- sem regressao, em cada um dos 3 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7cSpbr4T7njmLj1mqKe8P