### PR TITLE
fix+feat(scripts): corrige alinhamento e liga modelagem ao run_id pai em inspect_runs.py

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -129,7 +129,7 @@ def run_medallion_pipeline(
                 "(PCA -> clustering -> sentimento -> tópicos)..."
             )
             result = run_deterministic_modeling(
-                df_reels_silver, df_comments_silver, ModelingConfig()
+                df_reels_silver, df_comments_silver, ModelingConfig(), parent_run_id=run_id
             )
             logger.info(f"[MODELAGEM] Concluída com run_id: {result.run_id}")
         except Exception as e:

--- a/scripts/inspect_runs.py
+++ b/scripts/inspect_runs.py
@@ -138,16 +138,19 @@ def collect() -> dict[str, dict]:
         is_modeling = run_id in checkpoint_ids or bool(GOLD_MODELING_TABLES & gold.keys())
         is_etl_recalculado = bool(silver) or "governor_engagement" in gold
 
-        # Sem acento de proposito -- console do Windows (cp1252) engasga com
-        # caracteres acentuados em print() nao protegido.
+        # Curto de proposito -- ver LEGENDA_TIPOS, impressa junto da tabela
+        # (uma string longa aqui estoura a largura da coluna e desalinha
+        # tudo depois dela). Sem acento tambem de proposito -- console do
+        # Windows (cp1252) engasga com caracteres acentuados em print() nao
+        # protegido.
         if is_extraction and is_modeling:
-            tipo = "extracao+modelagem (!)"
+            tipo = "extracao+modelagem(!)"
         elif is_extraction:
             tipo = "extracao"
         elif is_modeling:
             tipo = "modelagem"
         elif is_etl_recalculado:
-            tipo = "etl (cache-hit, sem extracao nova)"
+            tipo = "etl-cache-hit"
         else:
             tipo = "desconhecido"
 
@@ -165,26 +168,58 @@ def collect() -> dict[str, dict]:
     return records
 
 
+LEGENDA_TIPOS = {
+    "etl-cache-hit": "Silver/governor_engagement recalculados via cache-hit, sem extracao nova",
+    "extracao+modelagem(!)": "mesmo run_id com sinal de extracao E de modelagem -- nao deveria acontecer (ADR 0001), investigar",
+}
+
+_COLUNAS = ["run_id", "tipo", "quando", "landing", "logs", "ckpt", "bronze", "silver", "gold"]
+
+
+def _linha(r: dict) -> list[str]:
+    return [
+        r["tipo"],
+        r["quando"],
+        "sim" if r["landing"] else "-",
+        "sim" if r["logs"] else "-",
+        "sim" if r["checkpoint"] else "-",
+        str(sum(r["bronze"].values()) or "-"),
+        str(sum(r["silver"].values()) or "-"),
+        str(sum(r["gold"].values()) or "-"),
+    ]
+
+
 def print_list(records: dict[str, dict]) -> None:
     if not records:
         print("Nenhum run_id encontrado em data/.")
         return
 
-    header = (
-        f"{'run_id':<38} {'tipo':<24} {'quando':<20} "
-        f"{'landing':<8} {'logs':<6} {'ckpt':<6} {'bronze':<8} {'silver':<8} {'gold':<8}"
-    )
-    print(header)
-    print("-" * len(header))
-    for run_id, r in sorted(records.items(), key=lambda kv: kv[1]["quando"]):
-        print(
-            f"{run_id:<38} {r['tipo']:<24} {r['quando']:<20} "
-            f"{'sim' if r['landing'] else '-':<8} {'sim' if r['logs'] else '-':<6} "
-            f"{'sim' if r['checkpoint'] else '-':<6} "
-            f"{sum(r['bronze'].values()) or '-':<8} "
-            f"{sum(r['silver'].values()) or '-':<8} "
-            f"{sum(r['gold'].values()) or '-':<8}"
-        )
+    ordenados = sorted(records.items(), key=lambda kv: kv[1]["quando"])
+    linhas = [[run_id, *_linha(r)] for run_id, r in ordenados]
+
+    # Largura por coluna calculada a partir do conteudo real (nao um chute
+    # fixo) -- um valor mais longo que o esperado (ex: "extracao+modelagem(!)")
+    # so alarga a coluna dele, nunca desalinha as outras.
+    larguras = [
+        max(len(_COLUNAS[i]), max((len(linha[i]) for linha in linhas), default=0))
+        for i in range(len(_COLUNAS))
+    ]
+
+    def _formata(valores: list[str]) -> str:
+        return "  ".join(v.ljust(w) for v, w in zip(valores, larguras))
+
+    cabecalho = _formata(_COLUNAS)
+    print(cabecalho)
+    print("-" * len(cabecalho))
+    for linha in linhas:
+        print(_formata(linha))
+
+    tipos_presentes = {r["tipo"] for r in records.values()}
+    legenda_relevante = {t: LEGENDA_TIPOS[t] for t in tipos_presentes if t in LEGENDA_TIPOS}
+    if legenda_relevante:
+        print()
+        for tipo, explicacao in legenda_relevante.items():
+            print(f"{tipo} = {explicacao}")
 
 
 def print_detail(run_id: str, records: dict[str, dict]) -> None:

--- a/scripts/inspect_runs.py
+++ b/scripts/inspect_runs.py
@@ -11,9 +11,16 @@ loga, ver ADR 0015).
 `run_apify_calibration_test.py` nao tem `run_id` nenhum, so um
 timestamp solto (`stamp`) -- nao ha o que correlacionar.
 
+O `run_id` de modelagem nunca reaproveita o `run_id` da extracao/invocacao de
+`pipeline.py` que a disparou (ADR 0001) -- mas `run_deterministic_modeling`
+grava esse `run_id` de origem como `parent_run_id`, so em `metadata.json`
+do checkpoint, puramente informativo. E o que permite ligar as duas pontas
+aqui e no modo `--pipeline`.
+
 Uso:
-    uv run python scripts/inspect_runs.py                # lista todos os run_id conhecidos
-    uv run python scripts/inspect_runs.py --run-id <ID>   # detalhe de um run_id especifico
+    uv run python scripts/inspect_runs.py                    # lista todos os run_id conhecidos
+    uv run python scripts/inspect_runs.py --run-id <ID>       # detalhe de um run_id especifico
+    uv run python scripts/inspect_runs.py --pipeline <ID>     # extracao <ID> + toda modelagem que ela disparou
 """
 
 import argparse
@@ -74,6 +81,25 @@ def _dir_run_ids(base: Path) -> set[str]:
     return {p.name for p in base.iterdir() if p.is_dir()}
 
 
+def _checkpoint_parent_ids(base: Path) -> dict[str, str | None]:
+    """run_id de modelagem -> parent_run_id lido de dentro do metadata.json
+    do checkpoint. None se o checkpoint foi gravado antes desse campo
+    existir, ou se metadata.json esta ausente/corrompido."""
+    result: dict[str, str | None] = {}
+    if not base.exists():
+        return result
+    for checkpoint_dir in base.iterdir():
+        if not checkpoint_dir.is_dir():
+            continue
+        try:
+            data = json.loads((checkpoint_dir / "metadata.json").read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            result[checkpoint_dir.name] = None
+            continue
+        result[checkpoint_dir.name] = data.get("parent_run_id")
+    return result
+
+
 def _backfill_report_run_ids() -> dict[str, Path]:
     """run_id -> caminho do relatorio. O nome do arquivo so tem a janela e
     um timestamp; o run_id de verdade so existe dentro do JSON."""
@@ -112,6 +138,7 @@ def collect() -> dict[str, dict]:
     logs_ids = _dir_run_ids(settings.LOGS_DIR)
     checkpoint_ids = _dir_run_ids(settings.MODEL_CHECKPOINTS_DIR)
     backfill_reports = _backfill_report_run_ids()
+    checkpoint_parents = _checkpoint_parent_ids(settings.MODEL_CHECKPOINTS_DIR)
 
     bronze_counts = {name: _delta_run_id_counts(path) for name, path in BRONZE_TABLES.items()}
     silver_counts = {name: _delta_run_id_counts(path) for name, path in SILVER_TABLES.items()}
@@ -164,6 +191,7 @@ def collect() -> dict[str, dict]:
             "bronze": bronze,
             "silver": silver,
             "gold": gold,
+            "parent_run_id": checkpoint_parents.get(run_id),
         }
     return records
 
@@ -173,13 +201,16 @@ LEGENDA_TIPOS = {
     "extracao+modelagem(!)": "mesmo run_id com sinal de extracao E de modelagem -- nao deveria acontecer (ADR 0001), investigar",
 }
 
-_COLUNAS = ["run_id", "tipo", "quando", "landing", "logs", "ckpt", "bronze", "silver", "gold"]
+_COLUNAS = [
+    "run_id", "tipo", "quando", "pai", "landing", "logs", "ckpt", "bronze", "silver", "gold"
+]
 
 
 def _linha(r: dict) -> list[str]:
     return [
         r["tipo"],
         r["quando"],
+        r["parent_run_id"] or "-",
         "sim" if r["landing"] else "-",
         "sim" if r["logs"] else "-",
         "sim" if r["checkpoint"] else "-",
@@ -233,6 +264,10 @@ def print_detail(run_id: str, records: dict[str, dict]) -> None:
     print(f"run_id: {run_id}")
     print(f"  tipo: {r['tipo']}")
     print(f"  quando (se codificado no run_id): {r['quando']}")
+    print(
+        f"  run_id pai (extracao/pipeline que disparou esta modelagem): "
+        f"{r['parent_run_id'] or 'desconhecido (checkpoint sem o campo, ou nao e modelagem)'}"
+    )
     print(f"  landing zone: {settings.LANDING_DIR / run_id if r['landing'] else 'nao'}")
     print(f"  log: {settings.LOGS_DIR / run_id / 'pipeline.log' if r['logs'] else 'nao'}")
     print(f"  checkpoint de modelagem: {settings.MODEL_CHECKPOINTS_DIR / run_id if r['checkpoint'] else 'nao'}")
@@ -242,6 +277,34 @@ def print_detail(run_id: str, records: dict[str, dict]) -> None:
     print(f"  Gold: {r['gold'] or 'nenhuma linha'}")
 
 
+def print_pipeline(run_id: str, records: dict[str, dict]) -> None:
+    """Mostra `run_id` (extracao/invocacao de pipeline.py) e toda modelagem
+    cujo parent_run_id aponta pra ele -- a visao de "o que rodou nessa
+    execucao completa do pipeline"."""
+    if run_id not in records:
+        print(f"run_id '{run_id}' nao encontrado em nenhuma fonte conhecida.")
+        return
+
+    filhos = [
+        filho_id
+        for filho_id, r in records.items()
+        if r["parent_run_id"] == run_id
+    ]
+
+    print(f"=== {run_id} (extracao/pipeline) ===")
+    print_detail(run_id, records)
+
+    if not filhos:
+        print()
+        print("Nenhuma modelagem encontrada com este run_id como pai (checkpoints antigos, sem o campo, tambem nao aparecem aqui).")
+        return
+
+    for filho_id in sorted(filhos, key=lambda fid: records[fid]["quando"]):
+        print()
+        print(f"=== {filho_id} (modelagem disparada por {run_id}) ===")
+        print_detail(filho_id, records)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Inspeciona os run_id espalhados por data/ (landing, logs, checkpoints, backfill, Bronze/Silver/Gold)."
@@ -249,10 +312,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--run-id", default=None, help="Mostra o detalhe de um run_id específico em vez da lista completa."
     )
+    parser.add_argument(
+        "--pipeline",
+        default=None,
+        metavar="RUN_ID",
+        help="Mostra RUN_ID (extração/invocação de pipeline.py) e toda modelagem disparada por ele (parent_run_id).",
+    )
     args = parser.parse_args()
 
     all_records = collect()
-    if args.run_id:
+    if args.pipeline:
+        print_pipeline(args.pipeline, all_records)
+    elif args.run_id:
         print_detail(args.run_id, all_records)
     else:
         print_list(all_records)

--- a/src/modeling/checkpoint.py
+++ b/src/modeling/checkpoint.py
@@ -26,6 +26,7 @@ class DeterministicCheckpoint:
     cluster_score: float
     cluster_algo_name: str | None
     embedding_model_name: str
+    parent_run_id: str | None = None
 
 
 def save_checkpoint(
@@ -42,6 +43,7 @@ def save_checkpoint(
     cluster_algo_name: str | None,
     embedding_model_name: str,
     checkpoints_dir: Path | None = None,
+    parent_run_id: str | None = None,
 ) -> Path:
     """Grava o checkpoint de `run_id` em `<checkpoints_dir>/<run_id>/`.
 
@@ -54,7 +56,14 @@ def save_checkpoint(
     O modelo de embedding não é reserializado junto do `topic_model`
     (`save_embedding_model=False`) — é grande, compartilhado entre execuções
     e já reproduzível a partir do nome (`embedding_model_name`), então
-    duplicá-lo a cada checkpoint só desperdiçaria disco."""
+    duplicá-lo a cada checkpoint só desperdiçaria disco.
+
+    `parent_run_id`, se informado, é o `run_id` da execução (extração ou
+    invocação de `pipeline.py`) que disparou esta modelagem -- puramente
+    informativo, gravado só em `metadata.json`. Não substitui nem se mistura
+    com o `run_id` da própria modelagem (ADR 0001: cada estágio mantém seu
+    `run_id` imutável); serve só pra reconstruir depois qual pipeline
+    completo gerou qual checkpoint (ver `scripts/inspect_runs.py`)."""
     checkpoint_dir = (checkpoints_dir or settings.MODEL_CHECKPOINTS_DIR) / run_id
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
 
@@ -79,6 +88,7 @@ def save_checkpoint(
         "cluster_algo_name": cluster_algo_name,
         "embedding_model_name": embedding_model_name,
         "pca_feature_columns": pca_feature_columns,
+        "parent_run_id": parent_run_id,
     }
     (checkpoint_dir / "metadata.json").write_text(
         json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8"
@@ -121,4 +131,7 @@ def load_checkpoint(
         cluster_score=metadata["cluster_score"],
         cluster_algo_name=metadata["cluster_algo_name"],
         embedding_model_name=metadata["embedding_model_name"],
+        # .get() -- checkpoints gravados antes deste campo existir nao tem
+        # a chave no metadata.json.
+        parent_run_id=metadata.get("parent_run_id"),
     )

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -35,6 +35,7 @@ class DeterministicModelingResult:
     cluster_algo_name: str | None
     docs: list[str]
     run_id: str
+    parent_run_id: str | None = None
 
 
 def _merge_topic_info(df_comments: pd.DataFrame, document_info: pd.DataFrame) -> pd.DataFrame:
@@ -52,11 +53,17 @@ def run_deterministic_modeling(
     df_comments: pd.DataFrame,
     config: ModelingConfig,
     run_id: str | None = None,
+    parent_run_id: str | None = None,
 ) -> DeterministicModelingResult:
     """Estágio 100% automatizável: PCA -> clustering -> sentimento -> tópicos
     (representação determinística via KeyBERTInspired, não via Gemini).
     Escreve as duas tabelas Gold (clusters e sentimento/tópicos provisórios)
-    sob um único `run_id` novo."""
+    sob um único `run_id` novo.
+
+    `parent_run_id`, se informado, é só rastreabilidade -- o `run_id` da
+    extração/invocação de `pipeline.py` que disparou esta chamada, gravado
+    no checkpoint (ver `save_checkpoint`). Nunca substitui o `run_id` novo
+    que esta função sempre cunha para a modelagem (ADR 0001)."""
     run_id = build_run_id(run_id)
     # Handler de arquivo trocado aqui, não em pipeline.py -- este é o ponto
     # onde o run_id da modelagem é de fato cunhado (ADR 0015, decisão 5).
@@ -101,6 +108,7 @@ def run_deterministic_modeling(
         cluster_algo_name=cluster_algo_name,
         embedding_model_name=config.topics.embedding_model,
         checkpoints_dir=config.checkpoints_dir,
+        parent_run_id=parent_run_id,
     )
 
     return DeterministicModelingResult(
@@ -114,6 +122,7 @@ def run_deterministic_modeling(
         cluster_algo_name=cluster_algo_name,
         docs=docs,
         run_id=run_id,
+        parent_run_id=parent_run_id,
     )
 
 

--- a/tests/test_inspect_runs.py
+++ b/tests/test_inspect_runs.py
@@ -4,11 +4,13 @@ import pandas as pd
 
 from scripts.inspect_runs import (
     _backfill_report_run_ids,
+    _checkpoint_parent_ids,
     _dir_run_ids,
     _parse_timestamp_from_run_id,
     collect,
     print_detail,
     print_list,
+    print_pipeline,
 )
 
 
@@ -142,6 +144,7 @@ def test_print_list_mantem_colunas_alinhadas_com_tipo_longo(capsys):
             "bronze": {},
             "silver": {},
             "gold": {"governor_sentiment": 10},
+            "parent_run_id": None,
         },
         "run_tipo_longo": {
             "tipo": "etl-cache-hit",
@@ -153,6 +156,7 @@ def test_print_list_mantem_colunas_alinhadas_com_tipo_longo(capsys):
             "bronze": {},
             "silver": {"profiles_clean": 5},
             "gold": {"governor_engagement": 3},
+            "parent_run_id": None,
         },
     }
 
@@ -194,6 +198,7 @@ def test_print_detail_run_id_encontrado_mostra_fontes(tmp_path, monkeypatch, cap
             "bronze": {"profiles": 27},
             "silver": {},
             "gold": {},
+            "parent_run_id": None,
         }
     }
 
@@ -203,3 +208,117 @@ def test_print_detail_run_id_encontrado_mostra_fontes(tmp_path, monkeypatch, cap
     assert "run_x" in saida
     assert "extracao" in saida
     assert "profiles" in saida
+
+
+def test_checkpoint_parent_ids_le_de_dentro_do_metadata(tmp_path):
+    checkpoint_dir = tmp_path / "run_modelagem"
+    checkpoint_dir.mkdir()
+    (checkpoint_dir / "metadata.json").write_text(
+        json.dumps({"parent_run_id": "run_extracao", "cluster_score": 0.5})
+    )
+    (tmp_path / "run_sem_campo").mkdir()
+    (tmp_path / "run_sem_campo" / "metadata.json").write_text(json.dumps({"cluster_score": 0.1}))
+    (tmp_path / "run_corrompido").mkdir()
+    (tmp_path / "run_corrompido" / "metadata.json").write_text("{nao e json valido")
+
+    result = _checkpoint_parent_ids(tmp_path)
+
+    assert result["run_modelagem"] == "run_extracao"
+    assert result["run_sem_campo"] is None
+    assert result["run_corrompido"] is None
+
+
+def test_collect_liga_modelagem_ao_run_id_pai_via_checkpoint(tmp_path, monkeypatch):
+    checkpoints_dir = tmp_path / "checkpoints"
+    (checkpoints_dir / "run_modelagem").mkdir(parents=True)
+    (checkpoints_dir / "run_modelagem" / "metadata.json").write_text(
+        json.dumps({"parent_run_id": "run_extracao_pai"})
+    )
+
+    monkeypatch.setattr("scripts.inspect_runs.settings.DATA_DIR", tmp_path)
+    monkeypatch.setattr("scripts.inspect_runs.settings.LANDING_DIR", tmp_path / "landing")
+    monkeypatch.setattr("scripts.inspect_runs.settings.LOGS_DIR", tmp_path / "logs")
+    monkeypatch.setattr("scripts.inspect_runs.settings.MODEL_CHECKPOINTS_DIR", checkpoints_dir)
+    monkeypatch.setattr("scripts.inspect_runs.BRONZE_TABLES", {})
+    monkeypatch.setattr("scripts.inspect_runs.SILVER_TABLES", {})
+    monkeypatch.setattr("scripts.inspect_runs.GOLD_TABLES", {})
+
+    records = collect()
+
+    assert records["run_modelagem"]["parent_run_id"] == "run_extracao_pai"
+
+
+def test_print_pipeline_agrupa_extracao_e_modelagem_filha(capsys):
+    records = {
+        "run_pai": {
+            "tipo": "extracao",
+            "quando": "2026-08-30 19:00:00",
+            "landing": True,
+            "logs": False,
+            "checkpoint": False,
+            "backfill_report": None,
+            "bronze": {"profiles": 27},
+            "silver": {},
+            "gold": {},
+            "parent_run_id": None,
+        },
+        "run_filho": {
+            "tipo": "modelagem",
+            "quando": "2026-08-30 19:05:00",
+            "landing": False,
+            "logs": False,
+            "checkpoint": True,
+            "backfill_report": None,
+            "bronze": {},
+            "silver": {},
+            "gold": {"governor_sentiment": 100},
+            "parent_run_id": "run_pai",
+        },
+        "run_nao_relacionado": {
+            "tipo": "modelagem",
+            "quando": "2026-08-29 10:00:00",
+            "landing": False,
+            "logs": False,
+            "checkpoint": True,
+            "backfill_report": None,
+            "bronze": {},
+            "silver": {},
+            "gold": {"governor_sentiment": 5},
+            "parent_run_id": "outro_run_qualquer",
+        },
+    }
+
+    print_pipeline("run_pai", records)
+
+    saida = capsys.readouterr().out
+    assert "run_pai" in saida
+    assert "run_filho" in saida
+    assert "run_nao_relacionado" not in saida
+
+
+def test_print_pipeline_sem_filhos_avisa_mas_nao_quebra(capsys):
+    records = {
+        "run_sozinho": {
+            "tipo": "extracao",
+            "quando": "2026-08-30 19:00:00",
+            "landing": True,
+            "logs": False,
+            "checkpoint": False,
+            "backfill_report": None,
+            "bronze": {"profiles": 27},
+            "silver": {},
+            "gold": {},
+            "parent_run_id": None,
+        }
+    }
+
+    print_pipeline("run_sozinho", records)
+
+    saida = capsys.readouterr().out
+    assert "run_sozinho" in saida
+    assert "Nenhuma modelagem encontrada" in saida
+
+
+def test_print_pipeline_run_id_nao_encontrado(capsys):
+    print_pipeline("run_inexistente", {})
+    assert "nao encontrado" in capsys.readouterr().out

--- a/tests/test_inspect_runs.py
+++ b/tests/test_inspect_runs.py
@@ -124,7 +124,47 @@ def test_collect_run_recalculado_via_cache_hit_nao_e_classificado_como_modelagem
 
     records = collect()
 
-    assert records["run_cache_hit"]["tipo"] == "etl (cache-hit, sem extracao nova)"
+    assert records["run_cache_hit"]["tipo"] == "etl-cache-hit"
+
+
+def test_print_list_mantem_colunas_alinhadas_com_tipo_longo(capsys):
+    """Um valor de "tipo" mais longo que os outros (ex: etl-cache-hit) nao
+    pode desalinhar as colunas seguintes -- a largura de cada coluna e
+    calculada a partir do conteudo real, nao um chute fixo."""
+    records = {
+        "run_curto": {
+            "tipo": "modelagem",
+            "quando": "2026-08-30 19:01:46",
+            "landing": False,
+            "logs": True,
+            "checkpoint": True,
+            "backfill_report": None,
+            "bronze": {},
+            "silver": {},
+            "gold": {"governor_sentiment": 10},
+        },
+        "run_tipo_longo": {
+            "tipo": "etl-cache-hit",
+            "quando": "2026-08-31 00:03:00",
+            "landing": False,
+            "logs": True,
+            "checkpoint": False,
+            "backfill_report": None,
+            "bronze": {},
+            "silver": {"profiles_clean": 5},
+            "gold": {"governor_engagement": 3},
+        },
+    }
+
+    print_list(records)
+
+    linhas_tabela = [
+        linha
+        for linha in capsys.readouterr().out.splitlines()
+        if linha and not linha.startswith("-") and "=" not in linha
+    ]
+    larguras = {len(linha) for linha in linhas_tabela}
+    assert len(larguras) == 1, f"linhas com larguras diferentes: {linhas_tabela}"
 
 
 def test_print_list_sem_registros_nao_quebra(capsys):


### PR DESCRIPTION
## Parte 1 -- fix de alinhamento

Usuario reportou que a tabela do modo lista de `scripts/inspect_runs.py` (PR #46) ficava
desalinhada: `"etl (cache-hit, sem extracao nova)"` (35 caracteres) estourava a largura fixa da
coluna `tipo` (`:<24`), empurrando as colunas seguintes pra fora de alinhamento nessa linha.

- Rotulos de tipo encurtados (`etl-cache-hit`, `extracao+modelagem(!)`), com uma `LEGENDA_TIPOS`
  impressa depois da tabela so quando algum desses tipos aparece.
- `print_list` agora calcula a largura de cada coluna a partir do conteudo real (o maior valor da
  coluna, nunca menor que o cabecalho) em vez de uma largura fixa chutada.

## Parte 2 -- run_id pai (extracao -> modelagem)

Usuario perguntou se nao seria melhor ter um run_id conectando os outros por tipo, e como mapear
um pipeline completo onde tudo rodou.

Decisao: **nao** adicionar uma coluna atravessando os schemas Delta (Bronze/Silver/Gold) -- vai
contra o design da ADR 0001 (cada estagio mantem seu `run_id` proprio e imutavel) e exigiria
migrar schema em varias tabelas pra resolver um problema so de rastreabilidade. Em vez disso:

- `save_checkpoint`/`load_checkpoint` ganham `parent_run_id` opcional, gravado/lido do
  `metadata.json` do checkpoint (JSON solto, nao schema Delta -- 100% backward-compatible,
  checkpoints antigos sem o campo continuam carregando normalmente via `.get()`).
- `run_deterministic_modeling` repassa `parent_run_id` pro checkpoint, sem nunca substituir o
  `run_id` proprio que a modelagem sempre cunha.
- `pipeline.py` passa `parent_run_id=run_id` (o da extracao) ao chamar `run_deterministic_modeling`.
- `scripts/inspect_runs.py`: nova coluna "pai" no modo lista, nova linha no modo `--run-id`, e um
  modo novo `--pipeline <RUN_ID>` que mostra a extracao/invocacao de `pipeline.py` e toda
  modelagem que ela disparou de uma vez.

## Test plan

- [x] `uv run pytest` -- 129 passed, 3 skipped (suite completa).
- [x] `uv run ruff check` limpo.
- [x] Novo teste confirma alinhamento de colunas mesmo com "tipo" bem mais longo que os outros.
- [x] Novos testes cobrem `_checkpoint_parent_ids`, `collect()` ligando modelagem ao pai via
      checkpoint, e `print_pipeline` (agrupa corretamente, ignora run_id nao relacionados, nao
      quebra sem filhos nem com run_id inexistente).
- [x] Rodado contra o `data/` real do projeto -- checkpoints gravados antes desta mudanca (sem o
      campo) aparecem corretamente como "-"/desconhecido, sem quebrar `--pipeline` nem a lista.
- [ ] Ainda nao validado com uma modelagem nova de ponta a ponta (exigiria rodar
      `pipeline.py --run-modeling`, ~10 min) -- a logica de gravacao/leitura esta coberta por
      teste unitario, mas vale um smoke test real na proxima rodada de modelagem.