### PR TITLE
feat(gold): ADR 0017 (reestruturação do dashboard) + histórico de sentimento (append)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,17 @@ flowchart LR
 |---|---|---|---|---|
 | **Bronze** | `data/bronze/` | `instagram_profiles`, `instagram_posts`, `instagram_reels` | `src/data_extract/bronze_writer.py` | Imutabilidade — append-only, nada é sobrescrito |
 | **Silver** | `data/silver/` | `profiles_clean`, `posts_clean`, `reels_clean`, `comments_clean` | `src/features/silver/*_cleaner.py` | Conformidade — tipos, deduplicação, comentários explodidos |
-| **Gold** | `data/gold/` | `governor_engagement`, `governor_engagement_history`, `governor_sentiment`, `governor_clusters` | `src/features/gold/*` | Prontidão — métricas agregadas, resultados de modelagem |
+| **Gold** | `data/gold/` | `governor_engagement`, `governor_engagement_history`, `governor_sentiment`, `governor_sentiment_history`, `governor_clusters` | `src/features/gold/*` | Prontidão — métricas agregadas, resultados de modelagem |
 
-`governor_engagement_history` é uma tabela paralela ao `governor_engagement`, mesmo schema, escrita
-em modo `append` a cada execução (`governor_engagement` continua em `overwrite`, sem mudança para os
-consumidores existentes) — acumula uma linha por governador por execução, a base para mostrar
-tendência de engajamento ao longo do tempo. Sentimento e clusters ainda não têm tabela de histórico
-equivalente (ver [ADR 0016](docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md)).
+`governor_engagement_history` e `governor_sentiment_history` são tabelas paralelas a
+`governor_engagement`/`governor_sentiment`, mesmo schema, escritas em modo `append` a cada execução
+(as tabelas originais continuam em `overwrite`, sem mudança para os consumidores existentes) — a base
+para mostrar tendência de engajamento e sentimento ao longo do tempo (ver
+[ADR 0016](docs/adr/0016-dashboard-auto-refresh-historico-gold-e-agendamento-alternavel-antes-da-aws.md)
+e [ADR 0017](docs/adr/0017-reestruturacao-do-dashboard-para-produto-externo.md)). O refinamento de
+tópicos via Gemini (`scripts/refine_topics.py`) reescreve `governor_sentiment` mas **não** grava no
+histórico — não gera uma nova medição de sentimento, só reescreve rótulos de tópico. Clusters ainda
+não têm tabela de histórico equivalente.
 
 ### Leitura dos dados
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -62,6 +62,10 @@ GOLD_ENGAGEMENT = GOLD_DIR / "governor_engagement"
 # overwrite, inalterada para os consumidores existentes.
 GOLD_ENGAGEMENT_HISTORY = GOLD_DIR / "governor_engagement_history"
 GOLD_SENTIMENT = GOLD_DIR / "governor_sentiment"
+# Tabela paralela de histórico (mesmo schema, modo append) -- ver issue #52 /
+# ADR 0017. `governor_sentiment` continua em overwrite, inalterada para os
+# consumidores existentes.
+GOLD_SENTIMENT_HISTORY = GOLD_DIR / "governor_sentiment_history"
 GOLD_CLUSTERS = GOLD_DIR / "governor_clusters"
 GOLD_PROFILE_CLUSTERS_ENGAGEMENT = GOLD_DIR / "governor_profile_clusters_engagement"
 

--- a/docs/adr/0017-reestruturacao-do-dashboard-para-produto-externo.md
+++ b/docs/adr/0017-reestruturacao-do-dashboard-para-produto-externo.md
@@ -1,0 +1,110 @@
+---
+status: accepted
+---
+
+# Reestruturar o dashboard de "visualização acadêmica de TCC" para produto voltado a público externo
+
+## Contexto
+
+O handoff de 2026-08-31 (sessão de monitoramento diário, ADR 0016 + PR #49 + PR #51) registrou o
+próximo pedido do usuário: não um ajuste incremental, mas um reposicionamento completo do
+dashboard Streamlit — de "visualização acadêmica de TCC" para um produto útil a governadores,
+assessores, jornalistas e curiosos por métricas de redes sociais. O handoff apontou que isso muda o
+que "boa visualização" significa aqui (linguagem, hierarquia de informação, paleta) e sugeriu
+`/grilling` antes de qualquer `/to-spec`/código, dado que "página que agrega valor pra jornalista" é
+decisão de produto, não algo derivável do código existente.
+
+Antes do grilling, o estado do dashboard era: `app.py` (home estática), `pages/01_exploratory.py`
+(perfis/engajamento/correlações, filtros de grupo), `pages/02_modeling.py` (sentimento/tópicos/
+clusters, seletor de governador próprio), `pages/03_monitoring.py` (tendência de engajamento via
+`governor_engagement_history`, único histórico em Gold existente — ver ADR 0016/PR #49). Os seams
+testados (`src/dashboard/loaders.py`, `src/visualization/charts.py`) deveriam ser preservados.
+
+Uma rodada de `/grilling` (pergunta a pergunta, com recomendação, mesmo padrão da ADR 0016) resolveu
+as decisões de produto em aberto.
+
+## Decisão
+
+1. **Público prioritário desta rodada: governadores/assessores.** Jornalistas e curiosos ficam para
+   rodadas futuras de refinamento, mas a base de dados/infra construída (seletor global, histórico de
+   sentimento) já serve aos três.
+2. **Job principal do público prioritário: "como estou indo vs. meus pares"** — comparação e
+   tendência, não só a trajetória isolada do próprio perfil nem só o sentimento do momento.
+3. **Seletor de governador global e persistente**, guardado em `st.session_state`, válido em todas as
+   páginas (substitui o seletor próprio de `02_modeling.py` e o multiselect próprio de
+   `03_monitoring.py`). Sempre com opção "todos" para uso exploratório/comparativo.
+4. **Esqueleto de páginas**: Home (visão geral) → **Performance** (funde `03_monitoring.py` com as
+   métricas-chave de `01_exploratory.py`, foco comparativo com histórico) → **Insights** (evolução de
+   `02_modeling.py`: sentimento/tópicos/clusters, linguagem menos técnica) → **Explorar** (o que sobra
+   de `01_exploratory.py`: correlações livres, mais para público analítico/jornalista) →
+   **Recommendations** (nova).
+5. **Recommendations é híbrido**: um motor de regras/heurísticas determinístico calcula os achados
+   (ex.: "engajamento caiu X% nas últimas N execuções", "pares do mesmo cluster postam Y% mais reels
+   curtos", "sentimento negativo concentrado no tópico Z") a partir dos dados reais — sem depender de
+   LLM, sem custo/latência por execução, sem risco de alucinar números. Redação em linguagem natural
+   via LLM por cima das regras fica como refinamento futuro, **não bloqueia o MVP** desta página.
+6. **Histórico de Gold estende para sentimento antes das páginas novas**: nova tabela
+   `governor_sentiment_history`, mesmo padrão `mode=append` de `governor_engagement_history`
+   (ADR 0016/PR #49) — ao lado de `governor_sentiment`, que continua `overwrite`, sem mudança para os
+   consumidores existentes. Histórico de clusters (`governor_clusters`/
+   `governor_profile_clusters_engagement`) fica deferido — menor frequência de mudança, não é central
+   para o MVP de Performance/Insights/Recommendations.
+7. **Ordem de implementação**: `governor_sentiment_history` (Gold) → seletor global de governador
+   (infra de UX compartilhada) → Home → Performance → Insights → Explorar → Recommendations. Cada
+   item como spec pequena via `/to-spec` → `/implement` → `/code-review`, na sequência — mesmo padrão
+   já validado nas sessões anteriores (issue #50 → PR #51), evitando uma reestruturação monolítica.
+
+## Por que
+
+- Comparação com pares como job principal: resposta direta do usuário à pergunta sobre o que um
+  governador/assessor resolve ao abrir o dashboard — rejeitou tanto "trajetória isolada" quanto "só
+  sentimento do momento" em favor de comparação, que já encaixa com o histórico de engajamento
+  existente e o cluster de perfil por engajamento (Fase 2) já calculado.
+- Seletor global: consequência direta do job de comparação — reselecionar o governador a cada troca
+  de página atritaria exatamente a experiência que o produto deveria entregar.
+- Esqueleto de páginas: confirmado pelo usuário como proposto, preservando a lógica de "uma página por
+  preocupação" que a estrutura atual já usa, só renomeada/reagrupada para a audiência nova.
+- Recommendations híbrido com LLM adiado: o usuário rejeitou tanto "regras puras" (sem opção de
+  redação natural) quanto "LLM gera tudo" (grounding arriscado sobre números reais) em favor do
+  híbrido, mas explicitamente colocou a camada de LLM como refinamento não bloqueante — mesmo
+  raciocínio de escopo mínimo já usado no projeto (ver ADR 0010, adiar o que não tem caso concreto
+  ainda).
+- Histórico de sentimento antes das páginas: mesma ordem de dependência já usada na ADR 0016
+  ("histórico em Gold primeiro, dashboard depois") — sem tendência de sentimento, Insights/
+  Recommendations mostrariam só o estado da última execução de modelagem.
+- Clusters sem histórico por ora: não perguntado como prioridade nesta rodada; mesmo raciocínio de
+  "sem caso concreto ainda" que a ADR 0016 já usou para os mesmos dados.
+
+## Opções consideradas
+
+- **Grilling amplo cobrindo os três públicos de uma vez** — rejeitado; o usuário escolheu
+  governadores/assessores como prioridade #1 explícita, deixando jornalistas/curiosos para rodadas
+  futuras de refinamento sobre a mesma base.
+- **Manter seletor de governador por página** (como hoje) — rejeitado; atritaria o job principal de
+  comparação contínua entre páginas.
+- **Absorver "Explorar" dentro de Insights/Performance, sem página própria** — considerado e
+  rejeitado pelo usuário; manter página própria evita misturar o público analítico/jornalista com o
+  fluxo comparativo do governador/assessor na mesma tela.
+- **Recommendations 100% regras** ou **100% LLM** — ambas rejeitadas explicitamente a favor do
+  híbrido (fatos por regra, redação por LLM como camada opcional futura).
+- **Estender histórico de Gold para sentimento E clusters já nesta rodada** — rejeitado; usuário
+  priorizou só sentimento agora, clusters ficam deferidos pelo mesmo raciocínio já usado no projeto.
+- **Dashboard/páginas primeiro, histórico de sentimento depois** — rejeitado; mesma ordem de
+  dependência da ADR 0016 (dado antes de UI).
+
+## Consequências
+
+- **Não implementado nesta sessão ainda** (documentado aqui como plano, a ser executado spec por spec
+  via `/to-spec`→`/implement`→`/code-review`): `governor_sentiment_history`, seletor global de
+  governador em `st.session_state`, e as páginas Home/Performance/Insights/Explorar/Recommendations
+  redesenhadas. Esta ADR registra a decisão de produto e a ordem; cada spec individual detalha o
+  desenho técnico (schema exato, componente do seletor, wireframe de cada página) no momento da
+  implementação.
+- `pages/01_exploratory.py` e `pages/02_modeling.py` deixam de existir como estão — seu conteúdo é
+  redistribuído entre Performance/Insights/Explorar, não descartado.
+- `pages/03_monitoring.py` é absorvida por Performance, não mantida como página separada.
+- Histórico de clusters continua fora de escopo até haver necessidade concreta — mesma situação da
+  ADR 0016, agora também para `governor_clusters`/`governor_profile_clusters_engagement`.
+- A camada de redação via LLM em Recommendations fica registrada aqui como decisão futura, não
+  esquecida: se implementada, precisa de grounding cuidadoso (o texto não pode divergir dos números
+  calculados pelas regras).

--- a/src/features/gold/model_enricher.py
+++ b/src/features/gold/model_enricher.py
@@ -24,10 +24,15 @@ class ModelEnricher:
         path: Path | str,
         run_id: str,
         mode: str = "overwrite",
+        generated_at: datetime | None = None,
     ) -> None:
         df = df_comments_with_sentiment.copy()
         df["_run_id"] = run_id
-        df["_generated_at"] = datetime.now(timezone.utc)
+        # `generated_at` explícito (issue #52) para que duas chamadas desta
+        # função para o mesmo run -- governor_sentiment e
+        # governor_sentiment_history -- carimbem o mesmo timestamp, em vez
+        # de dois `datetime.now()` levemente diferentes.
+        df["_generated_at"] = generated_at or datetime.now(timezone.utc)
         write_delta(path, df, GOLD_SENTIMENT_SCHEMA, mode=mode)
 
     def write_clusters(

--- a/src/features/gold/model_enricher.py
+++ b/src/features/gold/model_enricher.py
@@ -19,12 +19,16 @@ from src.schemas_delta import (
 
 class ModelEnricher:
     def write_sentiment(
-        self, df_comments_with_sentiment: pd.DataFrame, path: Path | str, run_id: str
+        self,
+        df_comments_with_sentiment: pd.DataFrame,
+        path: Path | str,
+        run_id: str,
+        mode: str = "overwrite",
     ) -> None:
         df = df_comments_with_sentiment.copy()
         df["_run_id"] = run_id
         df["_generated_at"] = datetime.now(timezone.utc)
-        write_delta(path, df, GOLD_SENTIMENT_SCHEMA)
+        write_delta(path, df, GOLD_SENTIMENT_SCHEMA, mode=mode)
 
     def write_clusters(
         self,

--- a/src/modeling/config.py
+++ b/src/modeling/config.py
@@ -81,6 +81,8 @@ class ModelingConfig:
     topics: TopicModelConfig = field(default_factory=TopicModelConfig)
     gold_clusters_path: Path = settings.GOLD_CLUSTERS
     gold_sentiment_path: Path = settings.GOLD_SENTIMENT
+    # Tabela paralela de histórico (mode append) -- ver issue #52 / ADR 0017.
+    gold_sentiment_history_path: Path = settings.GOLD_SENTIMENT_HISTORY
     checkpoints_dir: Path = settings.MODEL_CHECKPOINTS_DIR
     logs_dir: Path = settings.LOGS_DIR
 

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -95,6 +95,15 @@ def run_deterministic_modeling(
     enricher = ModelEnricher()
     enricher.write_clusters(df_reels_clustered, config.gold_clusters_path, run_id)
     enricher.write_sentiment(df_comments_final, config.gold_sentiment_path, run_id)
+    # Tabela paralela de histórico, mode=append -- não substitui a tabela
+    # acima, que continua overwrite para os consumidores existentes (ver
+    # issue #52 / ADR 0017). Deliberadamente não replicado em
+    # `refine_topics_with_gemini`: o refinamento só reescreve Topic/Name,
+    # sem gerar uma nova medição de sentimento -- gravá-lo no histórico
+    # duplicaria pontos próximos no tempo com o mesmo sentiment_label/score.
+    enricher.write_sentiment(
+        df_comments_final, config.gold_sentiment_history_path, run_id, mode="append"
+    )
 
     # Checkpoint incondicional (ver ADR 0003): sem ele, o refinamento via
     # Gemini só poderia rodar no mesmo processo que acabou de ajustar o

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 import pandas as pd
 from bertopic import BERTopic
@@ -94,7 +95,15 @@ def run_deterministic_modeling(
 
     enricher = ModelEnricher()
     enricher.write_clusters(df_reels_clustered, config.gold_clusters_path, run_id)
-    enricher.write_sentiment(df_comments_final, config.gold_sentiment_path, run_id)
+    # `generated_at` calculado uma vez e repassado às duas escritas de
+    # sentimento abaixo, para que governor_sentiment e
+    # governor_sentiment_history carimbem o mesmo timestamp -- mesmo
+    # raciocínio de EngagementAggregator.aggregate(), que carimba
+    # `_generated_at` uma única vez antes de qualquer escrita.
+    generated_at = datetime.now(timezone.utc)
+    enricher.write_sentiment(
+        df_comments_final, config.gold_sentiment_path, run_id, generated_at=generated_at
+    )
     # Tabela paralela de histórico, mode=append -- não substitui a tabela
     # acima, que continua overwrite para os consumidores existentes (ver
     # issue #52 / ADR 0017). Deliberadamente não replicado em
@@ -102,7 +111,11 @@ def run_deterministic_modeling(
     # sem gerar uma nova medição de sentimento -- gravá-lo no histórico
     # duplicaria pontos próximos no tempo com o mesmo sentiment_label/score.
     enricher.write_sentiment(
-        df_comments_final, config.gold_sentiment_history_path, run_id, mode="append"
+        df_comments_final,
+        config.gold_sentiment_history_path,
+        run_id,
+        mode="append",
+        generated_at=generated_at,
     )
 
     # Checkpoint incondicional (ver ADR 0003): sem ele, o refinamento via

--- a/src/repositories/delta_repository.py
+++ b/src/repositories/delta_repository.py
@@ -63,6 +63,13 @@ class DeltaRepository(DataRepository):
                 raise
             return self._load(_join(self._silver_dir, "comments_clean"))
 
+    def load_sentiment_history(self) -> pd.DataFrame:
+        """Histórico de sentimento (mode append, uma linha por comentário por
+        execução de modelagem) -- ver issue #52 / ADR 0017. Separada de
+        `load_comments` porque tem granularidade temporal diferente (várias
+        execuções acumuladas, não só a última)."""
+        return self._load(_join(self._gold_dir, "governor_sentiment_history"))
+
     def load_clusters(self) -> pd.DataFrame:
         return self._load(_join(self._gold_dir, "governor_clusters"))
 

--- a/tests/test_delta_repository.py
+++ b/tests/test_delta_repository.py
@@ -76,3 +76,34 @@ def test_load_engagement_history_acumula_varias_execucoes(tmp_path):
 
     assert len(out) == 2
     assert set(out["_run_id"]) == {"r1", "r2"}
+
+
+def test_load_sentiment_history_acumula_varias_execucoes(tmp_path):
+    gold = tmp_path
+    history_path = gold / "governor_sentiment_history"
+    df_r1 = pd.DataFrame(
+        {
+            "id_comment": ["c1"],
+            "sentiment_label": ["Positive"],
+            "sentiment_score": [0.9],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    df_r2 = pd.DataFrame(
+        {
+            "id_comment": ["c2"],
+            "sentiment_label": ["Negative"],
+            "sentiment_score": [0.7],
+            "_run_id": ["r2"],
+            "_generated_at": pd.to_datetime(["2026-05-08"], utc=True),
+        }
+    )
+    write_deltalake(str(history_path), df_r1, mode="overwrite")
+    write_deltalake(str(history_path), df_r2, mode="append")
+
+    repo = DeltaRepository(gold_dir=gold)
+    out = repo.load_sentiment_history()
+
+    assert len(out) == 2
+    assert set(out["_run_id"]) == {"r1", "r2"}

--- a/tests/test_model_enricher.py
+++ b/tests/test_model_enricher.py
@@ -45,6 +45,26 @@ def test_write_sentiment_grava_topico_junto_do_sentimento(tmp_path):
     assert out.loc[0, "Topic"] == 3
 
 
+def test_write_sentiment_repassa_mode_para_write_delta(monkeypatch):
+    """`governor_sentiment_history` (issue #52) depende de `write_sentiment`
+    repassar `mode` para `write_delta` -- sem isso, toda escrita seria
+    sempre overwrite, e o histórico nunca acumularia mais de uma linha por
+    execução de modelagem (mesmo raciocínio do PR #49 para engajamento)."""
+    captured = {}
+
+    def fake_write_delta(path, df, schema, mode="overwrite"):
+        captured["path"] = path
+        captured["mode"] = mode
+
+    monkeypatch.setattr("src.features.gold.model_enricher.write_delta", fake_write_delta)
+
+    ModelEnricher().write_sentiment(
+        _comentarios_com_sentimento(), "some/path", run_id="r1", mode="append"
+    )
+
+    assert captured["mode"] == "append"
+
+
 def test_write_clusters_usa_granularidade_de_reel(tmp_path):
     """
     `write_clusters` é especificamente para a clusterização de reel do

--- a/tests/test_model_enricher.py
+++ b/tests/test_model_enricher.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pandas as pd
 import pytest
 from deltalake import DeltaTable
@@ -63,6 +65,35 @@ def test_write_sentiment_repassa_mode_para_write_delta(monkeypatch):
     )
 
     assert captured["mode"] == "append"
+
+
+def test_write_sentiment_aceita_generated_at_explicito_para_manter_consistencia(tmp_path):
+    """`governor_sentiment` e `governor_sentiment_history` (issue #52) são
+    escritos em duas chamadas separadas para o mesmo run -- sem um
+    `generated_at` explícito compartilhado, cada chamada carimbaria
+    `datetime.now()` na hora em que rodou, fazendo as duas tabelas
+    registrarem timestamps ligeiramente diferentes para a mesma execução
+    (como se fossem gerações distintas). Mesmo raciocínio de
+    `EngagementAggregator.aggregate()`, que carimba `_generated_at` uma
+    única vez antes de qualquer escrita."""
+    generated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    path_a = tmp_path / "governor_sentiment"
+    path_b = tmp_path / "governor_sentiment_history"
+
+    ModelEnricher().write_sentiment(
+        _comentarios_com_sentimento(), path_a, run_id="r1", generated_at=generated_at
+    )
+    ModelEnricher().write_sentiment(
+        _comentarios_com_sentimento(),
+        path_b,
+        run_id="r1",
+        mode="append",
+        generated_at=generated_at,
+    )
+
+    out_a = DeltaTable(str(path_a)).to_pandas()
+    out_b = DeltaTable(str(path_b)).to_pandas()
+    assert out_a.loc[0, "_generated_at"] == out_b.loc[0, "_generated_at"] == generated_at
 
 
 def test_write_clusters_usa_granularidade_de_reel(tmp_path):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -126,6 +126,9 @@ def test_run_deterministic_modeling_grava_sentimento_tambem_no_historico_em_appe
     assert (sentiment_out["_run_id"] == result.run_id).all()
     assert (history_out["_run_id"] == result.run_id).all()
     assert len(history_out) == len(sentiment_out)
+    # Mesma execução -- as duas tabelas precisam do mesmo _generated_at, não
+    # dois `datetime.now()` levemente diferentes (ver test_model_enricher.py).
+    assert (sentiment_out["_generated_at"] == history_out["_generated_at"].iloc[0]).all()
 
 
 def test_refine_topics_with_gemini_nao_grava_no_historico_de_sentimento(monkeypatch, tmp_path):

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from deltalake import DeltaTable
 
+from src.features.gold.model_enricher import ModelEnricher
 from src.modeling.config import ClusterConfig, GeminiRefinerConfig, ModelingConfig
 from src.modeling.orchestration import run_deterministic_modeling, refine_topics_with_gemini
 
@@ -91,6 +92,88 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
     assert (checkpoint_dir / "df_comments.parquet").exists()
     assert (checkpoint_dir / "pca_model.joblib").exists()
     assert (checkpoint_dir / "cluster_model.joblib").exists()
+
+
+def test_run_deterministic_modeling_grava_sentimento_tambem_no_historico_em_append(
+    monkeypatch, tmp_path
+):
+    """Issue #52: além de `governor_sentiment` (overwrite, como sempre), a
+    modelagem determinística agora também grava `governor_sentiment_history`
+    em modo append -- sem isso não há como acumular tendência de sentimento
+    ao longo do tempo (mesmo raciocínio do PR #49 para engajamento)."""
+    monkeypatch.setattr(
+        "src.modeling.orchestration.analyze_sentiment", _fake_analyze_sentiment
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.model_topics",
+        _make_fake_model_topics("0_provisorio", "0_refinado"),
+    )
+
+    config = ModelingConfig(
+        cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
+        gold_clusters_path=tmp_path / "governor_clusters",
+        gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
+    )
+
+    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+
+    sentiment_out = DeltaTable(str(config.gold_sentiment_path)).to_pandas()
+    history_out = DeltaTable(str(config.gold_sentiment_history_path)).to_pandas()
+
+    assert (sentiment_out["_run_id"] == result.run_id).all()
+    assert (history_out["_run_id"] == result.run_id).all()
+    assert len(history_out) == len(sentiment_out)
+
+
+def test_refine_topics_with_gemini_nao_grava_no_historico_de_sentimento(monkeypatch, tmp_path):
+    """Issue #52: o refinamento via Gemini reescreve só `Topic`/`Name` sob um
+    `run_id` novo, sem gerar uma nova medição de sentimento -- gravar no
+    histórico duplicaria pontos próximos no tempo com o mesmo
+    sentiment_label/score, distorcendo qualquer gráfico de tendência."""
+    monkeypatch.setattr(
+        "src.modeling.orchestration.analyze_sentiment", _fake_analyze_sentiment
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.model_topics",
+        _make_fake_model_topics("0_provisorio", "0_refinado"),
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.apply_gemini_refinement", _fake_apply_gemini_refinement
+    )
+
+    config = ModelingConfig(
+        cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
+        gold_clusters_path=tmp_path / "governor_clusters",
+        gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
+    )
+    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+
+    calls = []
+    original_write_sentiment = ModelEnricher.write_sentiment
+
+    def spy_write_sentiment(self, df, path, run_id, mode="overwrite"):
+        calls.append((str(path), mode))
+        return original_write_sentiment(self, df, path, run_id, mode=mode)
+
+    monkeypatch.setattr(ModelEnricher, "write_sentiment", spy_write_sentiment)
+
+    gemini_config = GeminiRefinerConfig(
+        api_key="fake-key", gold_sentiment_path=tmp_path / "governor_sentiment"
+    )
+    refine_topics_with_gemini(result.topic_model, result.docs, result.df_comments, gemini_config)
+
+    assert calls == [(str(gemini_config.gold_sentiment_path), "overwrite")]
+
+    # Histórico continua só com a linha da modelagem determinística original
+    # -- o refinamento não acrescentou nada a ele.
+    history_out = DeltaTable(str(config.gold_sentiment_history_path)).to_pandas()
+    assert (history_out["_run_id"] == result.run_id).all()
 
 
 def test_run_deterministic_modeling_grava_parent_run_id_como_primeira_linha_do_log(


### PR DESCRIPTION
## Summary

- **ADR 0017**: documenta as decisões de produto da rodada de `/grilling` desta sessão — reposicionar o dashboard de "visualização acadêmica de TCC" para produto voltado a governadores/assessores (prioridade #1), com seletor global de governador, esqueleto de páginas (Home/Performance/Insights/Explorar/Recommendations), Recommendations híbrido (regras determinísticas + LLM opcional futuro) e histórico de Gold estendido para sentimento antes das páginas novas. Nenhuma página é tocada nesta PR — só a decisão e a ordem de execução.
- **Closes #52**: `governor_sentiment_history`, primeiro corte da ordem definida na ADR 0017 — tabela paralela a `governor_sentiment`, mesmo schema, `mode="append"` a cada execução de `run_deterministic_modeling`. `governor_sentiment` continua `overwrite`, sem mudança para `pages/02_modeling.py`. O refinamento via Gemini (`refine_topics_with_gemini`) deliberadamente **não** grava no histórico — reescreve só `Topic`/`Name` sob um `run_id` novo, sem gerar uma nova medição de sentimento.
- Achado do `/code-review` (eixo Standards, ver histórico de commits): as duas escritas de sentimento carimbavam `_generated_at` separadamente, dando timestamps levemente diferentes para a mesma execução. Corrigido calculando `generated_at` uma vez e repassando às duas chamadas — mesmo padrão que `EngagementAggregator.aggregate()` já usava para engajamento.

## Test plan

- [x] `uv run python -m pytest -q` — 144 passed, 3 skipped (pré-existentes)
- [x] `uv run ruff check src/ pipeline.py lambdas/ tests/ config/` — sem erros
- [x] `/code-review since main` (dois sub-agents, Standards + Spec) — achado de Standards (timestamp drift) corrigido antes desta PR; Spec sem pendências
- [x] Testes novos: `mode` repassado por `ModelEnricher.write_sentiment`, `generated_at` explícito compartilhado entre as duas escritas, `DeltaRepository.load_sentiment_history()` acumula múltiplas execuções, `run_deterministic_modeling` grava as duas tabelas (overwrite + append) com mesmo `_run_id`/`_generated_at`, `refine_topics_with_gemini` **não** grava no histórico

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSoaVXgAzw8g5babsKhji9