### PR TITLE
fix(extraction): adiciona gate de custo/confirmacao ao fallback do pipeline.py

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -1,10 +1,12 @@
 import os
+from typing import Callable
 
 import pandas as pd
 from apify_client import ApifyClient
 from dotenv import load_dotenv
 
 from config import settings
+from scripts.apify_backfill_shared import estimate_cost_usd_for_results_limit
 from src.data_extract.bronze_writer import BronzeWriter
 from src.data_extract.ingestion import extract_and_land
 from src.data_extract.scraper import InstagramScraper, ScraperConfig
@@ -33,6 +35,7 @@ def run_medallion_pipeline(
     run_id: str | None = None,
     force_extract: bool = False,
     run_modeling: bool = False,
+    confirm_extraction: Callable[[float], bool] | None = None,
 ) -> str:
     run_id = build_run_id(run_id)
 
@@ -52,6 +55,12 @@ def run_medallion_pipeline(
                 raise ValueError(
                     "APIFY_API_TOKEN não fornecido e não há dados brutos locais."
                 )
+            if confirm_extraction is not None:
+                estimated_cost = estimate_cost_usd_for_results_limit(
+                    results_limit, len(links)
+                )
+                if not confirm_extraction(estimated_cost):
+                    raise SystemExit(1)
             print("[1/3] BRONZE: Extraindo dados brutos...")
             scraper = InstagramScraper(
                 client=ApifyClient(apify_api_token),
@@ -140,6 +149,16 @@ if __name__ == "__main__":
             "refinamento via Gemini nunca roda daqui -- ver scripts/refine_topics.py."
         ),
     )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Confirma uma extracao real na Apify (custo real), caso nao haja "
+            "Bronze/raw local em cache. Obrigatorio so quando o cache esta "
+            "vazio -- se a Bronze ja tem dado, o pipeline reusa e nao pede "
+            "confirmacao."
+        ),
+    )
     args = parser.parse_args()
 
     df_gov = pd.read_excel(settings.GOVERNADORES_FILE)
@@ -147,11 +166,24 @@ if __name__ == "__main__":
     token = os.getenv("APIFY_API_TOKEN")
     links = list(df_gov[settings.LINK_COLUMN].str.strip().unique())
 
+    def _confirm_extraction(estimated_cost: float) -> bool:
+        if args.yes:
+            return True
+        print(
+            f"[ABORTADO] Nao ha Bronze/raw local em cache -- rodar agora "
+            f"dispararia uma extracao real na Apify (~${estimated_cost} "
+            f"estimado no pior caso para {len(links)} governadores, "
+            f"resultsLimit={settings.RESULTS_LIMIT}, sem janela de data). "
+            "Rode de novo com --yes para confirmar."
+        )
+        return False
+
     run_id = run_medallion_pipeline(
         apify_api_token=token,
         links=links,
         results_limit=settings.RESULTS_LIMIT,
         run_modeling=args.run_modeling,
+        confirm_extraction=_confirm_extraction,
     )
     # Sem emoji: o console padrão do Windows usa cp1252 e levanta
     # UnicodeEncodeError ao imprimi-los.

--- a/scripts/apify_backfill_shared.py
+++ b/scripts/apify_backfill_shared.py
@@ -65,6 +65,16 @@ def estimate_cost_usd(days: int, n_governors: int) -> float:
     return round(estimated_results / 1000 * STARTER_PRICE_PER_1000_RESULTS, 2)
 
 
+def estimate_cost_usd_for_results_limit(results_limit: int, n_governors: int) -> float:
+    """Estimativa PRE-run para uma extracao sem janela de data (sem
+    `onlyPostsNewerThan`, caso do branch de fallback de `pipeline.py`) --
+    `results_limit` e um teto por perfil por tipo de midia (posts e reels)
+    aplicado pela Apify, entao o pior caso -- e o unico limite que da pra
+    calcular sem rodar -- e cada perfil bater o teto nos dois tipos."""
+    worst_case_results = results_limit * 2 * n_governors
+    return round(worst_case_results / 1000 * STARTER_PRICE_PER_1000_RESULTS, 2)
+
+
 def project_backfill_costs(total_results: int, days: int) -> dict[int, float]:
     """Extrapola o total de resultados calibrado (na janela rodada) para
     janelas de 1-4 anos e converte em custo estimado no plano Starter."""

--- a/tests/test_apify_backfill_shared.py
+++ b/tests/test_apify_backfill_shared.py
@@ -4,8 +4,10 @@ from config import settings
 from scripts.apify_backfill_shared import (
     RESULTS_LIMIT_FLOOR,
     RESULTS_LIMIT_SAFETY_MARGIN_PER_DAY,
+    STARTER_PRICE_PER_1000_RESULTS,
     default_results_limit,
     estimate_cost_usd,
+    estimate_cost_usd_for_results_limit,
     load_links,
     profiles_hitting_limit,
     project_backfill_costs,
@@ -46,6 +48,20 @@ def test_project_backfill_costs_retorna_as_quatro_janelas():
     projections = project_backfill_costs(total_results=1000, days=90)
     assert set(projections.keys()) == {1, 2, 3, 4}
     assert projections[1] < projections[4]
+
+
+def test_estimate_cost_usd_for_results_limit_e_positivo_e_cresce_com_o_limite():
+    custo_baixo = estimate_cost_usd_for_results_limit(results_limit=30, n_governors=27)
+    custo_alto = estimate_cost_usd_for_results_limit(results_limit=200, n_governors=27)
+    assert custo_baixo > 0
+    assert custo_alto > custo_baixo
+
+
+def test_estimate_cost_usd_for_results_limit_considera_posts_e_reels():
+    # pior caso: cada perfil bate o teto nos dois tipos de midia (posts e reels).
+    resultado = estimate_cost_usd_for_results_limit(results_limit=100, n_governors=1)
+    esperado = round(100 * 2 / 1000 * STARTER_PRICE_PER_1000_RESULTS, 2)
+    assert resultado == esperado
 
 
 def test_load_links_le_e_normaliza_planilha(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 
 def _fake_bronze_writer_class(df_profiles, df_posts, df_reels):
@@ -171,3 +172,107 @@ def test_run_medallion_pipeline_branch_de_extracao_usa_extract_and_land(
     assert (tmp_path / "landing" / "run_extract" / "profiles.json").exists()
     assert (tmp_path / "landing" / "run_extract" / "posts.json").exists()
     assert (tmp_path / "landing" / "run_extract" / "reels.json").exists()
+
+
+def _setup_extraction_branch(monkeypatch, tmp_path):
+    """Configura o pipeline para tomar o branch de extracao real (sem
+    depender de cache), reaproveitando os mocks das outras etapas."""
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+
+    bronze_calls = []
+    monkeypatch.setattr(
+        "pipeline.BronzeWriter", _fake_bronze_writer_class_recording(bronze_calls)
+    )
+
+    fake_scraper = MagicMock()
+    fake_scraper.scrape_profiles.return_value = [{"inputUrl": "u1", "username": "gov1"}]
+    fake_scraper.scrape_posts.return_value = [{"inputUrl": "u1", "id": "p1"}]
+    fake_scraper.scrape_reels.return_value = [{"inputUrl": "u1", "id": "r1"}]
+    monkeypatch.setattr("pipeline.ApifyClient", lambda token: MagicMock())
+    monkeypatch.setattr(
+        "pipeline.InstagramScraper", lambda client, config: fake_scraper
+    )
+    monkeypatch.setattr("pipeline.settings.LANDING_DIR", tmp_path / "landing")
+    return bronze_calls
+
+
+def test_confirm_extraction_recusada_aborta_sem_extrair(monkeypatch, tmp_path):
+    """Issue #35: sem cache local, run_medallion_pipeline nao deve disparar
+    uma extracao real sem antes checar confirm_extraction."""
+    import pipeline
+
+    bronze_calls = _setup_extraction_branch(monkeypatch, tmp_path)
+
+    with pytest.raises(SystemExit):
+        pipeline.run_medallion_pipeline(
+            apify_api_token="token",
+            links=["u1"],
+            run_id="run_extract",
+            force_extract=True,
+            confirm_extraction=lambda estimated_cost: False,
+        )
+
+    assert bronze_calls == []
+
+
+def test_confirm_extraction_aceita_prossegue_com_extracao(monkeypatch, tmp_path):
+    import pipeline
+
+    bronze_calls = _setup_extraction_branch(monkeypatch, tmp_path)
+
+    pipeline.run_medallion_pipeline(
+        apify_api_token="token",
+        links=["u1"],
+        run_id="run_extract",
+        force_extract=True,
+        confirm_extraction=lambda estimated_cost: True,
+    )
+
+    assert {kind for kind, _, _ in bronze_calls} == {"profiles", "posts", "reels"}
+
+
+def test_confirm_extraction_recebe_estimativa_baseada_em_results_limit(monkeypatch, tmp_path):
+    import pipeline
+    from scripts.apify_backfill_shared import estimate_cost_usd_for_results_limit
+
+    _setup_extraction_branch(monkeypatch, tmp_path)
+    custos_recebidos = []
+
+    def _confirm(estimated_cost):
+        custos_recebidos.append(estimated_cost)
+        return True
+
+    pipeline.run_medallion_pipeline(
+        apify_api_token="token",
+        links=["u1"],
+        results_limit=50,
+        run_id="run_extract",
+        force_extract=True,
+        confirm_extraction=_confirm,
+    )
+
+    assert custos_recebidos == [estimate_cost_usd_for_results_limit(50, n_governors=1)]
+
+
+def test_confirm_extraction_nao_e_chamada_quando_bronze_ja_tem_dado(monkeypatch):
+    """O gate so faz sentido quando uma extracao real vai de fato acontecer
+    -- com a Bronze em cache, run_medallion_pipeline nunca deveria nem
+    avaliar o custo."""
+    import pipeline
+
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+
+    confirm_extraction = MagicMock()
+
+    pipeline.run_medallion_pipeline(
+        apify_api_token="token",
+        links=["l"],
+        run_id="r1",
+        confirm_extraction=confirm_extraction,
+    )
+
+    confirm_extraction.assert_not_called()


### PR DESCRIPTION
Closes #35

## Resumo

`pipeline.py` podia disparar uma extracao real e paga na Apify sem nenhum aviso de custo nem
confirmacao explicita, ao contrario de `run_apify_backfill.py`/`run_apify_calibration_test.py` (que
exigem `--yes` e mostram estimativa antes de gastar). Foi a causa raiz do estouro de creditos real
investigado na ADR 0012/issue #33.

## O que mudou

- `run_medallion_pipeline` ganha um parametro `confirm_extraction: Callable[[float], bool] | None`,
  chamado **so** quando o cache local (Bronze/raw) esta vazio e uma extracao real de fato vai
  acontecer -- nao quando ha cache-hit. `None` (default) preserva o comportamento atual para os
  testes e o notebook `01_extracao_e_limpeza_de_dados.ipynb`, que chamam a funcao programaticamente
  e nao devem ficar bloqueados por um gate interativo.
- O CLI (`__main__`) ganha a flag `--yes` (mesma semantica de `run_apify_backfill.py`) e popula
  `confirm_extraction` com uma checagem dessa flag, imprimindo uma estimativa de pior caso antes de
  abortar com `SystemExit(1)` se nao confirmado.
- Novo `estimate_cost_usd_for_results_limit` em `scripts/apify_backfill_shared.py`: o estimador
  existente (`estimate_cost_usd`) e baseado em taxa diaria (`--days`/`onlyPostsNewerThan`), que nao
  existe no branch de fallback do `pipeline.py` -- ele so tem `results_limit` (teto por perfil por
  tipo de midia). O novo estimador calcula o pior caso (cada perfil batendo o teto em posts e reels)
  usando o mesmo `STARTER_PRICE_PER_1000_RESULTS` ja compartilhado.

## Por que essa abordagem (ponto de atencao levantado na propria issue)

A decisao "vai extrair de verdade ou nao" so e conhecida dentro de `run_medallion_pipeline`
(depende de `_bronze_has_data` em tempo de execucao). Duplicar essa checagem no `__main__` para
decidir se pede confirmacao antes de chamar a funcao arriscava divergir da logica real. Um parametro
callable evita essa duplicacao e mantem o gate exatamente no ponto onde a decisao de custo e tomada.

## Fora de escopo (conforme a issue)

- Comportamento de `run_apify_backfill.py`/`run_apify_calibration_test.py` (ja tem o gate).
- Os outros achados da ADR 0012 (naming de `get_latest_profiles`, baseline de custo desatualizado do
  `estimate_cost_usd` original, segunda passada de representacao do BERTopic).

## Test plan

- [x] `uv run pytest` -- 107 passed, 3 skipped (suite completa, nenhuma quebra).
- [x] `uv run ruff check` limpo nos arquivos alterados (dois `E402` remanescentes em
      `apify_backfill_shared.py` sao pre-existentes, confirmados via `git stash` contra `main`).
- [x] Novos testes cobrem: confirmacao recusada aborta com `SystemExit` sem chamar o scraper;
      confirmacao aceita prossegue normalmente; a estimativa de custo recebida bate com
      `estimate_cost_usd_for_results_limit`; o gate NAO e chamado quando a Bronze ja tem cache.