### PR TITLE
fix(tests): isola governor_sentiment_history em tmp_path (evita poluir dado real)

### DIFF
--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -72,6 +72,7 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
@@ -197,6 +198,7 @@ def test_run_deterministic_modeling_grava_parent_run_id_como_primeira_linha_do_l
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
@@ -235,6 +237,7 @@ def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )


### PR DESCRIPTION
## Summary

- Achado durante a implementação da issue #54 (não relacionado a ela): a PR #53 adicionou `gold_sentiment_history_path` a `ModelingConfig` com um default **real** (`settings.GOLD_SENTIMENT_HISTORY`), mas 3 testes pré-existentes em `tests/test_orchestration.py` que chamam `run_deterministic_modeling` não foram atualizados para sobrescrever esse campo com `tmp_path`. Resultado: desde o merge da #53, rodar `pytest` localmente escreve dados sintéticos de teste na tabela Delta real `data/gold/governor_sentiment_history` a cada execução da suite — silencioso, sem falha de teste, só poluição de dado real.
- Corrige os 3 call sites para sobrescrever `gold_sentiment_history_path=tmp_path/...`, mesmo padrão já usado para `gold_sentiment_path`/`gold_clusters_path` nesses mesmos testes.

## Test plan

- [x] `uv run python -m pytest -q` — 144 passed, 3 skipped (pré-existentes)
- [x] `uv run ruff check src/ pipeline.py lambdas/ tests/` — sem erros
- [x] Confirmado manualmente: `data/gold/governor_sentiment_history` **não** é criado depois de rodar a suite completa neste worktree (antes do fix, era criado a cada run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSoaVXgAzw8g5babsKhji9