### PR TITLE
fix(silver): corrige parse de timestamp com formatos mistos em PostCleaner

### DIFF
--- a/src/features/silver/post_cleaner.py
+++ b/src/features/silver/post_cleaner.py
@@ -66,8 +66,16 @@ class PostCleaner:
 
     def _parse_timestamp(self, df: pd.DataFrame) -> pd.DataFrame:
         if "timestamp" in df.columns:
+            # format="ISO8601" -- sem isso, pd.to_datetime infere o formato a
+            # partir do primeiro valor da série e aplica esse formato pra
+            # série inteira; um único timestamp sem timezone misturado com o
+            # restante (com timezone, formato real do Apify) faz quase todos
+            # os outros virarem NaT silenciosamente. Isso derruba a escrita
+            # da Silver inteira, já que `data_hora` é NOT NULL no schema --
+            # e numa Bronze acumulando muitos run_id (ADR 0011), basta um
+            # registro com timestamp em formato diferente pra travar tudo.
             df["data_hora"] = (
-                pd.to_datetime(df["timestamp"], errors="coerce", utc=True)
+                pd.to_datetime(df["timestamp"], errors="coerce", utc=True, format="ISO8601")
                 .dt.tz_convert("America/Sao_Paulo")
                 .dt.tz_localize(None)
             )

--- a/tests/test_silver_cleaners.py
+++ b/tests/test_silver_cleaners.py
@@ -150,6 +150,41 @@ def test_post_cleaner_deduplica_execucoes_acumuladas():
     assert out.iloc[0]["_run_id"] == "r2"
 
 
+def test_post_cleaner_parseia_timestamps_com_formatos_mistos():
+    """
+    pd.to_datetime (sem format="ISO8601") infere o formato a partir do
+    PRIMEIRO valor da série e aplica esse formato pra série inteira -- um
+    timestamp sem timezone misturado com o restante (com timezone, formato
+    real do Apify) faz quase todos os outros virarem NaT silenciosamente.
+    Numa Bronze acumulando muitos run_id ao longo do tempo (ADR 0011), basta
+    um registro assim pra travar a escrita inteira (data_hora é NOT NULL).
+    """
+    df = pd.DataFrame(
+        {
+            "id": ["p_naive", "p_tz_1", "p_tz_2"],
+            "ownerId": ["1", "1", "1"],
+            "ownerUsername": ["g", "g", "g"],
+            "commentsCount": [1, 1, 1],
+            "likesCount": [2, 2, 2],
+            # sem timezone primeiro, de propósito -- é a ordem que dispara o bug.
+            "timestamp": [
+                "2026-05-01T00:00:00",
+                "2026-05-02T00:00:00+00:00",
+                "2026-05-03T00:00:00+00:00",
+            ],
+            "_ingested_at": pd.to_datetime(
+                ["2026-05-01", "2026-05-02", "2026-05-03"], utc=True
+            ),
+            "_run_id": ["r1", "r2", "r3"],
+        }
+    )
+
+    out = PostCleaner().clean_posts(df)
+
+    assert out["data_hora"].notna().all()
+    assert len(out) == 3
+
+
 def test_comment_cleaner_promove_colunas_do_comentario():
     """
     O join reel × comentário sufixa colunas homônimas. Os campos que


### PR DESCRIPTION
## Contexto -- como este bug foi encontrado

Simulando localmente o cenario "AWS acumulando muitos run_id ao longo do tempo" (a pedido do
usuario, pra validar o que o monitor continuo da ADR 0011 precisaria aguentar): escrevi dado
sintetico direto na Bronze via BronzeWriter, simulando 20 execucoes reais + um post recapturado em
3 execucoes sucessivas com engajamento crescendo (simula onlyPostsNewerThan com janelas
sobrepostas). Rodar `pipeline.py` em cima dessa Bronze acumulada quebrou com:

```
ValueError: Field pyarrow.Field<data_hora: timestamp[us] not null> was non-nullable but
pandas column had 1080 null values
```

## Causa raiz

`PostCleaner._parse_timestamp` fazia `pd.to_datetime(df["timestamp"], errors="coerce", utc=True)`
sem especificar `format`. O pandas infere o formato a partir do **primeiro valor** da serie e
aplica esse formato vetorizado na serie inteira -- reproduzido isoladamente: 1 timestamp sem
timezone na frente de 1080 timestamps com timezone (formato real do Apify) faz **1080 virarem NaT
silenciosamente**. Como `data_hora` e `NOT NULL` em `SILVER_POSTS_SCHEMA`/`SILVER_REELS_SCHEMA`,
isso derruba a escrita da Silver inteira.

Numa execucao unica e limpa (como o teste da ADR 0012), todos os timestamps saem no mesmo formato,
entao isso nunca apareceu. Mas numa Bronze acumulando run_id por meses (o regime que a ADR 0011
prepara), basta **um unico registro** com timestamp em formato diferente pra travar o pipeline
inteiro sem aviso.

## Fix

`format="ISO8601"` faz o pandas parsear por elemento (dentro da familia ISO8601) em vez de inferir
um formato unico vetorizado -- testado isoladamente e confirmado: zero nulos no mesmo caso que
antes gerava 1080.

## Test plan

- [x] Novo teste (`test_post_cleaner_parseia_timestamps_com_formatos_mistos`) reproduz o caso
      misto (timestamp sem timezone primeiro, timestamps com timezone depois) e confirma
      `data_hora` sem nulos.
- [x] `uv run pytest` -- 113 passed, 3 skipped (suite completa).
- [x] `uv run ruff check` limpo.
- [x] Validado tambem end-to-end contra a simulacao completa (20 run_id sinteticos + o caso do post
      recapturado com formato misto): `pipeline.py` roda sem erro com o fix, e a deduplicacao por
      `_ingested_at` continua correta (mantem a versao mais recente do post recorrente).