### PR TITLE
feat(gold): tabela de histórico de engajamento + ADR 0016 (monitoramento diário)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,13 @@ flowchart LR
 |---|---|---|---|---|
 | **Bronze** | `data/bronze/` | `instagram_profiles`, `instagram_posts`, `instagram_reels` | `src/data_extract/bronze_writer.py` | Imutabilidade — append-only, nada é sobrescrito |
 | **Silver** | `data/silver/` | `profiles_clean`, `posts_clean`, `reels_clean`, `comments_clean` | `src/features/silver/*_cleaner.py` | Conformidade — tipos, deduplicação, comentários explodidos |
-| **Gold** | `data/gold/` | `governor_engagement`, `governor_sentiment`, `governor_clusters` | `src/features/gold/*` | Prontidão — métricas agregadas, resultados de modelagem |
+| **Gold** | `data/gold/` | `governor_engagement`, `governor_engagement_history`, `governor_sentiment`, `governor_clusters` | `src/features/gold/*` | Prontidão — métricas agregadas, resultados de modelagem |
+
+`governor_engagement_history` é uma tabela paralela ao `governor_engagement`, mesmo schema, escrita
+em modo `append` a cada execução (`governor_engagement` continua em `overwrite`, sem mudança para os
+consumidores existentes) — acumula uma linha por governador por execução, a base para mostrar
+tendência de engajamento ao longo do tempo. Sentimento e clusters ainda não têm tabela de histórico
+equivalente (ver [ADR 0016](docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md)).
 
 ### Leitura dos dados
 
@@ -475,9 +481,13 @@ Esta seção registra honestamente o que ainda não está fechado.
 
 **Pendências de documentação.** Os capítulos 6 (Resultados) e 7 (Conclusões) do TCC ainda estão no texto-modelo, embora os resultados já existam e estejam redigidos no capítulo 5.
 
+**Dashboard ainda é estático — histórico em Gold existe, mas nada o lê de volta ainda.** `governor_engagement_history` (ver seção 3 acima) acumula uma linha por governador a cada execução do pipeline desde esta versão, mas `app.py`/`pages/01_exploratory.py` continuam lendo a Gold uma única vez ao abrir, sem auto-refresh nem gráfico de tendência. Agendamento automático das Lambdas (EventBridge/cron) também segue pendente, com um gate de custo alternável planejado mas não implementado. Ver [ADR 0016](docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md) para o desenho completo e o que falta.
+
 ### Próximos passos
 
 1. Completar os capítulos 6 (Resultados) e 7 (Conclusões) do TCC
+2. Auto-refresh no dashboard consumindo `governor_engagement_history` (ADR 0016)
+3. Toggle de confirmação automática + regra EventBridge para o regime incremental/diário (ADR 0016)
 
 ---
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -53,6 +53,10 @@ SILVER_GOVERNORS_METADATA = SILVER_DIR / "governors_metadata"
 
 GOLD_DIR = DATA_DIR / "gold"
 GOLD_ENGAGEMENT = GOLD_DIR / "governor_engagement"
+# Tabela paralela de histórico (mesmo schema, modo append) -- só para
+# engajamento por enquanto, ver ADR 0016. `governor_engagement` continua em
+# overwrite, inalterada para os consumidores existentes.
+GOLD_ENGAGEMENT_HISTORY = GOLD_DIR / "governor_engagement_history"
 GOLD_SENTIMENT = GOLD_DIR / "governor_sentiment"
 GOLD_CLUSTERS = GOLD_DIR / "governor_clusters"
 GOLD_PROFILE_CLUSTERS_ENGAGEMENT = GOLD_DIR / "governor_profile_clusters_engagement"

--- a/docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md
+++ b/docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md
@@ -1,0 +1,107 @@
+---
+status: accepted
+---
+
+# Preparar o Streamlit para monitoramento diário: histórico em Gold primeiro, auto-refresh no dashboard, agendamento alternável — antes de subir para a AWS
+
+## Contexto
+
+O handoff de 2026-08-31 registrou o pedido do usuário: transformar o dashboard Streamlit num
+monitoramento diário das métricas dos governadores, acompanhável em "tempo real", **antes** de
+aplicar a infraestrutura AWS (`terraform apply` continua pendente). O handoff explicitamente pediu
+para não redesenhar do zero — a ADR 0011 já é o design que antecipa esse cenário (landing zone,
+extração consolidada, histórico em Gold) — e apontou quatro perguntas em aberto que só o usuário
+podia responder.
+
+Investigando o estado real do código antes de perguntar, duas das três decisões da ADR 0011 já
+estavam implementadas, ao contrário do que o handoff presumia:
+
+1. **Landing zone** (decisão 1) — implementada no PR #32 (`src/data_extract/ingestion.py::archive_raw_json`),
+   com o layout por `run_id` já corrigido pela ADR 0014.
+2. **Extração consolidada** (decisão 2) — implementada em `src/data_extract/ingestion.py::extract_and_land`,
+   já usada pelos três pontos de entrada (`pipeline.py`, `scripts/run_apify_backfill.py`,
+   `lambdas/extract/handler.py`).
+3. **Histórico em Gold** (decisão 3) — **não implementada**. Nenhuma tabela `_history` existe;
+   `EngagementAggregator.write` sempre grava em `mode="overwrite"` (via `write_delta`, que já aceita
+   um parâmetro `mode` desde a ADR 0011, sem uso ainda). Único item real desta ADR ainda pendente.
+
+Uma rodada de perguntas diretas ao usuário (via `AskUserQuestion`, seguindo o padrão de "pergunta a
+pergunta, com recomendação" que o handoff sugeriu) resolveu os quatro pontos em aberto.
+
+## Decisão
+
+1. **"Tempo real" = auto-refresh periódico**, não streaming nem só um botão manual. O dashboard, já
+   aberto, recarrega sozinho a cada N minutos, relendo a Gold via `DeltaRepository` — reflete a
+   última execução do pipeline sem precisar reiniciar o app.
+2. **Gold ganha histórico, mas só para engajamento por enquanto.** Nova tabela paralela
+   `governor_engagement_history`, mesmo schema de `governor_engagement`
+   (`GOLD_ENGAGEMENT_SCHEMA`, que já carimba `_run_id`/`_generated_at` em cada linha), escrita em
+   `mode="append"` a cada execução — ao lado da tabela atual, que continua em `overwrite` sem
+   nenhuma mudança para os consumidores existentes. `governor_sentiment`/`governor_clusters`/
+   `governor_profile_clusters_engagement` **não** ganham histórico nesta ADR — ligados à modelagem
+   (cadência própria, mais pesada, não roda a cada extração diária), diferente do engajamento, que é
+   subproduto direto de cada extração. Estender histórico a eles fica deferido, mesmo raciocínio de
+   "sem caso concreto ainda" que a ADR 0011 já usou para adiar outras peças.
+3. **Agendamento com gate de custo alternável, não fixo.** EventBridge/cron passa a disparar o
+   regime incremental/diário (`RESULTS_LIMIT` fixo, sem `--days`) na Lambda orquestradora. A
+   confirmação de custo vira uma variável de configuração (env var/Terraform var na orquestradora,
+   ex. `AUTO_CONFIRM_DAILY_EXTRACTION`) em vez de um comportamento fixo no código: `false` (padrão)
+   bloqueia o disparo agendado sem confirmação humana e loga a estimativa de custo, igual ao gate
+   manual de hoje (`pipeline.py`, issue #35); `true` deixa o disparo agendado prosseguir sozinho. O
+   backfill nunca lê esse toggle — continua sempre manual, sem exceção, exatamente como a ADR 0011
+   já havia decidido.
+4. **Fonte de leitura do dashboard: continua local.** Nenhuma mudança em `DeltaRepository` ou nos
+   caminhos que o dashboard lê. Migrar para S3 vira troca de configuração de path quando
+   `terraform apply` de fato acontecer — `DeltaRepository` já abstrai isso via `storage_options`.
+5. **Ordem de implementação: histórico em Gold primeiro, dashboard depois.** Sem histórico, não há
+   tendência real para o dashboard mostrar — só o estado da última execução. Implementar o
+   auto-refresh antes do histórico arriscaria redesenhar o dashboard duas vezes.
+
+## Por que
+
+Cada decisão veio de uma resposta explícita do usuário a uma pergunta com recomendação, não de uma
+suposição:
+
+- Auto-refresh: "Não pensei nisso, mas acho que um auto-refresh pode ser suficiente" — confirma a
+  recomendação original (streaming seria complexidade desproporcional ao volume de dados; um botão
+  manual não é "passivo" o suficiente para contar como monitoramento).
+- Agendamento alternável: "Eu gostaria de uma mistura de 1 e 2. Poder alternar entre essas opções,
+  como se eu pudesse 'habilitar' a confirmação automática" — rejeita explicitamente as duas opções
+  fixas (sempre manual / sempre automático) em favor de um toggle.
+- Fonte local: "Continua lendo local até a infra subir" — confirma a recomendação original,
+  evitando trabalho adiantado sem bucket real para testar contra.
+- Histórico primeiro: "Implementar histórico primeiro (landing zone + consolidação + tabelas
+  append)" — a investigação de código mostrou que landing zone e consolidação já estavam prontas;
+  o que resta desse pedido é só as tabelas de histórico.
+
+## Opções consideradas
+
+- **Streaming de verdade (websocket/push)** — rejeitada pelo usuário implicitamente ao aceitar a
+  recomendação de auto-refresh; volume de dados (extração diária, não por segundo) não justifica a
+  complexidade.
+- **Agendamento 100% manual, sem EventBridge** ou **100% automático, sem confirmação** — ambas
+  rejeitadas explicitamente; o usuário quer poder alternar entre os dois regimes, não fixar um.
+- **Já desenhar o dashboard para ler S3 diretamente** — rejeitada; sem bucket real aplicado, seria
+  implementação adiantada e não testável de verdade.
+- **Dashboard primeiro, histórico depois** — rejeitada; o usuário priorizou explicitamente o
+  histórico, evitando redesenhar o dashboard duas vezes.
+- **Estender histórico a `governor_sentiment`/`governor_clusters` já nesta ADR** — não perguntada
+  diretamente ao usuário; adiada por ora pelo mesmo raciocínio de "sem caso concreto ainda" que o
+  projeto já usa em decisões análogas (ver ADR 0011, ADR 0004/0005). Fica como decisão futura
+  separada se o monitoramento diário precisar de tendência de sentimento também.
+
+## Consequências
+
+- **Implementado nesta sessão:** `governor_engagement_history` (tabela Gold nova, append,
+  `GOLD_ENGAGEMENT_SCHEMA` reutilizado sem mudança), `EngagementAggregator.write` ganha parâmetro
+  `mode`, `pipeline.py` e `lambdas/load/handler.py` passam a escrever também na tabela de histórico,
+  `settings.GOLD_ENGAGEMENT_HISTORY` novo, `DeltaRepository.load_engagement_history()` novo.
+- **Não implementado nesta sessão, registrado como próximo passo:** auto-refresh no dashboard
+  (`app.py`/`pages/01_exploratory.py`) consumindo `governor_engagement_history`; o toggle
+  `AUTO_CONFIRM_DAILY_EXTRACTION` na Lambda orquestradora e a regra EventBridge correspondente em
+  `infra/main.tf` (aditiva, como o README já apontava). Nenhum dos dois exige `terraform apply` para
+  ser escrito — só para ser aplicado de fato, que continua sendo decisão manual do autor.
+- Até o auto-refresh existir, o dashboard continua estático (lê a Gold uma vez, sem recarregar
+  sozinho) — a tabela de histórico já existe e acumula dados, mas nada ainda a lê de volta.
+- Sentimento e clusters continuam sem histórico — visualizar tendência dessas métricas ao longo do
+  tempo fica fora de escopo até haver necessidade concreta, mesmo depois desta ADR.

--- a/lambdas/load/handler.py
+++ b/lambdas/load/handler.py
@@ -38,6 +38,8 @@ def handler(event, context):
     aggregator = EngagementAggregator()
     df_gold = aggregator.aggregate(df_profiles, df_posts, df_reels, run_id)
     aggregator.write(df_gold, f"{gold_base}governor_engagement")
+    # Tabela paralela de histórico, mode=append -- ver ADR 0016.
+    aggregator.write(df_gold, f"{gold_base}governor_engagement_history", mode="append")
 
     return {
         "statusCode": 200,

--- a/pipeline.py
+++ b/pipeline.py
@@ -115,6 +115,10 @@ def run_medallion_pipeline(
             df_profiles_silver, df_posts_silver, df_reels_silver, run_id
         )
         aggregator.write(df_gold, settings.GOLD_ENGAGEMENT)
+        # Tabela paralela de histórico, mode=append -- não substitui a
+        # tabela acima, que continua overwrite para os consumidores
+        # existentes (ver ADR 0016).
+        aggregator.write(df_gold, settings.GOLD_ENGAGEMENT_HISTORY, mode="append")
     except Exception as e:
         raise RuntimeError(f"[GOLD] Falha na agregação de métricas: {e}") from e
 

--- a/src/features/gold/engagement_aggregator.py
+++ b/src/features/gold/engagement_aggregator.py
@@ -76,5 +76,5 @@ class EngagementAggregator:
 
         return df
 
-    def write(self, df_gold: pd.DataFrame, path: Path | str) -> None:
-        write_delta(path, df_gold, GOLD_ENGAGEMENT_SCHEMA)
+    def write(self, df_gold: pd.DataFrame, path: Path | str, mode: str = "overwrite") -> None:
+        write_delta(path, df_gold, GOLD_ENGAGEMENT_SCHEMA, mode=mode)

--- a/src/repositories/delta_repository.py
+++ b/src/repositories/delta_repository.py
@@ -38,6 +38,13 @@ class DeltaRepository(DataRepository):
     def load_profiles(self) -> pd.DataFrame:
         return self._load(_join(self._gold_dir, "governor_engagement"))
 
+    def load_engagement_history(self) -> pd.DataFrame:
+        """Histórico de engajamento (mode append, uma linha por perfil por
+        execução) -- ver ADR 0016. Separada de `load_profiles` porque tem
+        granularidade diferente (várias linhas por governador ao longo do
+        tempo, não uma só)."""
+        return self._load(_join(self._gold_dir, "governor_engagement_history"))
+
     def load_posts(self) -> pd.DataFrame:
         if self._silver_dir is None:
             raise ValueError("silver_dir não foi configurado neste repositório.")

--- a/tests/test_delta_repository.py
+++ b/tests/test_delta_repository.py
@@ -43,3 +43,36 @@ def test_delta_repository_basic(tmp_path):
     repo = DeltaRepository(gold_dir=gold)
     out = repo.load_profiles()
     assert "% ENGAJAMENTO" in out.columns
+
+
+def test_load_engagement_history_acumula_varias_execucoes(tmp_path):
+    gold = tmp_path
+    history_path = gold / "governor_engagement_history"
+    df_r1 = pd.DataFrame(
+        {
+            "id": ["1"],
+            "username": ["g"],
+            "TOTAL ENGAJAMENTO": [10],
+            "% ENGAJAMENTO": [0.1],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    df_r2 = pd.DataFrame(
+        {
+            "id": ["1"],
+            "username": ["g"],
+            "TOTAL ENGAJAMENTO": [20],
+            "% ENGAJAMENTO": [0.2],
+            "_run_id": ["r2"],
+            "_generated_at": pd.to_datetime(["2026-05-02"], utc=True),
+        }
+    )
+    write_deltalake(str(history_path), df_r1, mode="overwrite")
+    write_deltalake(str(history_path), df_r2, mode="append")
+
+    repo = DeltaRepository(gold_dir=gold)
+    out = repo.load_engagement_history()
+
+    assert len(out) == 2
+    assert set(out["_run_id"]) == {"r1", "r2"}

--- a/tests/test_engagement_aggregator.py
+++ b/tests/test_engagement_aggregator.py
@@ -5,6 +5,25 @@ from src.features.gold.engagement_aggregator import EngagementAggregator
 from src.schemas_delta import GOLD_ENGAGEMENT_SCHEMA
 
 
+def test_write_repassa_mode_para_write_delta(monkeypatch):
+    """A tabela de histórico (ADR 0016) depende de `write` repassar `mode`
+    para `write_delta` -- sem isso, toda escrita seria sempre overwrite,
+    e a tabela _history nunca acumularia mais de uma linha por run."""
+    captured = {}
+
+    def fake_write_delta(path, df, schema, mode="overwrite"):
+        captured["path"] = path
+        captured["mode"] = mode
+
+    monkeypatch.setattr(
+        "src.features.gold.engagement_aggregator.write_delta", fake_write_delta
+    )
+
+    EngagementAggregator().write(pd.DataFrame(), "some/path", mode="append")
+
+    assert captured["mode"] == "append"
+
+
 def _perfis():
     return pd.DataFrame(
         {

--- a/tests/test_load_lambda.py
+++ b/tests/test_load_lambda.py
@@ -69,9 +69,12 @@ def test_load_handler(monkeypatch):
 
     monkeypatch.setattr("deltalake.DeltaTable", DummyDT)
 
-    # Stub gold writer to avoid real Delta writes
+    # Stub gold writer to avoid real Delta writes, capturing calls so we can
+    # assert the history table (ADR 0016) also gets written, in append mode.
+    write_calls = []
     monkeypatch.setattr(
-        "src.features.gold.engagement_aggregator.write_delta", lambda *a, **k: None
+        "src.features.gold.engagement_aggregator.write_delta",
+        lambda path, df, schema, mode="overwrite": write_calls.append((path, mode)),
     )
 
     from lambdas.load import handler as load_handler
@@ -81,6 +84,13 @@ def test_load_handler(monkeypatch):
     body = json.loads(resp["body"])
     assert body.get("run_id") == "test-run"
     assert body.get("status") == "gold_complete"
+
+    assert len(write_calls) == 2
+    assert write_calls[0] == ("s3://dummy-bucket/gold/governor_engagement", "overwrite")
+    assert write_calls[1] == (
+        "s3://dummy-bucket/gold/governor_engagement_history",
+        "append",
+    )
 
 
 def test_load_handler_missing_bucket(monkeypatch):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -63,7 +63,7 @@ def _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silv
 
     fake_run_deterministic_modeling = MagicMock()
     monkeypatch.setattr("pipeline.run_deterministic_modeling", fake_run_deterministic_modeling)
-    return fake_run_deterministic_modeling
+    return fake_run_deterministic_modeling, aggregator
 
 
 def test_run_medallion_pipeline_nao_roda_modelagem_por_padrao(monkeypatch):
@@ -71,7 +71,9 @@ def test_run_medallion_pipeline_nao_roda_modelagem_por_padrao(monkeypatch):
 
     df_reels_silver = pd.DataFrame({"id": ["1"]})
     df_comments_silver = pd.DataFrame({"text": ["oi"]})
-    fake_modeling = _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+    fake_modeling, _aggregator = _patch_medallion_dependencies(
+        monkeypatch, df_reels_silver, df_comments_silver
+    )
 
     pipeline.run_medallion_pipeline(apify_api_token="token", links=["l"], run_id="r1")
 
@@ -83,7 +85,9 @@ def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(mo
 
     df_reels_silver = pd.DataFrame({"id": ["1"]})
     df_comments_silver = pd.DataFrame({"text": ["oi"]})
-    fake_modeling = _patch_medallion_dependencies(monkeypatch, df_reels_silver, df_comments_silver)
+    fake_modeling, _aggregator = _patch_medallion_dependencies(
+        monkeypatch, df_reels_silver, df_comments_silver
+    )
 
     pipeline.run_medallion_pipeline(
         apify_api_token="token", links=["l"], run_id="r1", run_modeling=True
@@ -96,6 +100,29 @@ def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(mo
     # ADR 0001: "um run_id = um estado imutável" -- a modelagem deve gerar o
     # seu próprio run_id, nunca reaproveitar o run_id da ingestão.
     assert kwargs.get("run_id") != "r1"
+
+
+def test_run_medallion_pipeline_grava_tabela_de_historico_em_append(monkeypatch):
+    """ADR 0016: além da tabela `governor_engagement` (overwrite, como
+    sempre), o pipeline agora também grava `governor_engagement_history`
+    em modo append -- sem isso não há como acumular tendência ao longo do
+    tempo."""
+    import pipeline
+    from config import settings
+
+    df_reels_silver = pd.DataFrame({"id": ["1"]})
+    df_comments_silver = pd.DataFrame({"text": ["oi"]})
+    _fake_modeling, aggregator = _patch_medallion_dependencies(
+        monkeypatch, df_reels_silver, df_comments_silver
+    )
+
+    pipeline.run_medallion_pipeline(apify_api_token="token", links=["l"], run_id="r1")
+
+    assert aggregator.write.call_count == 2
+    first_call, second_call = aggregator.write.call_args_list
+    assert first_call.args[1] == settings.GOLD_ENGAGEMENT
+    assert second_call.args[1] == settings.GOLD_ENGAGEMENT_HISTORY
+    assert second_call.kwargs.get("mode") == "append"
 
 
 def test_run_medallion_pipeline_nunca_chama_refinamento_via_gemini(monkeypatch):


### PR DESCRIPTION
## Summary

- Fecha a última decisão pendente da ADR 0011: `governor_engagement_history`, tabela paralela a `governor_engagement`, mesmo schema (`GOLD_ENGAGEMENT_SCHEMA`), escrita em `mode=append` a cada execução — tanto no pipeline local quanto na Lambda `load`. `governor_engagement` continua `overwrite`, inalterada para os consumidores existentes.
- ADR 0016 registra as quatro decisões de design da sessão sobre "monitoramento diário/tempo real" (handoff de 2026-08-31): auto-refresh no dashboard, agendamento com gate de custo alternável (toggle em vez de sempre-manual/sempre-automático), leitura local até `terraform apply`, e histórico em Gold implementado primeiro. Auto-refresh e o toggle de agendamento ficam documentados como próximos passos, não implementados aqui.
- Durante a investigação, confirmado que as decisões 1 (landing zone) e 2 (extração consolidada) da ADR 0011 já estavam implementadas (PR #32, ADR 0014) — só a 3 (histórico) faltava.

## Test plan

- [x] `uv run python -m pytest -q` — 134 passed, 3 skipped (pré-existentes)
- [x] `uv run ruff check src/ pipeline.py lambdas/ tests/` — sem erros
- [x] Testes novos: escrita em `append` repassada por `EngagementAggregator.write`, pipeline grava as duas tabelas (overwrite + append), Lambda `load` idem, `DeltaRepository.load_engagement_history()` acumula múltiplas execuções

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G37Kjvk2AUMM9ig5FWAm4z