### PR TITLE
feat(dashboard): página Recommendations (motor de regras determinístico)

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ with col4:
 st.markdown("---")
 
 st.markdown("### Navegue pelas análises")
-nav1, nav2, nav3 = st.columns(3)
+nav1, nav2, nav3, nav4 = st.columns(4)
 with nav1:
     st.page_link(
         "pages/01_explorar.py",
@@ -63,6 +63,12 @@ with nav3:
         "pages/03_performance.py",
         label="Performance — como você está indo vs. seus pares",
         icon="🎯",
+    )
+with nav4:
+    st.page_link(
+        "pages/04_recommendations.py",
+        label="Recommendations — recomendações para este governador",
+        icon="✅",
     )
 
 st.markdown("---")

--- a/pages/04_recommendations.py
+++ b/pages/04_recommendations.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import sys
+
+import streamlit as st
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from src.dashboard.filters import (
+    TODOS_GOVERNADORES,
+    build_governor_directory,
+    build_profile_cluster_directory,
+    enrich_with_governor_metadata,
+    render_governor_selector,
+)
+from src.dashboard.loaders import (
+    load_comments,
+    load_engagement_history,
+    load_profiles,
+    load_reels,
+    load_sentiment_history,
+)
+from src.dashboard.recommendations import compute_recommendations
+
+st.set_page_config(
+    page_title="Instagram Analytics — Recommendations",
+    page_icon="✅",
+    layout="wide",
+)
+
+st.title("✅ Recommendations — Governadores do Brasil")
+st.markdown(
+    "Alertas gerados por regras determinísticas sobre os seus próprios dados — "
+    "sem redação por IA, só fatos calculados a partir do que já existe no "
+    "dashboard (tendência de engajamento, sentimento, tópicos e comparação "
+    "com pares de cluster)."
+)
+st.markdown("---")
+
+# Seletor global (issue #54 / ADR 0017), mesmo padrão de 02_insights.py/
+# 03_performance.py -- universo a partir de governor_engagement.
+df_engagement = load_profiles()
+if df_engagement.empty:
+    st.info(
+        "`governor_engagement` ainda não tem dados. Rode o pipeline "
+        "(`uv run python pipeline.py`) primeiro."
+    )
+    st.stop()
+
+governor_universe = df_engagement[["inputUrl"]].dropna().drop_duplicates()
+governor_universe_enriched = enrich_with_governor_metadata(governor_universe)
+governador_selecionado = render_governor_selector(
+    governor_universe_enriched,
+    directory_exists=not build_governor_directory().empty,
+    fallback_urls=df_engagement["inputUrl"].dropna().unique().tolist(),
+)
+if governador_selecionado is None:
+    st.stop()
+
+# Recomendações são por definição individuais -- não fazem sentido agregadas
+# pra "Todos os Governadores" (issue #65, user story 8).
+if governador_selecionado == TODOS_GOVERNADORES:
+    st.info("Selecione um governador específico na barra lateral para ver as recomendações dele.")
+    st.stop()
+
+df_engagement_history = load_engagement_history()
+df_sentiment = load_comments()
+df_sentiment_history = load_sentiment_history()
+df_reels = load_reels()
+df_profile_clusters = build_profile_cluster_directory()
+
+achados = compute_recommendations(
+    governador_selecionado,
+    df_engagement,
+    df_engagement_history,
+    df_sentiment,
+    df_sentiment_history,
+    df_reels,
+    df_profile_clusters,
+)
+
+if not achados:
+    st.success("Nenhum alerta identificado para este governador no momento.")
+else:
+    for mensagem in achados:
+        st.warning(mensagem)

--- a/src/dashboard/recommendations.py
+++ b/src/dashboard/recommendations.py
@@ -1,0 +1,257 @@
+"""Motor de regras determinístico da página Recommendations (issue #65 / ADR
+0017). Cada `check_*` é uma função pura: recebe DataFrame(s) já carregados +
+o `inputUrl` do governador selecionado, e retorna uma mensagem em português
+já com os números reais preenchidos (`str`) se a regra disparou, ou `None`
+caso contrário -- nunca levanta exceção por dado insuficiente, só não
+dispara (ver docstring de cada função para o que conta como "insuficiente").
+
+Mensagens são templates Python, não texto gerado por LLM -- a ADR 0017
+decidiu redação via LLM como refinamento futuro, fora do escopo desta spec.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.dashboard.filters import select_governor_rows
+
+
+def _peer_urls(df_profile_clusters: pd.DataFrame, governor_url: str) -> list[str] | None:
+    """inputUrl dos pares de cluster de perfil do governador (mesmo
+    `cluster_perfil_engajamento`, excluindo o próprio). `None` se o
+    governador não tiver cluster atribuído ou não tiver nenhum par."""
+    if df_profile_clusters.empty or "inputUrl" not in df_profile_clusters.columns:
+        return None
+    universo = df_profile_clusters["inputUrl"].dropna().unique().tolist()
+    linha_governador = select_governor_rows(df_profile_clusters, governor_url, universo)
+    if linha_governador.empty:
+        return None
+    cluster_governador = linha_governador["cluster_perfil_engajamento"].iloc[0]
+    if pd.isna(cluster_governador):
+        return None
+
+    pares = df_profile_clusters[
+        (df_profile_clusters["cluster_perfil_engajamento"] == cluster_governador)
+        & (~df_profile_clusters.index.isin(linha_governador.index))
+    ]
+    urls = pares["inputUrl"].dropna().unique().tolist()
+    return urls or None
+
+
+def check_engagement_drop(
+    df_engagement_history: pd.DataFrame,
+    governor_url: str,
+    min_execucoes: int = 2,
+    limiar_pct: float = 15.0,
+) -> str | None:
+    """Dispara se `% ENGAJAMENTO` da última execução caiu `limiar_pct`% ou
+    mais (relativo) vs. a média das execuções anteriores do mesmo
+    governador. Precisa de pelo menos `min_execucoes` execuções -- menos
+    que isso, retorna `None` (não há "anterior" pra comparar)."""
+    if df_engagement_history.empty:
+        return None
+    universo = df_engagement_history["inputUrl"].dropna().unique().tolist()
+    df_governador = select_governor_rows(df_engagement_history, governor_url, universo)
+    if len(df_governador) < min_execucoes:
+        return None
+
+    df_ordenado = df_governador.sort_values("_generated_at")
+    anteriores = df_ordenado["% ENGAJAMENTO"].iloc[:-1]
+    ultima = df_ordenado["% ENGAJAMENTO"].iloc[-1]
+    media_anterior = anteriores.mean()
+    if media_anterior <= 0:
+        return None
+
+    queda_pct = (media_anterior - ultima) / media_anterior * 100
+    if queda_pct >= limiar_pct:
+        return (
+            f"Seu engajamento caiu {queda_pct:.1f}% na última execução "
+            f"em relação à média das execuções anteriores."
+        )
+    return None
+
+
+def check_sentiment_trend_drop(
+    df_sentiment_history: pd.DataFrame,
+    governor_url: str,
+    min_execucoes: int = 2,
+    limiar_pp: float = 10.0,
+) -> str | None:
+    """Dispara se o `% Positivo` (mesmo cálculo de `plot_sentiment_trend`,
+    Insights) da última execução caiu `limiar_pp` pontos percentuais ou mais
+    vs. a média das execuções anteriores. Pontos percentuais, não % relativo
+    -- mais estável perto de zero. Precisa de pelo menos `min_execucoes`
+    execuções."""
+    if df_sentiment_history.empty:
+        return None
+    universo = df_sentiment_history["inputUrl"].dropna().unique().tolist()
+    df_governador = select_governor_rows(df_sentiment_history, governor_url, universo)
+    if df_governador.empty:
+        return None
+
+    por_execucao = (
+        df_governador.assign(_positivo=df_governador["sentiment_label"] == "positive")
+        .groupby(["_run_id", "_generated_at"])["_positivo"]
+        .mean()
+        .mul(100)
+        .reset_index(name="% Positivo")
+        .sort_values("_generated_at")
+    )
+    if len(por_execucao) < min_execucoes:
+        return None
+
+    anteriores = por_execucao["% Positivo"].iloc[:-1]
+    ultima = por_execucao["% Positivo"].iloc[-1]
+    media_anterior = anteriores.mean()
+    queda_pp = media_anterior - ultima
+    if queda_pp >= limiar_pp:
+        return (
+            f"O sentimento sobre você caiu {queda_pp:.1f} pontos percentuais "
+            f"de positividade na última execução em relação à média anterior."
+        )
+    return None
+
+
+def check_negative_sentiment_topic(
+    df_sentiment: pd.DataFrame,
+    governor_url: str,
+    min_comentarios: int = 5,
+    limiar_pct: float = 50.0,
+) -> str | None:
+    """Dispara se algum tópico (`Name`) com pelo menos `min_comentarios`
+    comentários do governador tiver `limiar_pct`% ou mais de comentários
+    negativos. Tópicos com poucos comentários são ignorados (ruído -- um
+    único comentário negativo não é "concentração")."""
+    if df_sentiment.empty or "Name" not in df_sentiment.columns:
+        return None
+    universo = df_sentiment["inputUrl"].dropna().unique().tolist()
+    df_governador = select_governor_rows(df_sentiment, governor_url, universo)
+    if df_governador.empty:
+        return None
+
+    por_topico = (
+        df_governador.dropna(subset=["Name"])
+        .assign(_negativo=lambda d: d["sentiment_label"] == "negative")
+        .groupby("Name")
+        .agg(total=("_negativo", "size"), pct_negativo=("_negativo", "mean"))
+    )
+    por_topico["pct_negativo"] *= 100
+    candidatos = por_topico[por_topico["total"] >= min_comentarios]
+    if candidatos.empty:
+        return None
+
+    pior_topico = candidatos["pct_negativo"].idxmax()
+    pior_pct = candidatos.loc[pior_topico, "pct_negativo"]
+    if pior_pct >= limiar_pct:
+        return (
+            f'O tópico "{pior_topico}" concentra {pior_pct:.0f}% de comentários '
+            f"negativos entre os assuntos mais discutidos."
+        )
+    return None
+
+
+def check_shorter_or_longer_reels_than_peers(
+    df_reels: pd.DataFrame,
+    df_profile_clusters: pd.DataFrame,
+    governor_url: str,
+    limiar_pct: float = 20.0,
+) -> str | None:
+    """Dispara se a duração média dos reels do governador for
+    `limiar_pct`% ou mais diferente (mais curta ou mais longa) da duração
+    média dos reels dos pares do mesmo cluster de perfil por engajamento.
+    Precisa de ao menos 1 par no mesmo cluster com dado de duração."""
+    if df_reels.empty or "videoDuration" not in df_reels.columns:
+        return None
+    pares_urls = _peer_urls(df_profile_clusters, governor_url)
+    if not pares_urls:
+        return None
+
+    universo = df_reels["inputUrl"].dropna().unique().tolist()
+    reels_governador = select_governor_rows(df_reels, governor_url, universo)
+    duracao_propria = pd.to_numeric(reels_governador["videoDuration"], errors="coerce").dropna()
+    if duracao_propria.empty:
+        return None
+
+    reels_pares = df_reels[df_reels["inputUrl"].isin(pares_urls)]
+    duracao_pares = pd.to_numeric(reels_pares["videoDuration"], errors="coerce").dropna()
+    if duracao_pares.empty:
+        return None
+
+    media_propria = duracao_propria.mean()
+    media_pares = duracao_pares.mean()
+    if media_pares <= 0:
+        return None
+
+    diff_pct = (media_propria - media_pares) / media_pares * 100
+    if abs(diff_pct) >= limiar_pct:
+        direcao = "mais curtos" if diff_pct < 0 else "mais longos"
+        return (
+            f"Seus reels são {direcao} que os dos seus pares de cluster "
+            f"({abs(diff_pct):.0f}% de diferença na duração média)."
+        )
+    return None
+
+
+def check_frequency_below_cluster_peers(
+    df_engagement: pd.DataFrame,
+    df_profile_clusters: pd.DataFrame,
+    governor_url: str,
+    limiar_pct: float = 20.0,
+) -> str | None:
+    """Dispara se `FREQUENCIA` do governador estiver `limiar_pct`% ou mais
+    abaixo da média dos pares do mesmo cluster de perfil por engajamento.
+    Só olha "abaixo" (não "acima") -- postar mais que os pares não é, por
+    si só, um alerta."""
+    if df_engagement.empty or "FREQUENCIA" not in df_engagement.columns:
+        return None
+    pares_urls = _peer_urls(df_profile_clusters, governor_url)
+    if not pares_urls:
+        return None
+
+    universo = df_engagement["inputUrl"].dropna().unique().tolist()
+    linha_governador = select_governor_rows(df_engagement, governor_url, universo)
+    if linha_governador.empty:
+        return None
+    freq_propria = pd.to_numeric(linha_governador["FREQUENCIA"], errors="coerce").iloc[0]
+    if pd.isna(freq_propria):
+        return None
+
+    freq_pares = pd.to_numeric(
+        df_engagement.loc[df_engagement["inputUrl"].isin(pares_urls), "FREQUENCIA"],
+        errors="coerce",
+    ).dropna()
+    if freq_pares.empty:
+        return None
+
+    media_pares = freq_pares.mean()
+    if media_pares <= 0:
+        return None
+
+    diff_pct = (media_pares - freq_propria) / media_pares * 100
+    if diff_pct >= limiar_pct:
+        return (
+            f"Sua frequência de postagem está {diff_pct:.0f}% abaixo da média "
+            f"dos seus pares de cluster."
+        )
+    return None
+
+
+def compute_recommendations(
+    governor_url: str,
+    df_engagement: pd.DataFrame,
+    df_engagement_history: pd.DataFrame,
+    df_sentiment: pd.DataFrame,
+    df_sentiment_history: pd.DataFrame,
+    df_reels: pd.DataFrame,
+    df_profile_clusters: pd.DataFrame,
+) -> list[str]:
+    """Roda as 5 regras na ordem definida, retorna as mensagens disparadas
+    (lista vazia se nenhuma regra disparou)."""
+    checagens = [
+        check_engagement_drop(df_engagement_history, governor_url),
+        check_sentiment_trend_drop(df_sentiment_history, governor_url),
+        check_negative_sentiment_topic(df_sentiment, governor_url),
+        check_shorter_or_longer_reels_than_peers(df_reels, df_profile_clusters, governor_url),
+        check_frequency_below_cluster_peers(df_engagement, df_profile_clusters, governor_url),
+    ]
+    return [mensagem for mensagem in checagens if mensagem is not None]

--- a/src/dashboard/recommendations.py
+++ b/src/dashboard/recommendations.py
@@ -30,12 +30,29 @@ def _peer_urls(df_profile_clusters: pd.DataFrame, governor_url: str) -> list[str
     if pd.isna(cluster_governador):
         return None
 
-    pares = df_profile_clusters[
-        (df_profile_clusters["cluster_perfil_engajamento"] == cluster_governador)
-        & (~df_profile_clusters.index.isin(linha_governador.index))
+    mesmo_cluster = df_profile_clusters[
+        df_profile_clusters["cluster_perfil_engajamento"] == cluster_governador
     ]
+    # Exclui o próprio governador por índice -- mesmo idioma de
+    # `comparisons.py::compute_governor_comparison` (`.drop(..., errors="ignore")`)
+    # pro mesmo conceito ("tira a própria linha da comparação com pares").
+    pares = mesmo_cluster.drop(linha_governador.index, errors="ignore")
     urls = pares["inputUrl"].dropna().unique().tolist()
     return urls or None
+
+
+def _pct_diff_vs_peers(valor_proprio: float, valores_pares: pd.Series) -> float | None:
+    """% de diferença entre `valor_proprio` e a média de `valores_pares`
+    (positivo = próprio maior que a média dos pares). `None` se não houver
+    pares com valor válido, ou se a média dos pares for <= 0 (divisão sem
+    sentido)."""
+    valores_pares = valores_pares.dropna()
+    if valores_pares.empty:
+        return None
+    media_pares = valores_pares.mean()
+    if media_pares <= 0:
+        return None
+    return (valor_proprio - media_pares) / media_pares * 100
 
 
 def check_engagement_drop(
@@ -172,18 +189,11 @@ def check_shorter_or_longer_reels_than_peers(
     if duracao_propria.empty:
         return None
 
-    reels_pares = df_reels[df_reels["inputUrl"].isin(pares_urls)]
-    duracao_pares = pd.to_numeric(reels_pares["videoDuration"], errors="coerce").dropna()
-    if duracao_pares.empty:
-        return None
-
-    media_propria = duracao_propria.mean()
-    media_pares = duracao_pares.mean()
-    if media_pares <= 0:
-        return None
-
-    diff_pct = (media_propria - media_pares) / media_pares * 100
-    if abs(diff_pct) >= limiar_pct:
+    duracao_pares = pd.to_numeric(
+        df_reels.loc[df_reels["inputUrl"].isin(pares_urls), "videoDuration"], errors="coerce"
+    )
+    diff_pct = _pct_diff_vs_peers(duracao_propria.mean(), duracao_pares)
+    if diff_pct is not None and abs(diff_pct) >= limiar_pct:
         direcao = "mais curtos" if diff_pct < 0 else "mais longos"
         return (
             f"Seus reels são {direcao} que os dos seus pares de cluster "
@@ -219,18 +229,14 @@ def check_frequency_below_cluster_peers(
     freq_pares = pd.to_numeric(
         df_engagement.loc[df_engagement["inputUrl"].isin(pares_urls), "FREQUENCIA"],
         errors="coerce",
-    ).dropna()
-    if freq_pares.empty:
-        return None
-
-    media_pares = freq_pares.mean()
-    if media_pares <= 0:
-        return None
-
-    diff_pct = (media_pares - freq_propria) / media_pares * 100
-    if diff_pct >= limiar_pct:
+    )
+    # _pct_diff_vs_peers é "próprio vs. pares" (positivo = próprio maior) --
+    # "abaixo dos pares" é o lado negativo dessa mesma convenção, por isso o
+    # limiar aqui é <= -limiar_pct, não >= limiar_pct.
+    diff_pct = _pct_diff_vs_peers(freq_propria, freq_pares)
+    if diff_pct is not None and diff_pct <= -limiar_pct:
         return (
-            f"Sua frequência de postagem está {diff_pct:.0f}% abaixo da média "
+            f"Sua frequência de postagem está {abs(diff_pct):.0f}% abaixo da média "
             f"dos seus pares de cluster."
         )
     return None

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,304 @@
+import pandas as pd
+
+from src.dashboard.recommendations import (
+    check_engagement_drop,
+    check_frequency_below_cluster_peers,
+    check_negative_sentiment_topic,
+    check_sentiment_trend_drop,
+    check_shorter_or_longer_reels_than_peers,
+    compute_recommendations,
+)
+
+GOV_A = "https://www.instagram.com/governador_a/"
+GOV_B = "https://www.instagram.com/governador_b/"
+GOV_C = "https://www.instagram.com/governador_c/"
+
+
+# --- check_engagement_drop ---
+
+
+def test_engagement_drop_dispara_com_queda_acima_do_limiar():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A, GOV_A],
+            "% ENGAJAMENTO": [10.0, 10.0, 5.0],
+            "_generated_at": pd.to_datetime(["2026-05-01", "2026-05-08", "2026-05-15"], utc=True),
+        }
+    )
+    msg = check_engagement_drop(df, GOV_A)
+    assert msg is not None
+    assert "caiu" in msg
+
+
+def test_engagement_drop_nao_dispara_com_queda_abaixo_do_limiar():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A],
+            "% ENGAJAMENTO": [10.0, 9.5],
+            "_generated_at": pd.to_datetime(["2026-05-01", "2026-05-08"], utc=True),
+        }
+    )
+    assert check_engagement_drop(df, GOV_A) is None
+
+
+def test_engagement_drop_nao_dispara_com_apenas_uma_execucao():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A],
+            "% ENGAJAMENTO": [5.0],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    assert check_engagement_drop(df, GOV_A) is None
+
+
+def test_engagement_drop_nao_dispara_com_dataframe_vazio():
+    df = pd.DataFrame(columns=["inputUrl", "% ENGAJAMENTO", "_generated_at"])
+    assert check_engagement_drop(df, GOV_A) is None
+
+
+# --- check_sentiment_trend_drop ---
+
+
+def test_sentiment_trend_drop_dispara_com_queda_acima_do_limiar():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A] * 4,
+            "sentiment_label": ["positive", "positive", "positive", "negative"],
+            "_run_id": ["r1", "r1", "r2", "r2"],
+            "_generated_at": pd.to_datetime(
+                ["2026-05-01", "2026-05-01", "2026-05-08", "2026-05-08"], utc=True
+            ),
+        }
+    )
+    # r1: 100% positivo, r2: 50% positivo -- queda de 50pp >= 10pp.
+    msg = check_sentiment_trend_drop(df, GOV_A)
+    assert msg is not None
+    assert "pontos percentuais" in msg
+
+
+def test_sentiment_trend_drop_nao_dispara_com_queda_pequena():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A] * 4,
+            "sentiment_label": ["positive", "negative", "positive", "positive"],
+            "_run_id": ["r1", "r1", "r2", "r2"],
+            "_generated_at": pd.to_datetime(
+                ["2026-05-01", "2026-05-01", "2026-05-08", "2026-05-08"], utc=True
+            ),
+        }
+    )
+    # r1: 50% positivo, r2: 100% positivo -- subiu, não caiu.
+    assert check_sentiment_trend_drop(df, GOV_A) is None
+
+
+def test_sentiment_trend_drop_nao_dispara_com_apenas_uma_execucao():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A],
+            "sentiment_label": ["negative"],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    assert check_sentiment_trend_drop(df, GOV_A) is None
+
+
+def test_sentiment_trend_drop_nao_dispara_com_dataframe_vazio():
+    df = pd.DataFrame(columns=["inputUrl", "sentiment_label", "_run_id", "_generated_at"])
+    assert check_sentiment_trend_drop(df, GOV_A) is None
+
+
+# --- check_negative_sentiment_topic ---
+
+
+def test_negative_sentiment_topic_dispara_quando_topico_concentra_negativos():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A] * 6,
+            "Name": ["saude"] * 5 + ["educacao"] * 1,
+            "sentiment_label": ["negative", "negative", "negative", "positive", "negative", "positive"],
+        }
+    )
+    # saude: 5 comentários, 4/5 = 80% negativo >= 50%.
+    msg = check_negative_sentiment_topic(df, GOV_A)
+    assert msg is not None
+    assert "saude" in msg
+
+
+def test_negative_sentiment_topic_nao_dispara_com_topico_abaixo_do_limiar():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A] * 5,
+            "Name": ["saude"] * 5,
+            "sentiment_label": ["negative", "negative", "positive", "positive", "positive"],
+        }
+    )
+    # saude: 2/5 = 40% negativo < 50%.
+    assert check_negative_sentiment_topic(df, GOV_A) is None
+
+
+def test_negative_sentiment_topic_ignora_topico_com_poucos_comentarios():
+    df = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A] * 2,
+            "Name": ["topico_raro"] * 2,
+            "sentiment_label": ["negative", "negative"],
+        }
+    )
+    # 100% negativo, mas só 2 comentários -- abaixo de min_comentarios=5.
+    assert check_negative_sentiment_topic(df, GOV_A) is None
+
+
+def test_negative_sentiment_topic_nao_dispara_com_dataframe_vazio():
+    df = pd.DataFrame(columns=["inputUrl", "Name", "sentiment_label"])
+    assert check_negative_sentiment_topic(df, GOV_A) is None
+
+
+# --- check_shorter_or_longer_reels_than_peers ---
+
+
+def _df_profile_clusters():
+    return pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_B, GOV_C],
+            "cluster_perfil_engajamento": [0, 0, 1],
+        }
+    )
+
+
+def test_reels_duration_dispara_quando_mais_curtos_que_pares():
+    df_reels = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A, GOV_B, GOV_B],
+            "videoDuration": [10.0, 10.0, 30.0, 30.0],
+        }
+    )
+    msg = check_shorter_or_longer_reels_than_peers(df_reels, _df_profile_clusters(), GOV_A)
+    assert msg is not None
+    assert "mais curtos" in msg
+
+
+def test_reels_duration_dispara_quando_mais_longos_que_pares():
+    df_reels = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A, GOV_B, GOV_B],
+            "videoDuration": [30.0, 30.0, 10.0, 10.0],
+        }
+    )
+    msg = check_shorter_or_longer_reels_than_peers(df_reels, _df_profile_clusters(), GOV_A)
+    assert msg is not None
+    assert "mais longos" in msg
+
+
+def test_reels_duration_nao_dispara_com_duracao_similar():
+    df_reels = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A, GOV_B, GOV_B],
+            "videoDuration": [20.0, 20.0, 21.0, 21.0],
+        }
+    )
+    assert check_shorter_or_longer_reels_than_peers(df_reels, _df_profile_clusters(), GOV_A) is None
+
+
+def test_reels_duration_nao_dispara_sem_pares_no_cluster():
+    df_reels = pd.DataFrame({"inputUrl": [GOV_C], "videoDuration": [10.0]})
+    # governador_c é o único do cluster 1 -- sem pares.
+    assert check_shorter_or_longer_reels_than_peers(df_reels, _df_profile_clusters(), GOV_C) is None
+
+
+def test_reels_duration_nao_dispara_com_dataframe_vazio():
+    df_reels = pd.DataFrame(columns=["inputUrl", "videoDuration"])
+    assert check_shorter_or_longer_reels_than_peers(df_reels, _df_profile_clusters(), GOV_A) is None
+
+
+# --- check_frequency_below_cluster_peers ---
+
+
+def test_frequency_below_peers_dispara_quando_abaixo_do_limiar():
+    df_engagement = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_B],
+            "FREQUENCIA": [1.0, 2.0],
+        }
+    )
+    msg = check_frequency_below_cluster_peers(df_engagement, _df_profile_clusters(), GOV_A)
+    # 1.0 vs média dos pares (2.0) -- 50% abaixo, >= limiar de 20%.
+    assert msg is not None
+    assert "abaixo da média" in msg
+
+
+def test_frequency_below_peers_nao_dispara_quando_acima_dos_pares():
+    df_engagement = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_B],
+            "FREQUENCIA": [3.0, 2.0],
+        }
+    )
+    assert check_frequency_below_cluster_peers(df_engagement, _df_profile_clusters(), GOV_A) is None
+
+
+def test_frequency_below_peers_nao_dispara_sem_pares_no_cluster():
+    df_engagement = pd.DataFrame({"inputUrl": [GOV_C], "FREQUENCIA": [0.1]})
+    assert check_frequency_below_cluster_peers(df_engagement, _df_profile_clusters(), GOV_C) is None
+
+
+def test_frequency_below_peers_nao_dispara_com_dataframe_vazio():
+    df_engagement = pd.DataFrame(columns=["inputUrl", "FREQUENCIA"])
+    assert check_frequency_below_cluster_peers(df_engagement, _df_profile_clusters(), GOV_A) is None
+
+
+# --- compute_recommendations ---
+
+
+def test_compute_recommendations_agrega_regras_disparadas_na_ordem():
+    df_engagement = pd.DataFrame({"inputUrl": [GOV_A, GOV_B], "FREQUENCIA": [1.0, 2.0]})
+    df_engagement_history = pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_A],
+            "% ENGAJAMENTO": [10.0, 5.0],
+            "_generated_at": pd.to_datetime(["2026-05-01", "2026-05-08"], utc=True),
+        }
+    )
+    df_sentiment = pd.DataFrame(columns=["inputUrl", "Name", "sentiment_label"])
+    df_sentiment_history = pd.DataFrame(
+        columns=["inputUrl", "sentiment_label", "_run_id", "_generated_at"]
+    )
+    df_reels = pd.DataFrame(columns=["inputUrl", "videoDuration"])
+    df_profile_clusters = _df_profile_clusters()
+
+    achados = compute_recommendations(
+        GOV_A,
+        df_engagement,
+        df_engagement_history,
+        df_sentiment,
+        df_sentiment_history,
+        df_reels,
+        df_profile_clusters,
+    )
+    # Só engagement_drop (dado suficiente) e frequency_below_peers devem disparar.
+    assert len(achados) == 2
+    assert "caiu" in achados[0]
+    assert "abaixo da média" in achados[1]
+
+
+def test_compute_recommendations_retorna_lista_vazia_sem_nenhum_disparo():
+    df_engagement = pd.DataFrame(columns=["inputUrl", "FREQUENCIA"])
+    df_engagement_history = pd.DataFrame(columns=["inputUrl", "% ENGAJAMENTO", "_generated_at"])
+    df_sentiment = pd.DataFrame(columns=["inputUrl", "Name", "sentiment_label"])
+    df_sentiment_history = pd.DataFrame(
+        columns=["inputUrl", "sentiment_label", "_run_id", "_generated_at"]
+    )
+    df_reels = pd.DataFrame(columns=["inputUrl", "videoDuration"])
+    df_profile_clusters = pd.DataFrame(columns=["inputUrl", "cluster_perfil_engajamento"])
+
+    achados = compute_recommendations(
+        GOV_A,
+        df_engagement,
+        df_engagement_history,
+        df_sentiment,
+        df_sentiment_history,
+        df_reels,
+        df_profile_clusters,
+    )
+    assert achados == []


### PR DESCRIPTION
## Summary

- Closes #65, sétimo e último corte da ordem de execução da ADR 0017 (`governor_sentiment_history` → seletor global → Home → Performance → Insights → Explorar → **Recommendations**). Fecha o esqueleto completo de páginas.
- Novo módulo `src/dashboard/recommendations.py` com 5 regras determinísticas, cada uma uma função pura testável (`DataFrame(s) + url -> str | None`, mensagem em português já com os números preenchidos, nunca texto gerado por LLM — redação via IA fica como refinamento futuro, decisão da ADR 0017):
  - `check_engagement_drop` — queda de `% ENGAJAMENTO` na última execução vs. média das anteriores.
  - `check_sentiment_trend_drop` — queda de `% Positivo` (mesmo cálculo da Insights) vs. média anterior.
  - `check_negative_sentiment_topic` — tópico com maior concentração de sentimento negativo.
  - `check_shorter_or_longer_reels_than_peers` — duração média de reel divergente dos pares de cluster.
  - `check_frequency_below_cluster_peers` — `FREQUENCIA` abaixo da média dos pares de cluster.
- `pages/04_recommendations.py`: exige governador específico selecionado (seletor global, issue #54) — "Todos os Governadores" mostra instrução pra selecionar um específico. Sem alertas disparados, mostra mensagem de sucesso. `app.py` ganha a 4ª coluna de navegação.
- Escopo das 5 regras (3 originais da ADR 0017 + 2 extras) confirmado com o usuário via `/grilling` curto antes desta spec.

## Test plan

- [x] `uv run python -m pytest -q` — 23 testes novos, cobrindo disparo/não-disparo/degradação graciosa de cada regra
- [x] `uv run ruff check src/ pipeline.py lambdas/ tests/` — sem erros
- [x] Verificação manual via `streamlit.testing.v1.AppTest` (browser não conectado nesta sessão): "Todos" pede seleção específica; governador engenheirado pra disparar queda de engajamento mostra os alertas corretos (2 regras dispararam, mensagens com os números certos); governador sem gatilho mostra mensagem de sucesso; `app.py` nav com 4 links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSoaVXgAzw8g5babsKhji9