### PR TITLE
feat(modeling): torna parent_run_id obrigatorio nos pontos de entrada reais

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,11 @@ Passar `force_extract=True` pula direto para a API.
 O notebook 03 não dispara mais nenhuma escrita — só lê Gold/checkpoint para análise (ver [ADR 0003](docs/adr/0003-desacoplar-modelagem-do-notebook-via-scripts-cli-com-checkpoint.md)). Os disparadores são dois scripts em `scripts/`:
 
 ```bash
-uv run python scripts/run_modeling.py                  # estágio determinístico, sobre a Silver existente
-uv run python scripts/refine_topics.py --run-id <ID>    # refinamento manual via Gemini, sobre o checkpoint acima
+uv run python scripts/run_modeling.py --parent-run-id <RUN_ID_DA_EXTRACAO>  # estágio determinístico, sobre a Silver existente
+uv run python scripts/refine_topics.py --run-id <ID>                       # refinamento manual via Gemini, sobre o checkpoint acima
 ```
+
+`--parent-run-id` é obrigatório — é o `run_id` da extração/invocação de `pipeline.py` que gerou a Silver sendo usada aqui, gravado no checkpoint só para rastreabilidade (dados → modelo, ver `scripts/inspect_runs.py --pipeline`); nunca substitui o `run_id` próprio que a modelagem sempre cunha (ADR 0001). Não dá para inferir isso sozinho porque a Silver pode ter dado de múltiplas extrações antigas misturadas — rode `uv run python scripts/inspect_runs.py` primeiro se não souber qual foi.
 
 `run_modeling.py` imprime o `run_id` usado — é esse valor que vai em `--run-id` do `refine_topics.py` (e em `RUN_ID` no notebook 03). Cada chamada de `run_deterministic_modeling` (daqui, do `pipeline.py --run-modeling`, ou do notebook, se alguém ainda chamar diretamente) grava incondicionalmente um checkpoint local em `data/model_checkpoints/<run_id>/` — o `topic_model` do BERTopic, o `df_comments`/`df_reels` provisórios e os modelos de PCA/clustering — porque sem isso o refinamento via Gemini só poderia rodar no mesmo processo que acabou de ajustar o `topic_model`. `refine_topics.py` atualiza esse checkpoint com os rótulos finais depois de refinar.
 
@@ -420,7 +422,7 @@ cp .env.example .env      # editar e preencher APIFY_API_TOKEN
 uv run python pipeline.py
 
 # 5. (opcional) Modelagem — preencher API_GEMINI no .env antes do segundo comando
-uv run python scripts/run_modeling.py
+uv run python scripts/run_modeling.py --parent-run-id <RUN_ID_IMPRESSO_NO_PASSO_4>
 uv run python scripts/refine_topics.py --run-id <ID_IMPRESSO_ACIMA>
 
 # 6. Abrir os dashboards

--- a/scripts/run_modeling.py
+++ b/scripts/run_modeling.py
@@ -20,13 +20,13 @@ from src.modeling.orchestration import run_deterministic_modeling
 from src.repositories.delta_repository import DeltaRepository
 
 
-def run(run_id: str | None = None) -> str:
+def run(run_id: str | None = None, parent_run_id: str | None = None) -> str:
     repo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
     df_reels = repo.load_reels()
     df_comments = repo.load_comments()
 
     result = run_deterministic_modeling(
-        df_reels, df_comments, ModelingConfig(), run_id=run_id
+        df_reels, df_comments, ModelingConfig(), run_id=run_id, parent_run_id=parent_run_id
     )
     return result.run_id
 
@@ -43,9 +43,22 @@ if __name__ == "__main__":
         default=None,
         help="run_id a usar para esta execucao (default: gerado automaticamente).",
     )
+    parser.add_argument(
+        "--parent-run-id",
+        required=True,
+        help=(
+            "run_id da extracao/execucao de pipeline.py que gerou a Silver sendo usada aqui -- "
+            "obrigatorio para rastreabilidade completa (dados -> modelo, ver "
+            "scripts/inspect_runs.py --pipeline). A Silver pode ter dado de multiplas extracoes "
+            "misturadas (overwrite por _run_id mais recente por linha), entao nao da pra inferir "
+            "isso sozinho; se voce nao souber qual foi, rode "
+            "'uv run python scripts/inspect_runs.py' para descobrir o run_id de extracao mais "
+            "recente antes de rodar este script."
+        ),
+    )
     args = parser.parse_args()
 
-    run_id = run(run_id=args.run_id)
+    run_id = run(run_id=args.run_id, parent_run_id=args.parent_run_id)
     # Sem emoji: o console padrao do Windows usa cp1252 e levanta
     # UnicodeEncodeError ao imprimi-los.
     print(f"[OK] Modelagem deterministica concluida com run_id: {run_id}")

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -68,6 +68,11 @@ def run_deterministic_modeling(
     # Handler de arquivo trocado aqui, não em pipeline.py -- este é o ponto
     # onde o run_id da modelagem é de fato cunhado (ADR 0015, decisão 5).
     attach_run_log_handler(run_id, config.logs_dir)
+    # Primeira linha do log da modelagem, sempre -- rastreabilidade completa
+    # (dados -> modelo) exige que quem abrir só este arquivo, sem checar o
+    # checkpoint, já saiba de qual execução esta modelagem veio (ou que não
+    # tem uma, se parent_run_id não foi informado).
+    logger.debug("parent_run_id: %s", parent_run_id or "nenhum (execução standalone)")
 
     logger.info("[PCA] Reduzindo dimensionalidade...")
     df_reels_pca, pca_model = reduce_dimensions(df_reels, config.pca)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -90,6 +91,44 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
     assert (checkpoint_dir / "df_comments.parquet").exists()
     assert (checkpoint_dir / "pca_model.joblib").exists()
     assert (checkpoint_dir / "cluster_model.joblib").exists()
+
+
+def test_run_deterministic_modeling_grava_parent_run_id_como_primeira_linha_do_log(
+    monkeypatch, tmp_path
+):
+    """Rastreabilidade completa (dados -> modelo, pedido do usuario) exige
+    que quem abrir so o arquivo de log da modelagem, sem checar o
+    checkpoint, ja saiba de qual execucao ela veio."""
+    monkeypatch.setattr(
+        "src.modeling.orchestration.analyze_sentiment", _fake_analyze_sentiment
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.model_topics",
+        _make_fake_model_topics("0_provisorio", "0_refinado"),
+    )
+
+    config = ModelingConfig(
+        cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
+        gold_clusters_path=tmp_path / "governor_clusters",
+        gold_sentiment_path=tmp_path / "governor_sentiment",
+        checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
+    )
+
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), config, parent_run_id="run_extracao_pai"
+    )
+
+    assert result.parent_run_id == "run_extracao_pai"
+
+    log_path = config.logs_dir / result.run_id / "pipeline.log"
+    primeira_linha = log_path.read_text(encoding="utf-8").splitlines()[0]
+    assert "parent_run_id: run_extracao_pai" in primeira_linha
+
+    metadata = json.loads(
+        (config.checkpoints_dir / result.run_id / "metadata.json").read_text(encoding="utf-8")
+    )
+    assert metadata["parent_run_id"] == "run_extracao_pai"
 
 
 def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(

--- a/tests/test_run_modeling_script.py
+++ b/tests/test_run_modeling_script.py
@@ -27,6 +27,25 @@ def test_run_le_silver_e_chama_run_deterministic_modeling(monkeypatch):
     assert kwargs["run_id"] == "run_fixo"
 
 
+def test_run_repassa_parent_run_id_para_o_orquestrador(monkeypatch):
+    import scripts.run_modeling as run_modeling_script
+
+    fake_repo = MagicMock()
+    fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
+    fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
+
+    fake_run_deterministic_modeling = MagicMock(return_value=MagicMock(run_id="run_abc"))
+    monkeypatch.setattr(
+        "scripts.run_modeling.run_deterministic_modeling", fake_run_deterministic_modeling
+    )
+
+    run_modeling_script.run(run_id="run_fixo", parent_run_id="run_extracao_pai")
+
+    kwargs = fake_run_deterministic_modeling.call_args.kwargs
+    assert kwargs["parent_run_id"] == "run_extracao_pai"
+
+
 def test_run_sem_run_id_deixa_orquestrador_gerar_um_novo(monkeypatch):
     import scripts.run_modeling as run_modeling_script
 


### PR DESCRIPTION
## Contexto

Usuario pediu que todo log gerado tenha o `run_id` pai preenchido obrigatoriamente, para conseguir
rastrear tudo dos dados ao modelo (seguindo o `parent_run_id` do PR #47). Duas decisoes tomadas
explicitamente com o usuario antes de implementar:

### 1. Onde travar a obrigatoriedade

**Nao** na funcao `run_deterministic_modeling` em si -- continua aceitando `parent_run_id=None`,
entao testes e o notebook nao quebram. A obrigatoriedade trava nos **pontos de entrada reais**:

- `pipeline.py` ja sempre passava `parent_run_id=run_id` (PR anterior) -- automatico, usuario nao
  faz nada.
- `scripts/run_modeling.py` ganha `--parent-run-id` **obrigatorio** na CLI (sem default -- argparse
  recusa rodar sem ele, com mensagem de erro clara). Nao da pra inferir isso sozinho porque a
  Silver pode ter dado de multiplas extracoes antigas misturadas (overwrite por `_run_id` mais
  recente por linha) -- o usuario declara explicitamente qual extracao gerou o dado sendo modelado
  (e pode descobrir isso com `scripts/inspect_runs.py` se nao souber).

### 2. Onde o parent_run_id aparece

Alem do `metadata.json` do checkpoint (ja feito no PR #47), agora tambem como a **primeira linha do
proprio arquivo de log da modelagem**: `run_deterministic_modeling` loga
`parent_run_id: <X ou 'nenhum (execucao standalone)'>` em DEBUG logo apos anexar o handler de
arquivo, antes de qualquer outra linha -- rastreavel abrindo so o log, sem precisar checar o
checkpoint.

## Mudancas

- `src/modeling/orchestration.py`: nova linha de log logo apos `attach_run_log_handler`.
- `scripts/run_modeling.py`: `--parent-run-id` obrigatorio na CLI; `run()` ganha o parametro
  (opcional, repassado pro orquestrador).
- `README.md`: dois exemplos de comando corrigidos (quebrariam sem `--parent-run-id` agora).

## Test plan

- [x] `uv run pytest` -- 131 passed, 3 skipped (suite completa).
- [x] `uv run ruff check` limpo (4 `E402` remanescentes em `scripts/run_modeling.py` sao
      pre-existentes, confirmados via `git stash` contra `main`).
- [x] `uv run python scripts/run_modeling.py` (sem `--parent-run-id`) -- confirmado que falha com
      mensagem clara do argparse.
- [x] Novo teste em `test_orchestration.py` confirma que `parent_run_id` e a primeira linha do
      arquivo de log e que aparece no `metadata.json`.
- [x] Novo teste em `test_run_modeling_script.py` confirma que `run()` repassa `parent_run_id` pro
      orquestrador.
- [x] Rodado contra o `data/` real do projeto (`scripts/run_modeling.py --parent-run-id <ID real>`)
      -- o processo foi interrompido no meio do BERTopic (encerramento de sessao, nao um bug), mas
      o log parcial gerado (`data/logs/20260831_022905_eadf8aa0/pipeline.log`) confirma a linha
      `parent_run_id: 20260831_020452_31f96256` como primeira linha, exatamente como desenhado.
      Nenhum checkpoint nem escrita em Gold aconteceu antes da interrupcao (nada corrompido).