### PR TITLE
fix(gitignore): adiciona entradas ausentes para landing/backfill/calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,12 @@ data/model_checkpoints/
 !data/silver/**/.gitkeep
 !data/gold/**/.gitkeep
 
+# Landing zone (JSON bruto por run_id) e artefatos de backfill/calibracao --
+# nunca devem ser versionados (ADR 0014 / issue de gap encontrado pos-PR #38).
+data/landing/
+data/backfill/
+data/calibration/
+
 # Backup local de data/ antes de simular ambiente limpo (issue #33) -- nunca
 # deve ser versionado, mesmo que criado fora de data/.
 data_backup_*/


### PR DESCRIPTION
## Resumo

`data/landing/`, `data/backfill/` e `data/calibration/` nao tinham entrada propria no
`.gitignore`, apesar de serem os diretorios de saida de `run_apify_backfill.py`,
`run_apify_calibration_test.py` e da reorganizacao da landing zone por `run_id` (ADR 0014 / PR
#38). Achado ao sincronizar o `main` local: `git status` mostrava esses diretorios como untracked
(`??`), nao ignorados.

## Risco que isso mitiga

Sem essas entradas, um `git add -A` descuidado versionaria os JSONs brutos da landing zone --
dezenas de milhares de linhas por execucao (o unico run ja existente, `a8f36a6f-...`, tem 3 JSONs
somando mais de 149 mil linhas).

## Test plan

- [x] Mudanca isolada em `.gitignore`, sem codigo afetado.
- [x] Confirmado localmente que `data/landing/` e `data/backfill/` (com dados reais do teste E2E da
      ADR 0012) passam a nao aparecer mais em `git status` apos a mudanca.