### PR TITLE
feat(scripts): adiciona inspect_runs.py para rastrear run_id em data/

### DIFF
--- a/scripts/inspect_runs.py
+++ b/scripts/inspect_runs.py
@@ -1,0 +1,223 @@
+"""
+Consolida os `run_id` espalhados por `data/landing/`, `data/logs/`,
+`data/model_checkpoints/`, `data/backfill/` e as colunas `_run_id` da
+Bronze/Silver/Gold numa visao unica -- sem isso, entender "o que gerou
+esse run_id e o que existe dele" exige cruzar timestamps manualmente
+entre pastas que nunca tiveram a intencao de bater 1:1 (extracao e
+modelagem sempre tem run_id proprios, ver ADR 0001; nem todo script
+loga, ver ADR 0015).
+
+`data/calibration/` fica de fora de proposito: os relatorios de
+`run_apify_calibration_test.py` nao tem `run_id` nenhum, so um
+timestamp solto (`stamp`) -- nao ha o que correlacionar.
+
+Uso:
+    uv run python scripts/inspect_runs.py                # lista todos os run_id conhecidos
+    uv run python scripts/inspect_runs.py --run-id <ID>   # detalhe de um run_id especifico
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from deltalake import DeltaTable
+
+from config import settings
+
+BRONZE_TABLES = {
+    "profiles": settings.BRONZE_PROFILES,
+    "posts": settings.BRONZE_POSTS,
+    "reels": settings.BRONZE_REELS,
+}
+SILVER_TABLES = {
+    "profiles_clean": settings.SILVER_PROFILES,
+    "posts_clean": settings.SILVER_POSTS,
+    "reels_clean": settings.SILVER_REELS,
+    "comments_clean": settings.SILVER_COMMENTS,
+    "governors_metadata": settings.SILVER_GOVERNORS_METADATA,
+}
+GOLD_TABLES = {
+    "governor_engagement": settings.GOLD_ENGAGEMENT,
+    "governor_sentiment": settings.GOLD_SENTIMENT,
+    "governor_clusters": settings.GOLD_CLUSTERS,
+    "governor_profile_clusters_engagement": settings.GOLD_PROFILE_CLUSTERS_ENGAGEMENT,
+}
+# governor_engagement e escrito por toda invocacao de run_medallion_pipeline,
+# com ou sem --run-modeling -- nao e sinal de modelagem, ao contrario dos
+# outros tres (saida de run_deterministic_modeling/lambdas/model).
+GOLD_MODELING_TABLES = {
+    "governor_sentiment",
+    "governor_clusters",
+    "governor_profile_clusters_engagement",
+}
+
+
+def _delta_run_id_counts(path) -> dict[str, int]:
+    """run_id -> contagem de linhas. {} se a tabela nao existe ou nao tem
+    a coluna _run_id (schemas Delta antigos/dado vazio)."""
+    try:
+        df = DeltaTable(str(path)).to_pandas()
+    except Exception:
+        return {}
+    if "_run_id" not in df.columns or df.empty:
+        return {}
+    return df["_run_id"].value_counts().to_dict()
+
+
+def _dir_run_ids(base: Path) -> set[str]:
+    if not base.exists():
+        return set()
+    return {p.name for p in base.iterdir() if p.is_dir()}
+
+
+def _backfill_report_run_ids() -> dict[str, Path]:
+    """run_id -> caminho do relatorio. O nome do arquivo so tem a janela e
+    um timestamp; o run_id de verdade so existe dentro do JSON."""
+    backfill_dir = settings.DATA_DIR / "backfill"
+    result: dict[str, Path] = {}
+    if not backfill_dir.exists():
+        return result
+    for report_path in backfill_dir.glob("backfill_report_*.json"):
+        try:
+            data = json.loads(report_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        run_id = data.get("run_id")
+        if run_id:
+            result[run_id] = report_path
+    return result
+
+
+def _parse_timestamp_from_run_id(run_id: str) -> str:
+    """run_id no formato de src/run_id.py::build_run_id (YYYYMMDD_HHMMSS_hex8)
+    tem o timestamp embutido; outros formatos (uuid4 do scraper legado, ids
+    sinteticos de teste, etc.) nao -- devolve "?" nesse caso."""
+    parts = run_id.split("_")
+    if len(parts) >= 2 and len(parts[0]) == 8 and len(parts[1]) == 6:
+        try:
+            return datetime.strptime(f"{parts[0]}_{parts[1]}", "%Y%m%d_%H%M%S").strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+        except ValueError:
+            pass
+    return "?"
+
+
+def collect() -> dict[str, dict]:
+    landing_ids = _dir_run_ids(settings.LANDING_DIR)
+    logs_ids = _dir_run_ids(settings.LOGS_DIR)
+    checkpoint_ids = _dir_run_ids(settings.MODEL_CHECKPOINTS_DIR)
+    backfill_reports = _backfill_report_run_ids()
+
+    bronze_counts = {name: _delta_run_id_counts(path) for name, path in BRONZE_TABLES.items()}
+    silver_counts = {name: _delta_run_id_counts(path) for name, path in SILVER_TABLES.items()}
+    gold_counts = {name: _delta_run_id_counts(path) for name, path in GOLD_TABLES.items()}
+
+    all_run_ids: set[str] = landing_ids | logs_ids | checkpoint_ids | set(backfill_reports)
+    for counts in (*bronze_counts.values(), *silver_counts.values(), *gold_counts.values()):
+        all_run_ids |= set(counts.keys())
+
+    records: dict[str, dict] = {}
+    for run_id in all_run_ids:
+        bronze = {k: v[run_id] for k, v in bronze_counts.items() if run_id in v}
+        silver = {k: v[run_id] for k, v in silver_counts.items() if run_id in v}
+        gold = {k: v[run_id] for k, v in gold_counts.items() if run_id in v}
+
+        # Extracao e modelagem nunca compartilham run_id (ADR 0001) -- se
+        # os dois sinais aparecerem juntos aqui, e sinal de colisao real
+        # (ou de dado sintetico de teste reaproveitando um id à toa).
+        # bronze so recebe linha nova numa extracao real (extract_and_land) --
+        # silver/governor_engagement sao recalculados em toda invocacao de
+        # run_medallion_pipeline, inclusive no caminho de cache-hit (sem
+        # extracao nova nenhuma), entao sozinhos nao provam extracao.
+        is_extraction = run_id in landing_ids or run_id in backfill_reports or bool(bronze)
+        is_modeling = run_id in checkpoint_ids or bool(GOLD_MODELING_TABLES & gold.keys())
+        is_etl_recalculado = bool(silver) or "governor_engagement" in gold
+
+        # Sem acento de proposito -- console do Windows (cp1252) engasga com
+        # caracteres acentuados em print() nao protegido.
+        if is_extraction and is_modeling:
+            tipo = "extracao+modelagem (!)"
+        elif is_extraction:
+            tipo = "extracao"
+        elif is_modeling:
+            tipo = "modelagem"
+        elif is_etl_recalculado:
+            tipo = "etl (cache-hit, sem extracao nova)"
+        else:
+            tipo = "desconhecido"
+
+        records[run_id] = {
+            "tipo": tipo,
+            "quando": _parse_timestamp_from_run_id(run_id),
+            "landing": run_id in landing_ids,
+            "logs": run_id in logs_ids,
+            "checkpoint": run_id in checkpoint_ids,
+            "backfill_report": backfill_reports.get(run_id),
+            "bronze": bronze,
+            "silver": silver,
+            "gold": gold,
+        }
+    return records
+
+
+def print_list(records: dict[str, dict]) -> None:
+    if not records:
+        print("Nenhum run_id encontrado em data/.")
+        return
+
+    header = (
+        f"{'run_id':<38} {'tipo':<24} {'quando':<20} "
+        f"{'landing':<8} {'logs':<6} {'ckpt':<6} {'bronze':<8} {'silver':<8} {'gold':<8}"
+    )
+    print(header)
+    print("-" * len(header))
+    for run_id, r in sorted(records.items(), key=lambda kv: kv[1]["quando"]):
+        print(
+            f"{run_id:<38} {r['tipo']:<24} {r['quando']:<20} "
+            f"{'sim' if r['landing'] else '-':<8} {'sim' if r['logs'] else '-':<6} "
+            f"{'sim' if r['checkpoint'] else '-':<6} "
+            f"{sum(r['bronze'].values()) or '-':<8} "
+            f"{sum(r['silver'].values()) or '-':<8} "
+            f"{sum(r['gold'].values()) or '-':<8}"
+        )
+
+
+def print_detail(run_id: str, records: dict[str, dict]) -> None:
+    # Sem acento de proposito -- console do Windows (cp1252) engasga com
+    # caracteres acentuados em print() nao protegido.
+    r = records.get(run_id)
+    if r is None:
+        print(f"run_id '{run_id}' nao encontrado em nenhuma fonte conhecida (landing/logs/checkpoint/backfill/Bronze/Silver/Gold).")
+        return
+
+    print(f"run_id: {run_id}")
+    print(f"  tipo: {r['tipo']}")
+    print(f"  quando (se codificado no run_id): {r['quando']}")
+    print(f"  landing zone: {settings.LANDING_DIR / run_id if r['landing'] else 'nao'}")
+    print(f"  log: {settings.LOGS_DIR / run_id / 'pipeline.log' if r['logs'] else 'nao'}")
+    print(f"  checkpoint de modelagem: {settings.MODEL_CHECKPOINTS_DIR / run_id if r['checkpoint'] else 'nao'}")
+    print(f"  relatorio de backfill: {r['backfill_report'] or 'nao'}")
+    print(f"  Bronze: {r['bronze'] or 'nenhuma linha'}")
+    print(f"  Silver: {r['silver'] or 'nenhuma linha'}")
+    print(f"  Gold: {r['gold'] or 'nenhuma linha'}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Inspeciona os run_id espalhados por data/ (landing, logs, checkpoints, backfill, Bronze/Silver/Gold)."
+    )
+    parser.add_argument(
+        "--run-id", default=None, help="Mostra o detalhe de um run_id específico em vez da lista completa."
+    )
+    args = parser.parse_args()
+
+    all_records = collect()
+    if args.run_id:
+        print_detail(args.run_id, all_records)
+    else:
+        print_list(all_records)

--- a/tests/test_inspect_runs.py
+++ b/tests/test_inspect_runs.py
@@ -1,0 +1,165 @@
+import json
+
+import pandas as pd
+
+from scripts.inspect_runs import (
+    _backfill_report_run_ids,
+    _dir_run_ids,
+    _parse_timestamp_from_run_id,
+    collect,
+    print_detail,
+    print_list,
+)
+
+
+def test_dir_run_ids_lista_subdiretorios(tmp_path):
+    (tmp_path / "run_a").mkdir()
+    (tmp_path / "run_b").mkdir()
+    (tmp_path / "arquivo_solto.txt").write_text("nao e um run_id")
+
+    assert _dir_run_ids(tmp_path) == {"run_a", "run_b"}
+
+
+def test_dir_run_ids_diretorio_inexistente(tmp_path):
+    assert _dir_run_ids(tmp_path / "nao_existe") == set()
+
+
+def test_backfill_report_run_ids_le_de_dentro_do_json(tmp_path, monkeypatch):
+    monkeypatch.setattr("scripts.inspect_runs.settings.DATA_DIR", tmp_path)
+    backfill_dir = tmp_path / "backfill"
+    backfill_dir.mkdir()
+    (backfill_dir / "backfill_report_1d_20260830T190037Z.json").write_text(
+        json.dumps({"run_id": "run_backfill_1", "window_days": 1})
+    )
+    (backfill_dir / "backfill_report_corrompido.json").write_text("{nao e json valido")
+
+    result = _backfill_report_run_ids()
+
+    assert set(result.keys()) == {"run_backfill_1"}
+
+
+def test_parse_timestamp_from_run_id_formato_build_run_id():
+    assert _parse_timestamp_from_run_id("20260830_190146_bffaff02") == "2026-08-30 19:01:46"
+
+
+def test_parse_timestamp_from_run_id_formato_desconhecido():
+    assert _parse_timestamp_from_run_id("a8f36a6f-4644-4588-be24-5bb53d564c57") == "?"
+
+
+class _FakeDeltaTable:
+    """Substitui deltalake.DeltaTable nos testes -- devolve um DataFrame
+    fixo por caminho, sem precisar escrever uma tabela Delta de verdade."""
+
+    _tables: dict[str, pd.DataFrame] = {}
+
+    def __init__(self, path, storage_options=None):
+        if path not in self._tables:
+            raise FileNotFoundError(path)
+        self._df = self._tables[path]
+
+    def to_pandas(self):
+        return self._df
+
+
+def test_collect_classifica_extracao_e_modelagem_separadamente(tmp_path, monkeypatch):
+    landing_dir = tmp_path / "landing"
+    logs_dir = tmp_path / "logs"
+    checkpoints_dir = tmp_path / "checkpoints"
+    (landing_dir / "run_extracao").mkdir(parents=True)
+    (checkpoints_dir / "run_modelagem").mkdir(parents=True)
+
+    monkeypatch.setattr("scripts.inspect_runs.settings.DATA_DIR", tmp_path)
+    monkeypatch.setattr("scripts.inspect_runs.settings.LANDING_DIR", landing_dir)
+    monkeypatch.setattr("scripts.inspect_runs.settings.LOGS_DIR", logs_dir)
+    monkeypatch.setattr("scripts.inspect_runs.settings.MODEL_CHECKPOINTS_DIR", checkpoints_dir)
+
+    _FakeDeltaTable._tables = {
+        "bronze_profiles": pd.DataFrame({"_run_id": ["run_extracao", "run_extracao"]}),
+        "gold_sentiment": pd.DataFrame({"_run_id": ["run_modelagem"]}),
+    }
+    monkeypatch.setattr("scripts.inspect_runs.DeltaTable", _FakeDeltaTable)
+    monkeypatch.setattr(
+        "scripts.inspect_runs.BRONZE_TABLES", {"profiles": "bronze_profiles"}
+    )
+    monkeypatch.setattr("scripts.inspect_runs.SILVER_TABLES", {})
+    monkeypatch.setattr(
+        "scripts.inspect_runs.GOLD_TABLES", {"governor_sentiment": "gold_sentiment"}
+    )
+
+    records = collect()
+
+    assert records["run_extracao"]["tipo"] == "extracao"
+    assert records["run_extracao"]["bronze"] == {"profiles": 2}
+    assert records["run_extracao"]["landing"] is True
+    assert records["run_extracao"]["checkpoint"] is False
+
+    assert records["run_modelagem"]["tipo"] == "modelagem"
+    assert records["run_modelagem"]["gold"] == {"governor_sentiment": 1}
+    assert records["run_modelagem"]["checkpoint"] is True
+    assert records["run_modelagem"]["landing"] is False
+
+
+def test_collect_run_recalculado_via_cache_hit_nao_e_classificado_como_modelagem(
+    tmp_path, monkeypatch
+):
+    """governor_engagement e recalculado em toda invocacao de
+    run_medallion_pipeline (cache-hit incluso, sem extracao nova nenhuma) --
+    sozinho, nao deve classificar o run_id como "modelagem"."""
+    monkeypatch.setattr("scripts.inspect_runs.settings.DATA_DIR", tmp_path)
+    monkeypatch.setattr("scripts.inspect_runs.settings.LANDING_DIR", tmp_path / "landing")
+    monkeypatch.setattr("scripts.inspect_runs.settings.LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        "scripts.inspect_runs.settings.MODEL_CHECKPOINTS_DIR", tmp_path / "checkpoints"
+    )
+
+    _FakeDeltaTable._tables = {
+        "gold_engagement": pd.DataFrame({"_run_id": ["run_cache_hit"]}),
+    }
+    monkeypatch.setattr("scripts.inspect_runs.DeltaTable", _FakeDeltaTable)
+    monkeypatch.setattr("scripts.inspect_runs.BRONZE_TABLES", {})
+    monkeypatch.setattr("scripts.inspect_runs.SILVER_TABLES", {})
+    monkeypatch.setattr(
+        "scripts.inspect_runs.GOLD_TABLES", {"governor_engagement": "gold_engagement"}
+    )
+
+    records = collect()
+
+    assert records["run_cache_hit"]["tipo"] == "etl (cache-hit, sem extracao nova)"
+
+
+def test_print_list_sem_registros_nao_quebra(capsys):
+    print_list({})
+    assert "Nenhum run_id encontrado" in capsys.readouterr().out
+
+
+def test_print_detail_run_id_nao_encontrado(capsys):
+    print_detail("run_inexistente", {})
+    assert "nao encontrado" in capsys.readouterr().out
+
+
+def test_print_detail_run_id_encontrado_mostra_fontes(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("scripts.inspect_runs.settings.LANDING_DIR", tmp_path / "landing")
+    monkeypatch.setattr("scripts.inspect_runs.settings.LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr(
+        "scripts.inspect_runs.settings.MODEL_CHECKPOINTS_DIR", tmp_path / "checkpoints"
+    )
+    records = {
+        "run_x": {
+            "tipo": "extracao",
+            "quando": "2026-08-30 19:01:46",
+            "landing": True,
+            "logs": False,
+            "checkpoint": False,
+            "backfill_report": None,
+            "bronze": {"profiles": 27},
+            "silver": {},
+            "gold": {},
+        }
+    }
+
+    print_detail("run_x", records)
+
+    saida = capsys.readouterr().out
+    assert "run_x" in saida
+    assert "extracao" in saida
+    assert "profiles" in saida


### PR DESCRIPTION
## Contexto

Usuario ficou confuso ao ver run_id diferentes em data/landing/, data/logs/ e
data/model_checkpoints/ sem baterem entre si -- e essa e a intencao real do design (ADR 0001:
extracao e modelagem nunca compartilham run_id; ADR 0015: logging so cobre pipeline.py/
src/modeling, nao os scripts utilitarios), mas nao existia nenhuma ferramenta pra consultar isso,
so cruzar timestamps manualmente.

## O que este PR adiciona

`scripts/inspect_runs.py`, com dois modos:

- **Lista** (`uv run python scripts/inspect_runs.py`): tabela com todo run_id conhecido (varrendo
  `data/landing/`, `data/logs/`, `data/model_checkpoints/`, `data/backfill/` e as colunas
  `_run_id` de Bronze/Silver/Gold), classificado como `extracao` / `modelagem` /
  `etl (cache-hit, sem extracao nova)` / `desconhecido`, com contagem de linhas por camada.
- **Detalhe** (`--run-id <ID>`): caminhos exatos (landing/log/checkpoint) e contagem por tabela
  pra um run_id especifico.

`data/calibration/` fica de fora de proposito -- os relatorios de `run_apify_calibration_test.py`
nao tem `run_id` nenhum, so um timestamp solto (`stamp`), entao nao ha o que correlacionar.

## Achado ao validar contra dado real

A primeira versao classificava qualquer run_id com linha em *qualquer* tabela Gold como
"modelagem" -- errado, porque `governor_engagement` e recalculado (overwrite) em toda invocacao
de `run_medallion_pipeline`, inclusive no caminho de cache-hit sem nenhuma extracao nova. Corrigido
pra so contar `governor_sentiment`/`governor_clusters`/`governor_profile_clusters_engagement` como
sinal real de modelagem -- e isso revelou uma categoria nova genuina (`etl (cache-hit, sem
extracao nova)`) pra runs que so recalcularam Silver/engagement sem extrair nada.

## Test plan

- [x] `uv run pytest` -- 122 passed, 3 skipped (suite completa, 10 testes novos).
- [x] `uv run ruff check` limpo.
- [x] Rodado contra o `data/` real do projeto (`DATA_DIR=... uv run python scripts/inspect_runs.py`
      e com `--run-id`) -- a saida bateu com o mapeamento manual feito na conversa com o usuario.
- [x] Strings impressas sem acento de proposito -- confirmado que o console Windows (cp1252)
      mangulava "extração"/"não"/"relatório" antes da correcao.