### PR TITLE
feat(observability): implementa o logging estruturado da ADR 0015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ data/landing/
 data/backfill/
 data/calibration/
 
+# Logs estruturados por run_id (ADR 0015).
+data/logs/
+
 # Backup local de data/ antes de simular ambiente limpo (issue #33) -- nunca
 # deve ser versionado, mesmo que criado fora de data/.
 data_backup_*/

--- a/config/settings.py
+++ b/config/settings.py
@@ -60,3 +60,7 @@ GOLD_PROFILE_CLUSTERS_ENGAGEMENT = GOLD_DIR / "governor_profile_clusters_engagem
 # Checkpoints locais do estágio determinístico de modelagem (ver ADR 0003) —
 # não são Delta, ficam fora do git.
 MODEL_CHECKPOINTS_DIR = DATA_DIR / "model_checkpoints"
+
+# Logs estruturados por run_id (ver ADR 0015) -- separado de LANDING_DIR e
+# MODEL_CHECKPOINTS_DIR de propósito: log operacional não é dado de negócio.
+LOGS_DIR = DATA_DIR / "logs"

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Callable
 
@@ -15,9 +16,12 @@ from src.features.silver.comment_cleaner import CommentCleaner
 from src.features.silver.governors_metadata_cleaner import GovernorsMetadataCleaner
 from src.features.silver.post_cleaner import PostCleaner
 from src.features.silver.profile_cleaner import ProfileCleaner
+from src.logging_setup import attach_run_log_handler, configure_console_logging
 from src.modeling.config import ModelingConfig
 from src.modeling.orchestration import run_deterministic_modeling
 from src.run_id import build_run_id
+
+logger = logging.getLogger(__name__)
 
 
 def _bronze_has_data(bronze: BronzeWriter) -> bool:
@@ -61,7 +65,7 @@ def run_medallion_pipeline(
                 )
                 if not confirm_extraction(estimated_cost):
                     raise SystemExit(1)
-            print("[1/3] BRONZE: Extraindo dados brutos...")
+            logger.info("[1/3] BRONZE: Extraindo dados brutos...")
             scraper = InstagramScraper(
                 client=ApifyClient(apify_api_token),
                 config=ScraperConfig(results_limit=results_limit),
@@ -75,7 +79,7 @@ def run_medallion_pipeline(
         raise RuntimeError(f"[BRONZE] Falha na ingestão de dados brutos: {e}") from e
 
     try:
-        print("[2/3] SILVER: Limpando e conformando dados...")
+        logger.info("[2/3] SILVER: Limpando e conformando dados...")
         profile_cleaner = ProfileCleaner()
         post_cleaner = PostCleaner()
         comment_cleaner = CommentCleaner()
@@ -105,7 +109,7 @@ def run_medallion_pipeline(
         ) from e
 
     try:
-        print("[3/3] GOLD: Agregando métricas de engajamento...")
+        logger.info("[3/3] GOLD: Agregando métricas de engajamento...")
         aggregator = EngagementAggregator()
         df_gold = aggregator.aggregate(
             df_profiles_silver, df_posts_silver, df_reels_silver, run_id
@@ -120,14 +124,14 @@ def run_medallion_pipeline(
         # fora de propósito — é uma etapa manual e de revisão humana, não
         # deve rodar sozinha a cada execução do pipeline (ver ADR 0001).
         try:
-            print(
+            logger.info(
                 "[MODELAGEM] Rodando estágio determinístico "
                 "(PCA -> clustering -> sentimento -> tópicos)..."
             )
             result = run_deterministic_modeling(
                 df_reels_silver, df_comments_silver, ModelingConfig()
             )
-            print(f"[MODELAGEM] Concluída com run_id: {result.run_id}")
+            logger.info(f"[MODELAGEM] Concluída com run_id: {result.run_id}")
         except Exception as e:
             raise RuntimeError(f"[MODELAGEM] Falha no estágio determinístico: {e}") from e
 
@@ -161,6 +165,13 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    configure_console_logging()
+    # run_id gerado aqui (não deixado para run_medallion_pipeline) porque o
+    # handler de arquivo por run_id (ADR 0015) precisa ser anexado antes de
+    # qualquer trabalho começar -- inclusive antes da eventual extração real.
+    run_id = build_run_id()
+    attach_run_log_handler(run_id, settings.LOGS_DIR)
+
     df_gov = pd.read_excel(settings.GOVERNADORES_FILE)
     df_gov.columns = df_gov.columns.str.strip()
     token = os.getenv("APIFY_API_TOKEN")
@@ -169,7 +180,7 @@ if __name__ == "__main__":
     def _confirm_extraction(estimated_cost: float) -> bool:
         if args.yes:
             return True
-        print(
+        logger.info(
             f"[ABORTADO] Nao ha Bronze/raw local em cache -- rodar agora "
             f"dispararia uma extracao real na Apify (~${estimated_cost} "
             f"estimado no pior caso para {len(links)} governadores, "
@@ -182,9 +193,10 @@ if __name__ == "__main__":
         apify_api_token=token,
         links=links,
         results_limit=settings.RESULTS_LIMIT,
+        run_id=run_id,
         run_modeling=args.run_modeling,
         confirm_extraction=_confirm_extraction,
     )
     # Sem emoji: o console padrão do Windows usa cp1252 e levanta
     # UnicodeEncodeError ao imprimi-los.
-    print(f"[OK] Pipeline Medallion finalizado com run_id: {run_id}")
+    logger.info(f"[OK] Pipeline Medallion finalizado com run_id: {run_id}")

--- a/src/logging_setup.py
+++ b/src/logging_setup.py
@@ -1,0 +1,80 @@
+"""Setup de `logging` para `pipeline.py` e `src/modeling/*` (ADR 0015).
+
+Console em INFO (mesmo volume dos `print()`s que substitui); arquivo em DEBUG,
+um por `run_id`, em `data/logs/<run_id>/pipeline.log`. O handler de arquivo
+troca (não acumula) a cada `run_id` novo -- ver `attach_run_log_handler`.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+_FILE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_CONSOLE_FORMAT = "%(message)s"
+
+_current_run_file_handler: logging.FileHandler | None = None
+
+
+def configure_console_logging(level: int = logging.INFO) -> None:
+    """Configura o logger raiz para aceitar até DEBUG (a filtragem real fica a
+    cargo de cada handler) e garante um único `StreamHandler` de console, em
+    `level`. Idempotente -- seguro chamar mais de uma vez no mesmo processo."""
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+
+    for handler in root.handlers:
+        if getattr(handler, "_is_console_handler", False):
+            return
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level)
+    console_handler.setFormatter(logging.Formatter(_CONSOLE_FORMAT))
+    console_handler._is_console_handler = True  # type: ignore[attr-defined]
+    root.addHandler(console_handler)
+
+
+def attach_run_log_handler(run_id: str, logs_dir: Path) -> None:
+    """Troca o handler de arquivo (DEBUG) ativo para `<logs_dir>/<run_id>/pipeline.log`.
+
+    `logs_dir` é recebido explicitamente (não lido de `config.settings` aqui
+    dentro) para que os testes possam apontar para `tmp_path` sem sujar o
+    `data/logs/` real -- mesmo padrão já usado por `ModelingConfig.checkpoints_dir`
+    e pelos `gold_*_path` de teste.
+
+    Remove o handler do `run_id` anterior (se houver) do logger raiz e do
+    logger interno do BERTopic antes de anexar o novo -- ver ADR 0015, decisão
+    5 (log por `run_id` é trocado, não acumulado).
+
+    O BERTopic anexa seu próprio `StreamHandler` a `logging.getLogger("BERTopic")`
+    e desliga `propagate` ao se configurar (`bertopic/_bertopic.py`), então suas
+    mensagens de sub-etapa (embedding/dimensionalidade/clustering/representação)
+    só chegam a um arquivo nosso se anexarmos o handler diretamente nesse logger.
+    """
+    global _current_run_file_handler
+
+    bertopic_logger = logging.getLogger("BERTopic")
+    root = logging.getLogger()
+    # Independente de `configure_console_logging` já ter rodado ou não --
+    # quem chama isto direto (ex: run_deterministic_modeling, usado por
+    # testes e pelo notebook sem nenhum setup de console) ainda precisa que
+    # os registros DEBUG/INFO cheguem ao handler de arquivo.
+    root.setLevel(logging.DEBUG)
+
+    if _current_run_file_handler is not None:
+        root.removeHandler(_current_run_file_handler)
+        bertopic_logger.removeHandler(_current_run_file_handler)
+        _current_run_file_handler.close()
+
+    log_dir = logs_dir / run_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    file_handler = logging.FileHandler(log_dir / "pipeline.log", encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(logging.Formatter(_FILE_FORMAT))
+
+    root.addHandler(file_handler)
+    bertopic_logger.addHandler(file_handler)
+
+    _current_run_file_handler = file_handler

--- a/src/modeling/config.py
+++ b/src/modeling/config.py
@@ -82,6 +82,7 @@ class ModelingConfig:
     gold_clusters_path: Path = settings.GOLD_CLUSTERS
     gold_sentiment_path: Path = settings.GOLD_SENTIMENT
     checkpoints_dir: Path = settings.MODEL_CHECKPOINTS_DIR
+    logs_dir: Path = settings.LOGS_DIR
 
 
 @dataclass

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import pandas as pd
 from bertopic import BERTopic
 
 from src.features.gold.model_enricher import ModelEnricher
+from src.logging_setup import attach_run_log_handler
 from src.modeling.checkpoint import save_checkpoint
 from src.modeling.clustering import cluster_reels
 from src.modeling.config import GeminiRefinerConfig, ModelingConfig
@@ -17,6 +19,8 @@ from src.modeling.preprocessing import preprocess_comments
 from src.modeling.sentiment import analyze_sentiment
 from src.modeling.topics import model_topics
 from src.run_id import build_run_id
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -54,15 +58,23 @@ def run_deterministic_modeling(
     Escreve as duas tabelas Gold (clusters e sentimento/tópicos provisórios)
     sob um único `run_id` novo."""
     run_id = build_run_id(run_id)
+    # Handler de arquivo trocado aqui, não em pipeline.py -- este é o ponto
+    # onde o run_id da modelagem é de fato cunhado (ADR 0015, decisão 5).
+    attach_run_log_handler(run_id, config.logs_dir)
 
+    logger.info("[PCA] Reduzindo dimensionalidade...")
     df_reels_pca, pca_model = reduce_dimensions(df_reels, config.pca)
+
+    logger.info("[CLUSTERING] Agrupando reels...")
     df_reels_clustered, cluster_model, cluster_config, cluster_score, cluster_algo_name = (
         cluster_reels(df_reels_pca, config.cluster)
     )
 
+    logger.info("[SENTIMENTO] Analisando sentimento dos comentários...")
     df_comments_sentiment = analyze_sentiment(df_comments, config.sentiment)
     df_comments_preprocessed = preprocess_comments(df_comments_sentiment, config.preprocessing)
 
+    logger.info("[TÓPICOS] Ajustando BERTopic...")
     docs = list(df_comments_preprocessed["text_demojized"])
     topic_model, _topics, _probs, document_info = model_topics(docs, config.topics)
 

--- a/src/modeling/topics.py
+++ b/src/modeling/topics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from typing import Any
 
 import numpy as np
@@ -12,6 +14,8 @@ from hdbscan import HDBSCAN
 from sklearn.feature_extraction.text import CountVectorizer
 
 from src.modeling.config import TopicModelConfig
+
+logger = logging.getLogger(__name__)
 
 
 def model_topics(
@@ -46,7 +50,27 @@ def model_topics(
     )
 
     _topics, probs = topic_model.fit_transform(docs)
+
+    # ADR 0012/0015: `reduce_topics` recalcula a representação inteira mesmo
+    # quando não há nada a reduzir (nr_topics >= tópicos atuais) -- comportamento
+    # incondicional do BERTopic (`_bertopic.py::_reduce_topics`), não corrigido
+    # aqui, só tornado visível.
+    n_topics_before = len(topic_model.get_topics())
+    is_noop = isinstance(config.nr_topics, int) and config.nr_topics >= n_topics_before
+    if is_noop:
+        logger.debug(
+            "BERTopic.reduce_topics: no-op esperado (tópicos atuais=%d <= "
+            "nr_topics=%d), mas o BERTopic recalcula a representação mesmo "
+            "assim (achado da ADR 0012).",
+            n_topics_before,
+            config.nr_topics,
+        )
+    start = time.monotonic()
     topic_model.reduce_topics(docs, nr_topics=config.nr_topics)
+    elapsed = time.monotonic() - start
+    logger.debug(
+        "BERTopic.reduce_topics levou %.1fs (no-op=%s).", elapsed, is_noop
+    )
 
     # `reduce_topics` não retorna as atribuições atualizadas — o array
     # `_topics` de `fit_transform` fica desatualizado após a redução.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state():
+    """`src.logging_setup.attach_run_log_handler` muta o logger raiz e o
+    logger nomeado "BERTopic" globalmente (ver ADR 0015) -- sem limpeza, um
+    handler de arquivo apontando pro `tmp_path` de um teste vazaria pros
+    testes seguintes."""
+    root = logging.getLogger()
+    bertopic_logger = logging.getLogger("BERTopic")
+    root_handlers_antes = list(root.handlers)
+    bertopic_handlers_antes = list(bertopic_logger.handlers)
+
+    yield
+
+    for handler in list(root.handlers):
+        if handler not in root_handlers_antes:
+            root.removeHandler(handler)
+            handler.close()
+    for handler in list(bertopic_logger.handlers):
+        if handler not in bertopic_handlers_antes:
+            bertopic_logger.removeHandler(handler)
+            handler.close()
+
+    import src.logging_setup as logging_setup
+
+    logging_setup._current_run_file_handler = None

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,51 @@
+import logging
+
+from src.logging_setup import attach_run_log_handler, configure_console_logging
+
+
+def test_attach_run_log_handler_cria_arquivo_dentro_do_run_id(tmp_path):
+    attach_run_log_handler("run_a", tmp_path)
+
+    logging.getLogger("algum.modulo").info("mensagem de teste")
+
+    log_path = tmp_path / "run_a" / "pipeline.log"
+    assert log_path.exists()
+    assert "mensagem de teste" in log_path.read_text(encoding="utf-8")
+
+
+def test_attach_run_log_handler_troca_nao_acumula(tmp_path):
+    attach_run_log_handler("run_a", tmp_path)
+    attach_run_log_handler("run_b", tmp_path)
+
+    logging.getLogger("algum.modulo").info("so deve ir pro run_b")
+
+    log_a = (tmp_path / "run_a" / "pipeline.log").read_text(encoding="utf-8")
+    log_b = (tmp_path / "run_b" / "pipeline.log").read_text(encoding="utf-8")
+    assert "so deve ir pro run_b" not in log_a
+    assert "so deve ir pro run_b" in log_b
+
+
+def test_attach_run_log_handler_captura_logger_do_bertopic(tmp_path):
+    attach_run_log_handler("run_a", tmp_path)
+
+    # .warning() porque o BERTopic (fora de um `BERTopic(verbose=True)` real)
+    # configura seu logger em WARNING por padrão -- ver bertopic/_bertopic.py.
+    logging.getLogger("BERTopic").warning("mensagem do bertopic")
+
+    log_path = tmp_path / "run_a" / "pipeline.log"
+    assert "mensagem do bertopic" in log_path.read_text(encoding="utf-8")
+
+
+def test_configure_console_logging_e_idempotente():
+    configure_console_logging()
+    n_handlers_apos_primeira_chamada = len(
+        [h for h in logging.getLogger().handlers if getattr(h, "_is_console_handler", False)]
+    )
+
+    configure_console_logging()
+    n_handlers_apos_segunda_chamada = len(
+        [h for h in logging.getLogger().handlers if getattr(h, "_is_console_handler", False)]
+    )
+
+    assert n_handlers_apos_primeira_chamada == 1
+    assert n_handlers_apos_segunda_chamada == 1

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -71,6 +71,7 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
     )
 
     result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
@@ -110,6 +111,7 @@ def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
     )
     result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
 

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -64,6 +64,27 @@ def test_model_topics_com_embedder_fake_encontra_multiplos_topicos():
     assert topics == document_info["Topic"].tolist()
 
 
+def test_model_topics_loga_debug_quando_reduce_topics_e_noop(caplog):
+    """ADR 0012/0015: reduce_topics recalcula a representação mesmo quando
+    não há nada a reduzir -- essa checagem deve ficar visível em DEBUG."""
+    caplog.set_level("DEBUG", logger="src.modeling.topics")
+    docs = _docs_sinteticos()
+    config = TopicModelConfig(
+        hdbscan_min_cluster_size=4,
+        hdbscan_min_samples=2,
+        nr_topics=10,  # acima dos 4 tópicos que os grupos sintéticos produzem -- no-op.
+        calculate_probabilities=False,
+        verbose=False,
+    )
+
+    model_topics(docs, config, embedding_model=_FakeEmbedder())
+
+    mensagens_noop = [
+        r.getMessage() for r in caplog.records if "no-op esperado" in r.getMessage()
+    ]
+    assert len(mensagens_noop) == 1
+
+
 def test_model_topics_retorna_document_info_com_colunas_esperadas():
     docs = _docs_sinteticos()
     config = TopicModelConfig(


### PR DESCRIPTION
## Contexto -- por que este PR existe

O PR #42 mergeou a ADR 0015 (design do logging), mas foi mergeado no momento em que a branch
`logging-observability-design` so tinha o commit da ADR (`17ef58e`) -- eu tinha pushado a
implementacao real (`555326a`) *depois* desse merge, entao ela ficou orfa na branch antiga, sem
nunca chegar em `main`. Este PR traz esse commit (via cherry-pick, resolvendo o conflito esperado
com o PR #41, que ja estava mergeado) pra cima do `main` atual.

## O que este PR implementa

Fecha a lacuna: `main` tem o *design* (ADR 0015) mas nao tinha o *codigo*. Este PR adiciona:

- Novo `src/logging_setup.py`: `configure_console_logging()` (StreamHandler em INFO, idempotente,
  uma vez por processo) e `attach_run_log_handler(run_id, logs_dir)` (FileHandler em DEBUG, trocado
  -- nao acumulado -- a cada run_id novo, anexado tambem em `logging.getLogger("BERTopic")`).
- `pipeline.py` (`__main__`): gera o `run_id` da extracao antes de qualquer trabalho, liga console +
  arquivo logo no inicio; os `print()` de estagio (incluindo o do gate de custo da issue #35, PR
  #41, ja mergeado) viram `logger.info()`.
- `run_deterministic_modeling` (`src/modeling/orchestration.py`): anexa seu proprio handler no
  momento em que cunha o `run_id` da modelagem (ponto de troca, ADR 0015 decisao 5), e ganha logs de
  estagio (PCA/clustering/sentimento/topicos) que nao existiam antes.
- `ModelingConfig` ganha `logs_dir` (mesmo padrao de `checkpoints_dir`) para os testes apontarem pra
  `tmp_path` sem sujar `data/logs/` real.
- `model_topics` (`src/modeling/topics.py`): anexa o handler de arquivo em
  `logging.getLogger("BERTopic")` e adiciona checagem explicita + cronometragem do caso em que
  `reduce_topics` e um no-op mas o BERTopic recalcula representacao mesmo assim (achado da ADR 0012).
- `config/settings.py` ganha `LOGS_DIR`; `.gitignore` ganha `data/logs/`.
- Novo `tests/conftest.py` com fixture `autouse` que desfaz handlers de logging vazados entre testes.

Ver ADR 0015 (`docs/adr/0015-*.md`, ja em `main`) para o raciocinio completo por decisao de design.

## Test plan

- [x] `uv run pytest` -- 112 passed, 3 skipped (suite completa contra o `main` atual, com PR #41 ja
      incluido -- nenhuma quebra).
- [x] `uv run ruff check` limpo em todos os arquivos alterados/novos.
- [x] `uv run python pipeline.py --help` -- as duas flags (`--run-modeling` do fluxo existente e
      `--yes` do PR #41) coexistem sem conflito.
- [x] Testes cobrem: `attach_run_log_handler` cria o arquivo certo por run_id; a troca de run_id nao
      acumula; mensagens do logger `"BERTopic"` sao capturadas no arquivo; `configure_console_logging`
      e idempotente; `model_topics` loga DEBUG quando `reduce_topics` e um no-op esperado.