### PR TITLE
feat(dashboard): reposiciona a Home para o público externo

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,12 @@ with nav3:
 
 st.markdown("---")
 
-with st.expander("Como isso funciona"):
+st.markdown(
+    "Por trás dos números: um pipeline de NLP combina PCA, clusterização, "
+    "análise de sentimento e modelagem de tópicos (BERTopic) para chegar "
+    "nessas métricas."
+)
+with st.expander("Como isso funciona", expanded=False):
     st.markdown(
         """
 O pipeline aplica quatro técnicas em sequência, cada uma alimentando a seguinte:

--- a/app.py
+++ b/app.py
@@ -19,10 +19,9 @@ st.set_page_config(
 
 st.title("📊 Instagram Analytics — Governadores do Brasil")
 st.markdown(
-    "TCC de Ciência de Dados e Inteligência Artificial (IESB) que propõe e valida uma "
-    "**metodologia híbrida de NLP** — sentimento, modelagem de tópicos (BERTopic) e "
-    "clusterização integrados, em vez de aplicados isoladamente — sobre os perfis de "
-    "Instagram dos **27 governadores do Brasil**."
+    "Acompanhe engajamento, sentimento e tópicos discutidos nos perfis de Instagram dos "
+    "**27 governadores do Brasil** — uma visão consolidada pra quem acompanha comunicação "
+    "e métricas de redes sociais no setor público."
 )
 
 df_profiles = load_profiles()
@@ -45,27 +44,6 @@ with col4:
 
 st.markdown("---")
 
-st.markdown(
-    """
-### Metodologia
-
-O pipeline aplica quatro técnicas em sequência, cada uma alimentando a seguinte:
-
-1. **PCA** reduz as métricas de engajamento e duração dos reels a dois componentes.
-2. **`AutoClusterHPO`** (peça original do trabalho) testa KMeans, DBSCAN e
-   Agglomerative Clustering automaticamente, escolhendo o melhor via um score
-   CVI combinado (Silhouette + Calinski-Harabasz + Davies-Bouldin).
-3. **Análise de sentimento** classifica os comentários em positivo, neutro ou
-   negativo (`cardiffnlp/twitter-xlm-roberta-base-sentiment`).
-4. **BERTopic** extrai os temas discutidos nos comentários.
-
-O achado central do trabalho, em uma frase: **o conteúdo padrão é aprovado, o
-viral é debatido, e o longo é ignorado** — uma leitura que nenhuma das três
-técnicas produz isoladamente. A metodologia completa e os resultados
-detalhados estão no `README.md` do repositório.
-"""
-)
-
 st.markdown("### Navegue pelas análises")
 nav1, nav2, nav3 = st.columns(3)
 with nav1:
@@ -85,4 +63,27 @@ with nav3:
         "pages/03_monitoring.py",
         label="Monitoramento — tendência de engajamento ao longo do tempo",
         icon="📡",
+    )
+
+st.markdown("---")
+
+with st.expander("Como isso funciona"):
+    st.markdown(
+        """
+O pipeline aplica quatro técnicas em sequência, cada uma alimentando a seguinte:
+
+1. **PCA** reduz as métricas de engajamento e duração dos reels a dois componentes.
+2. **`AutoClusterHPO`** (peça original do trabalho) testa KMeans, DBSCAN e
+   Agglomerative Clustering automaticamente, escolhendo o melhor via um score
+   CVI combinado (Silhouette + Calinski-Harabasz + Davies-Bouldin).
+3. **Análise de sentimento** classifica os comentários em positivo, neutro ou
+   negativo (`cardiffnlp/twitter-xlm-roberta-base-sentiment`).
+4. **BERTopic** extrai os temas discutidos nos comentários.
+
+O achado central, em uma frase: **o conteúdo padrão é aprovado, o viral é
+debatido, e o longo é ignorado** — uma leitura que nenhuma das três técnicas
+produz isoladamente. A metodologia completa e os resultados detalhados estão
+no `README.md` do repositório (TCC de Ciência de Dados e Inteligência
+Artificial, IESB).
+"""
     )


### PR DESCRIPTION
## Summary

- Closes #57, terceiro corte da ADR 0017 (`governor_sentiment_history` → seletor global → **Home** → Performance → Insights → Explorar → Recommendations).
- Parágrafo de abertura deixa de se apresentar como "TCC de Ciência de Dados e Inteligência Artificial (IESB)" e passa a descrever o que o dashboard monitora (engajamento/sentimento/tópicos dos governadores).
- Bloco `### Metodologia` (PCA/AutoClusterHPO/sentimento/BERTopic) resumido e movido pro rodapé, dentro de um `st.expander` fechado por padrão ("Como isso funciona") — conteúdo preservado, só reposicionado.
- Sem mudança nas 4 métricas de topo nem na navegação pras 3 páginas existentes — serão renomeadas/reagrupadas pelas próximas specs da ADR 0017. Sem seletor global nem filtros de grupo na Home (decisão confirmada com o usuário: Home = ponto de entrada + navegação, não análise).

## Test plan

- [x] `uv run python -m pytest -q` — 147 passed, sem falhas
- [x] `uv run ruff check src/ pipeline.py lambdas/ tests/` — sem erros
- [x] Verificação manual via `streamlit.testing.v1.AppTest` (browser não conectado nesta sessão): página roda sem exceção, 4 métricas de topo com os mesmos valores de antes, 3 `page_link` continuam presentes, expander "Como isso funciona" existe, começa fechado (`expanded=False`) e contém o texto de metodologia preservado (AutoClusterHPO/BERTopic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSoaVXgAzw8g5babsKhji9