### PR TITLE
feat(dashboard): página de monitoramento com auto-refresh e tendência

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ detalhados estão no `README.md` do repositório.
 )
 
 st.markdown("### Navegue pelas análises")
-nav1, nav2 = st.columns(2)
+nav1, nav2, nav3 = st.columns(3)
 with nav1:
     st.page_link(
         "pages/01_exploratory.py",
@@ -79,4 +79,10 @@ with nav2:
         "pages/02_modeling.py",
         label="Modelagem — sentimento, tópicos e clusters",
         icon="📈",
+    )
+with nav3:
+    st.page_link(
+        "pages/03_monitoring.py",
+        label="Monitoramento — tendência de engajamento ao longo do tempo",
+        icon="📡",
     )

--- a/config/settings.py
+++ b/config/settings.py
@@ -27,6 +27,10 @@ RESULTS_LIMIT = int(os.environ.get("RESULTS_LIMIT", 30))
 N_CLUSTERS_KMEANS = int(os.environ.get("N_CLUSTERS_KMEANS", 5))
 TSNE_PERPLEXITY = int(os.environ.get("TSNE_PERPLEXITY", 30))
 
+# Intervalo de auto-refresh (segundos) da página de monitoramento do
+# dashboard (`pages/03_monitoring.py`) -- ver issue #50 / ADR 0016.
+DASHBOARD_REFRESH_SECONDS = int(os.environ.get("DASHBOARD_REFRESH_SECONDS", 60))
+
 # Colunas frequentemente usadas
 PROFILE_COLUMN = os.environ.get("PROFILE_COLUMN", "@_perfil")
 TEXT_COLUMN = os.environ.get("TEXT_COLUMN", "text")

--- a/pages/03_monitoring.py
+++ b/pages/03_monitoring.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import sys
+
+import streamlit as st
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from config import settings
+from src.dashboard.loaders import load_engagement_history
+from src.visualization.charts import plot_engagement_trend
+
+st.set_page_config(
+    page_title="Instagram Analytics — Monitoramento",
+    page_icon="📡",
+    layout="wide",
+)
+
+st.title("📡 Monitoramento — Governadores do Brasil")
+st.markdown(
+    "Tendência de engajamento a partir de `governor_engagement_history` "
+    "(uma linha por governador a cada execução do pipeline). Esta seção "
+    f"recarrega sozinha a cada {settings.DASHBOARD_REFRESH_SECONDS}s, sem "
+    "precisar reiniciar o app — ver ADR 0016."
+)
+st.markdown("---")
+
+
+@st.fragment(run_every=f"{settings.DASHBOARD_REFRESH_SECONDS}s")
+def render_monitoring() -> None:
+    df_history = load_engagement_history()
+
+    if df_history.empty:
+        st.info(
+            "`governor_engagement_history` ainda não tem dados. Rode o pipeline "
+            "(`uv run python pipeline.py`) para começar a acumular histórico."
+        )
+        return
+
+    ultima_execucao = df_history.loc[df_history["_generated_at"].idxmax()]
+    st.caption(
+        f"Última atualização: {ultima_execucao['_generated_at']} "
+        f"(run_id: `{ultima_execucao['_run_id']}`)"
+    )
+
+    governadores_disponiveis = sorted(df_history["username"].dropna().unique())
+    governadores_selecionados = st.multiselect(
+        "Governadores",
+        options=governadores_disponiveis,
+        default=governadores_disponiveis,
+    )
+    df_filtrado = df_history[df_history["username"].isin(governadores_selecionados)]
+
+    if df_filtrado.empty:
+        st.warning("Nenhum governador selecionado.")
+        return
+
+    st.plotly_chart(
+        plot_engagement_trend(
+            df_filtrado,
+            y_col="TOTAL ENGAJAMENTO",
+            title="Tendência de Engajamento Total",
+        ),
+        width="stretch",
+    )
+    st.plotly_chart(
+        plot_engagement_trend(
+            df_filtrado,
+            y_col="% ENGAJAMENTO",
+            title="Tendência de % de Engajamento",
+        ),
+        width="stretch",
+    )
+
+
+render_monitoring()

--- a/src/dashboard/loaders.py
+++ b/src/dashboard/loaders.py
@@ -61,3 +61,13 @@ def load_profile_clusters_engagement() -> pd.DataFrame:
         return get_delta_repository().load_profile_clusters_engagement()
     except FileNotFoundError:
         return pd.DataFrame()
+
+
+@st.cache_data(ttl=settings.DASHBOARD_REFRESH_SECONDS)
+def load_engagement_history() -> pd.DataFrame:
+    # TTL curto (ao contrário dos loaders acima) para o auto-refresh da
+    # página de monitoramento reler a Delta de verdade a cada rerun.
+    try:
+        return get_delta_repository().load_engagement_history()
+    except FileNotFoundError:
+        return pd.DataFrame()

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -69,3 +69,22 @@ def plot_scatter(
 ) -> go.Figure:
     """Gráfico de dispersão interativo."""
     return px.scatter(df, x=x, y=y, hover_data=df.columns, height=height, width=width)
+
+
+def plot_engagement_trend(
+    df_history: pd.DataFrame,
+    y_col: str,
+    label_col: str = "username",
+    title: str | None = None,
+) -> go.Figure:
+    """Tendência de `y_col` ao longo de `_generated_at`, uma linha por `label_col`."""
+    if df_history.empty:
+        return go.Figure()
+    return px.line(
+        df_history.sort_values("_generated_at"),
+        x="_generated_at",
+        y=y_col,
+        color=label_col,
+        title=title,
+        markers=True,
+    )

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import plotly.graph_objects as go
+
+from src.visualization.charts import plot_engagement_trend
+
+
+def _df_history():
+    return pd.DataFrame(
+        {
+            "username": ["gov_a", "gov_a", "gov_b"],
+            "TOTAL ENGAJAMENTO": [10, 20, 5],
+            "_generated_at": pd.to_datetime(
+                ["2026-05-01", "2026-05-02", "2026-05-01"], utc=True
+            ),
+        }
+    )
+
+
+def test_plot_engagement_trend_returns_figure():
+    fig = plot_engagement_trend(_df_history(), y_col="TOTAL ENGAJAMENTO")
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_engagement_trend_uma_trace_por_governador():
+    fig = plot_engagement_trend(_df_history(), y_col="TOTAL ENGAJAMENTO")
+    trace_names = {trace.name for trace in fig.data}
+    assert trace_names == {"gov_a", "gov_b"}
+
+
+def test_plot_engagement_trend_nao_levanta_com_dataframe_vazio():
+    df_vazio = pd.DataFrame(columns=["username", "TOTAL ENGAJAMENTO", "_generated_at"])
+    fig = plot_engagement_trend(df_vazio, y_col="TOTAL ENGAJAMENTO")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 0

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -56,3 +56,46 @@ def test_get_delta_repository_resolves_to_delta_repository(tmp_path, monkeypatch
 
     assert isinstance(repo, DeltaRepository)
     _clear_caches()
+
+
+def test_load_engagement_history_returns_delta_table(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+    history_path = settings.GOLD_DIR / "governor_engagement_history"
+    df_r1 = pd.DataFrame(
+        {
+            "id": ["1"],
+            "username": ["g"],
+            "TOTAL ENGAJAMENTO": [10],
+            "% ENGAJAMENTO": [0.1],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    df_r2 = pd.DataFrame(
+        {
+            "id": ["1"],
+            "username": ["g"],
+            "TOTAL ENGAJAMENTO": [20],
+            "% ENGAJAMENTO": [0.2],
+            "_run_id": ["r2"],
+            "_generated_at": pd.to_datetime(["2026-05-02"], utc=True),
+        }
+    )
+    write_deltalake(str(history_path), df_r1, mode="overwrite")
+    write_deltalake(str(history_path), df_r2, mode="append")
+
+    out = loaders.load_engagement_history()
+
+    assert len(out) == 2
+    assert set(out["_run_id"]) == {"r1", "r2"}
+    _clear_caches()
+
+
+def test_load_engagement_history_returns_empty_dataframe_when_missing(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+
+    out = loaders.load_engagement_history()
+
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty
+    _clear_caches()


### PR DESCRIPTION
## Summary

Implementa a issue #50 (spec produzida via `/to-spec`, validada seam a seam antes de codar):

- Nova `pages/03_monitoring.py` — tendência de `TOTAL ENGAJAMENTO`/`% ENGAJAMENTO` por governador ao longo do tempo, a partir de `governor_engagement_history` (PR #49).
- Auto-refresh isolado a essa página via `st.fragment(run_every=...)`, intervalo configurável por `DASHBOARD_REFRESH_SECONDS` (default 60s) — threaded tanto no TTL do novo loader quanto no `run_every` do fragment.
- `app.py` ganha o terceiro link de navegação.
- TDD nos dois seams testáveis: `load_engagement_history()` (`src/dashboard/loaders.py`, mesmo padrão try/except `FileNotFoundError` dos loaders existentes) e `plot_engagement_trend()` (`src/visualization/charts.py`, função pura sem dependência de Streamlit).

**Base desta PR:** `worktree-feat-gold-history-monitoring` (PR #49), não `main` — esta feature depende de `governor_engagement_history`, que ainda não foi mergeada. O diff mostrado aqui inclui o commit do PR #49 até ele mergear; depois disso o base pode ser trocado para `main` (ou o GitHub atualiza sozinho).

## Test plan

- [x] `uv run python -m pytest -q` — 139 passed, 3 skipped (pré-existentes)
- [x] `uv run ruff check src/` — sem erros
- [x] Smoke test real via `streamlit.testing.v1.AppTest` contra dado sintético (Delta real em diretório temporário, sem custo de Apify) — cobre o caminho com histórico populado (2 gráficos renderizados, sem exceções) e o caminho vazio (tabela ainda não existe → `st.info`, sem quebrar)
- [x] `/code-review` (dois sub-agents em paralelo, Standards + Spec): spec sem divergências; um achado de Standards (docstrings multi-linha destoando da convenção do módulo) corrigido antes do commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G37Kjvk2AUMM9ig5FWAm4z