### PR TITLE
Dashboard: diverging bar de sentimento + agregação de tendência de engajamento

### DIFF
--- a/pages/02_insights.py
+++ b/pages/02_insights.py
@@ -29,7 +29,11 @@ from src.dashboard.loaders import (
     load_reels,
     load_sentiment_history,
 )
-from src.visualization.charts import plot_sentiment_trend, plot_top_n_bar, plot_value_counts
+from src.visualization.charts import (
+    plot_sentiment_diverging_bar,
+    plot_sentiment_trend,
+    plot_top_n_bar,
+)
 
 # --- CONFIGURAÇÃO DA PÁGINA ---
 st.set_page_config(
@@ -144,7 +148,7 @@ else:
         st.markdown("#### Distribuição de Sentimento")
         if tem_modelagem:
             st.plotly_chart(
-                plot_value_counts(
+                plot_sentiment_diverging_bar(
                     df_filtrado_comments,
                     column="sentiment_label",
                     title="Sentimento dos comentários",

--- a/pages/03_performance.py
+++ b/pages/03_performance.py
@@ -14,6 +14,7 @@ from src.dashboard.comparisons import compute_governor_comparison
 from src.dashboard.filters import (
     TODOS_GOVERNADORES,
     build_governor_directory,
+    build_governor_label_map,
     enrich_with_governor_metadata,
     render_governor_selector,
     select_governor_rows,
@@ -88,18 +89,12 @@ governador_selecionado = render_governor_selector(
 if governador_selecionado is None:
     st.stop()
 
-# Nome de exibição do governador selecionado (issue #68) -- mesmo padrão de
-# fallback de `render_governor_selector`: usa a URL crua se não houver nome
-# cadastrado em `governors_metadata`. `governador_selecionado` vem das
-# próprias opções de `governor_universe_enriched`, então a comparação exata
-# (sem normalização de URL) é segura aqui -- é a mesma tabela, não um
-# cruzamento entre tabelas diferentes.
-nome_por_url = dict(zip(governor_universe_enriched["inputUrl"], governor_universe_enriched["nome"]))
-_nome_bruto = nome_por_url.get(governador_selecionado)
-# `.get` pode devolver NaN (float, não string) pra URL sem match em
-# governors_metadata -- `NaN or fallback` NÃO cairia no fallback (NaN é
-# truthy em Python), por isso o check explícito de tipo em vez de `or`.
-nome_governador_selecionado = _nome_bruto if isinstance(_nome_bruto, str) else governador_selecionado
+# Nome de exibição do governador selecionado (issue #68), rótulo da linha em
+# destaque no gráfico de tendência -- mesmo helper de resolução de nome
+# usado por `render_governor_selector`, não uma segunda implementação.
+nome_governador_selecionado = build_governor_label_map(governor_universe_enriched).get(
+    governador_selecionado, governador_selecionado
+)
 
 if governador_selecionado != TODOS_GOVERNADORES:
     st.markdown("### Como você está indo vs. seus pares")

--- a/pages/03_performance.py
+++ b/pages/03_performance.py
@@ -19,7 +19,10 @@ from src.dashboard.filters import (
     select_governor_rows,
 )
 from src.dashboard.loaders import load_engagement_history, load_profiles
-from src.visualization.charts import plot_engagement_trend
+from src.visualization.charts import (
+    plot_engagement_group_summary_trend,
+    plot_engagement_trend_with_group_context,
+)
 
 st.set_page_config(
     page_title="Instagram Analytics — Performance",
@@ -85,6 +88,19 @@ governador_selecionado = render_governor_selector(
 if governador_selecionado is None:
     st.stop()
 
+# Nome de exibição do governador selecionado (issue #68) -- mesmo padrão de
+# fallback de `render_governor_selector`: usa a URL crua se não houver nome
+# cadastrado em `governors_metadata`. `governador_selecionado` vem das
+# próprias opções de `governor_universe_enriched`, então a comparação exata
+# (sem normalização de URL) é segura aqui -- é a mesma tabela, não um
+# cruzamento entre tabelas diferentes.
+nome_por_url = dict(zip(governor_universe_enriched["inputUrl"], governor_universe_enriched["nome"]))
+_nome_bruto = nome_por_url.get(governador_selecionado)
+# `.get` pode devolver NaN (float, não string) pra URL sem match em
+# governors_metadata -- `NaN or fallback` NÃO cairia no fallback (NaN é
+# truthy em Python), por isso o check explícito de tipo em vez de `or`.
+nome_governador_selecionado = _nome_bruto if isinstance(_nome_bruto, str) else governador_selecionado
+
 if governador_selecionado != TODOS_GOVERNADORES:
     st.markdown("### Como você está indo vs. seus pares")
     df_comparacao = compute_governor_comparison(
@@ -136,6 +152,28 @@ def render_performance_trend() -> None:
         f"(run_id: `{ultima_execucao['_run_id']}`)"
     )
 
+    if governador_selecionado == TODOS_GOVERNADORES:
+        # Issue #68: uma linha por governador (até 27 séries/cores no mesmo
+        # gráfico) estoura o teto categórico da paleta e fica ilegível --
+        # agrega em Média/Mediana do grupo em vez de plotar todo mundo.
+        st.plotly_chart(
+            plot_engagement_group_summary_trend(
+                df_history,
+                y_col="TOTAL ENGAJAMENTO",
+                title="Tendência de Engajamento Total — Média/Mediana do grupo",
+            ),
+            width="stretch",
+        )
+        st.plotly_chart(
+            plot_engagement_group_summary_trend(
+                df_history,
+                y_col="% ENGAJAMENTO",
+                title="Tendência de % de Engajamento — Média/Mediana do grupo",
+            ),
+            width="stretch",
+        )
+        return
+
     universo_urls = df_history["inputUrl"].dropna().unique().tolist()
     df_filtrado = select_governor_rows(df_history, governador_selecionado, universo_urls)
 
@@ -144,17 +182,21 @@ def render_performance_trend() -> None:
         return
 
     st.plotly_chart(
-        plot_engagement_trend(
+        plot_engagement_trend_with_group_context(
             df_filtrado,
+            df_history,
             y_col="TOTAL ENGAJAMENTO",
+            governor_label=nome_governador_selecionado,
             title="Tendência de Engajamento Total",
         ),
         width="stretch",
     )
     st.plotly_chart(
-        plot_engagement_trend(
+        plot_engagement_trend_with_group_context(
             df_filtrado,
+            df_history,
             y_col="% ENGAJAMENTO",
+            governor_label=nome_governador_selecionado,
             title="Tendência de % de Engajamento",
         ),
         width="stretch",

--- a/src/dashboard/filters.py
+++ b/src/dashboard/filters.py
@@ -206,6 +206,17 @@ def enrich_with_governor_metadata(df: pd.DataFrame, url_col: str = "inputUrl") -
     return merged
 
 
+def build_governor_label_map(directory: pd.DataFrame) -> dict[str, str]:
+    """`inputUrl -> nome de exibição`, caindo pra própria URL onde `nome` for
+    nulo (governador sem match em `governors_metadata`) -- helper compartilhado
+    entre `render_governor_selector` (mapa completo, pro `format_func` do
+    seletor) e qualquer chamador que só precise resolver 1 nome (ex:
+    `03_performance.py`, rótulo da linha em destaque no gráfico de tendência)."""
+    if directory.empty or "nome" not in directory.columns:
+        return {}
+    return dict(zip(directory["inputUrl"], directory["nome"].fillna(directory["inputUrl"])))
+
+
 def render_unmatched_warning(df_enriched: pd.DataFrame, url_col: str = "inputUrl") -> None:
     """Mostra um `st.warning` visível se alguma linha de `df_enriched` (já
     passado por `enrich_with_governor_metadata`) não casou com `governadores.xlsx`
@@ -361,12 +372,7 @@ def render_governor_selector(
                 "Nenhum governador corresponde aos filtros de grupo selecionados."
             )
             return None
-        label_by_url = dict(
-            zip(
-                directory_filtered["inputUrl"],
-                directory_filtered["nome"].fillna(directory_filtered["inputUrl"]),
-            )
-        )
+        label_by_url = build_governor_label_map(directory_filtered)
         label_by_url[TODOS_GOVERNADORES] = "Todos os Governadores"
         options = [TODOS_GOVERNADORES] + directory_filtered["inputUrl"].dropna().unique().tolist()
 

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -17,6 +17,13 @@ _CATEGORICAL_SLOT_1 = "#2a78d6"
 _CATEGORICAL_SLOT_2 = "#eb6834"
 _MUTED_CONTEXT_COLOR = "#898781"
 
+# Abaixo desse percentual, o rótulo "XX%" não cabe com respiro dentro do
+# segmento (issue #67: "medir antes de renderizar... nunca usar overflow:
+# hidden pra cortar"). Plotly não expõe medição de texto pré-render, então
+# isso é um proxy pragmático -- segmento menor que isso conta só com
+# legenda/tooltip, não rótulo direto.
+_MIN_SEGMENT_PCT_FOR_LABEL = 6.0
+
 
 def plot_top_n_bar(
     df: pd.DataFrame,
@@ -104,7 +111,7 @@ def plot_sentiment_diverging_bar(
                 orientation="h",
                 name=nome,
                 marker_color=cor,
-                text=f"{valor:.0f}%" if valor > 0 else None,
+                text=f"{valor:.0f}%" if valor >= _MIN_SEGMENT_PCT_FOR_LABEL else None,
                 textposition="auto",
                 textfont={"color": cor_texto},
             )

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -3,6 +3,20 @@ import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
+# Paleta de fallback da skill /dataviz (references/palette.md) -- usada sempre
+# que a tentativa de puxar hex da identidade visual da IESB reprova o
+# validador (scripts/validate_palette.js). Ver issues #67/#68: o par
+# diverging vermelho/azul da IESB reprova banda de luminosidade + contraste
+# no modo escuro, e o par categórico dourado/verde reprova separação sob
+# daltonismo (ΔE 1.0 sob protanopia) nos dois modos -- por isso os dois
+# gráficos abaixo caem pro par genérico documentado, não pras cores da marca.
+_DIVERGING_NEGATIVE_COLOR = "#e34948"
+_DIVERGING_POSITIVE_COLOR = "#2a78d6"
+_DIVERGING_NEUTRAL_COLOR = "#f0efec"
+_CATEGORICAL_SLOT_1 = "#2a78d6"
+_CATEGORICAL_SLOT_2 = "#eb6834"
+_MUTED_CONTEXT_COLOR = "#898781"
+
 
 def plot_top_n_bar(
     df: pd.DataFrame,
@@ -57,11 +71,48 @@ def plot_correlation_heatmap(df: pd.DataFrame, method: str = "pearson") -> go.Fi
     )
 
 
-def plot_value_counts(df: pd.DataFrame, column: str, title: str) -> go.Figure:
-    """Gráfico de pizza com a contagem de valores de uma coluna categórica."""
-    counts = df[column].value_counts().reset_index(name="count")
-    counts.columns = [column, "count"]
-    return px.pie(counts, names=column, values="count", title=title)
+def plot_sentiment_diverging_bar(
+    df: pd.DataFrame, column: str = "sentiment_label", title: str | None = None
+) -> go.Figure:
+    """Distribuição de sentimento (negativo/neutro/positivo) como uma diverging
+    stacked bar centrada no zero -- sentimento é uma escala ordenada (Likert),
+    não categorias nominais soltas, então o segmento neutro fica metade à
+    esquerda e metade à direita do zero, negativo cresce pra esquerda a partir
+    daí e positivo pra direita (issue #67). Substitui a pizza de
+    `plot_value_counts` (removida -- essa era a única chamadora)."""
+    serie = df[column].dropna()
+    if serie.empty:
+        return go.Figure()
+
+    neg_pct = (serie == "negative").mean() * 100
+    neu_pct = (serie == "neutral").mean() * 100
+    pos_pct = (serie == "positive").mean() * 100
+
+    segmentos = [
+        ("Negativo", -(neg_pct + neu_pct / 2), neg_pct, _DIVERGING_NEGATIVE_COLOR, "white"),
+        ("Neutro", -neu_pct / 2, neu_pct, _DIVERGING_NEUTRAL_COLOR, "#52514e"),
+        ("Positivo", neu_pct / 2, pos_pct, _DIVERGING_POSITIVE_COLOR, "white"),
+    ]
+
+    fig = go.Figure()
+    for nome, base, valor, cor, cor_texto in segmentos:
+        fig.add_trace(
+            go.Bar(
+                y=["Sentimento"],
+                x=[valor],
+                base=[base],
+                orientation="h",
+                name=nome,
+                marker_color=cor,
+                text=f"{valor:.0f}%" if valor > 0 else None,
+                textposition="auto",
+                textfont={"color": cor_texto},
+            )
+        )
+    fig.update_layout(barmode="overlay", title=title, showlegend=True)
+    fig.update_xaxes(showticklabels=False, zeroline=False, showgrid=False)
+    fig.update_yaxes(showticklabels=False)
+    return fig
 
 
 def plot_scatter(
@@ -115,3 +166,90 @@ def plot_sentiment_trend(df_sentiment_history: pd.DataFrame, title: str | None =
         title=title,
         markers=True,
     )
+
+
+def plot_engagement_group_summary_trend(
+    df_history: pd.DataFrame, y_col: str, title: str | None = None
+) -> go.Figure:
+    """Média e mediana de `y_col` por execução (`_run_id`/`_generated_at`)
+    entre todos os governadores de `df_history` -- usada no lugar de 1 linha
+    por governador (`plot_engagement_trend`) quando "Todos os Governadores"
+    está selecionado em Performance: até 27 séries/cores no mesmo gráfico
+    estoura o teto categórico da paleta e fica ilegível (issue #68)."""
+    if df_history.empty:
+        return go.Figure()
+
+    agrupado = (
+        df_history.groupby(["_run_id", "_generated_at"])[y_col]
+        .agg(["mean", "median"])
+        .reset_index()
+        .sort_values("_generated_at")
+    )
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=agrupado["_generated_at"],
+            y=agrupado["mean"],
+            name="Média",
+            mode="lines+markers",
+            line={"color": _CATEGORICAL_SLOT_1},
+        )
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=agrupado["_generated_at"],
+            y=agrupado["median"],
+            name="Mediana",
+            mode="lines+markers",
+            line={"color": _CATEGORICAL_SLOT_2},
+        )
+    )
+    fig.update_layout(title=title)
+    return fig
+
+
+def plot_engagement_trend_with_group_context(
+    df_governador: pd.DataFrame,
+    df_grupo: pd.DataFrame,
+    y_col: str,
+    governor_label: str,
+    title: str | None = None,
+) -> go.Figure:
+    """Linha do governador selecionado em destaque + média de `y_col` do grupo
+    inteiro (`df_grupo`, não filtrado por governador) como linha de contexto
+    cinza atrás dela -- padrão "emphasis" da `/dataviz`: 1 série é o ponto, o
+    resto é contexto. Dá à tendência ao longo do tempo a mesma leitura "vs.
+    pares" que os cards de comparação já dão em texto (issue #68)."""
+    df_governador_ordenado = df_governador.sort_values("_generated_at")
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=df_governador_ordenado["_generated_at"],
+            y=df_governador_ordenado[y_col],
+            name=governor_label,
+            mode="lines+markers",
+            line={"color": _CATEGORICAL_SLOT_1},
+        )
+    )
+
+    if not df_grupo.empty:
+        media_grupo = (
+            df_grupo.groupby(["_run_id", "_generated_at"])[y_col]
+            .mean()
+            .reset_index(name=y_col)
+            .sort_values("_generated_at")
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=media_grupo["_generated_at"],
+                y=media_grupo[y_col],
+                name="Média do grupo",
+                mode="lines",
+                line={"color": _MUTED_CONTEXT_COLOR},
+            )
+        )
+
+    fig.update_layout(title=title)
+    return fig

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -108,6 +108,19 @@ def test_plot_sentiment_diverging_bar_nao_levanta_com_dataframe_vazio():
     assert len(fig.data) == 0
 
 
+def test_plot_sentiment_diverging_bar_esconde_rotulo_de_segmento_muito_pequeno():
+    # 100 linhas: 3% negativo, 2% neutro, 95% positivo -- os dois primeiros
+    # ficam abaixo do limiar de "cabe o rótulo com respiro" (issue #67).
+    df = pd.DataFrame(
+        {"sentiment_label": ["negative"] * 3 + ["neutral"] * 2 + ["positive"] * 95}
+    )
+    fig = plot_sentiment_diverging_bar(df)
+    texto_por_nome = {trace.name: trace.text for trace in fig.data}
+    assert texto_por_nome["Negativo"] is None
+    assert texto_por_nome["Neutro"] is None
+    assert texto_por_nome["Positivo"] is not None
+
+
 def test_plot_sentiment_diverging_bar_categoria_ausente_nao_quebra():
     df_sem_negativo = pd.DataFrame({"sentiment_label": ["neutral", "positive"]})
     fig = plot_sentiment_diverging_bar(df_sem_negativo)

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,7 +1,14 @@
 import pandas as pd
 import plotly.graph_objects as go
+import pytest
 
-from src.visualization.charts import plot_engagement_trend, plot_sentiment_trend
+from src.visualization.charts import (
+    plot_engagement_group_summary_trend,
+    plot_engagement_trend,
+    plot_engagement_trend_with_group_context,
+    plot_sentiment_diverging_bar,
+    plot_sentiment_trend,
+)
 
 
 def _df_history():
@@ -65,3 +72,135 @@ def test_plot_sentiment_trend_nao_levanta_com_dataframe_vazio():
     fig = plot_sentiment_trend(df_vazio)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) == 0
+
+
+def _df_sentiment_counts():
+    # 1 negativo, 1 neutro, 2 positivos -- 25%/25%/50%.
+    return pd.DataFrame(
+        {"sentiment_label": ["negative", "neutral", "positive", "positive"]}
+    )
+
+
+def test_plot_sentiment_diverging_bar_returns_figure_com_3_traces():
+    fig = plot_sentiment_diverging_bar(_df_sentiment_counts())
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 3
+
+
+def test_plot_sentiment_diverging_bar_calcula_percentuais():
+    fig = plot_sentiment_diverging_bar(_df_sentiment_counts())
+    por_nome = {trace.name: trace.x[0] for trace in fig.data}
+    assert por_nome["Negativo"] == 25.0
+    assert por_nome["Neutro"] == 25.0
+    assert por_nome["Positivo"] == 50.0
+
+
+def test_plot_sentiment_diverging_bar_neutro_centralizado_no_zero():
+    fig = plot_sentiment_diverging_bar(_df_sentiment_counts())
+    trace_neutro = next(trace for trace in fig.data if trace.name == "Neutro")
+    assert trace_neutro.base[0] + trace_neutro.x[0] / 2 == pytest.approx(0.0)
+
+
+def test_plot_sentiment_diverging_bar_nao_levanta_com_dataframe_vazio():
+    df_vazio = pd.DataFrame(columns=["sentiment_label"])
+    fig = plot_sentiment_diverging_bar(df_vazio)
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 0
+
+
+def test_plot_sentiment_diverging_bar_categoria_ausente_nao_quebra():
+    df_sem_negativo = pd.DataFrame({"sentiment_label": ["neutral", "positive"]})
+    fig = plot_sentiment_diverging_bar(df_sem_negativo)
+    trace_negativo = next(trace for trace in fig.data if trace.name == "Negativo")
+    assert trace_negativo.x[0] == 0.0
+
+
+def _df_history_multi_governador():
+    return pd.DataFrame(
+        {
+            "inputUrl": ["a", "a", "b", "b"],
+            "_run_id": ["r1", "r2", "r1", "r2"],
+            "TOTAL ENGAJAMENTO": [10.0, 30.0, 20.0, 50.0],
+            "_generated_at": pd.to_datetime(
+                ["2026-05-01", "2026-05-08", "2026-05-01", "2026-05-08"], utc=True
+            ),
+        }
+    )
+
+
+def test_plot_engagement_group_summary_trend_returns_media_e_mediana():
+    fig = plot_engagement_group_summary_trend(
+        _df_history_multi_governador(), y_col="TOTAL ENGAJAMENTO"
+    )
+    trace_names = {trace.name for trace in fig.data}
+    assert trace_names == {"Média", "Mediana"}
+
+
+def test_plot_engagement_group_summary_trend_calcula_media_e_mediana_por_execucao():
+    # r1: [10, 20] -> média 15, mediana 15. r2: [30, 50] -> média 40, mediana 40.
+    fig = plot_engagement_group_summary_trend(
+        _df_history_multi_governador(), y_col="TOTAL ENGAJAMENTO"
+    )
+    por_nome = {trace.name: list(trace.y) for trace in fig.data}
+    assert por_nome["Média"] == [15.0, 40.0]
+    assert por_nome["Mediana"] == [15.0, 40.0]
+
+
+def test_plot_engagement_group_summary_trend_nao_levanta_com_dataframe_vazio():
+    df_vazio = pd.DataFrame(
+        columns=["inputUrl", "_run_id", "TOTAL ENGAJAMENTO", "_generated_at"]
+    )
+    fig = plot_engagement_group_summary_trend(df_vazio, y_col="TOTAL ENGAJAMENTO")
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 0
+
+
+def _df_history_um_governador():
+    return pd.DataFrame(
+        {
+            "inputUrl": ["a", "a"],
+            "_run_id": ["r1", "r2"],
+            "TOTAL ENGAJAMENTO": [10.0, 30.0],
+            "_generated_at": pd.to_datetime(["2026-05-01", "2026-05-08"], utc=True),
+        }
+    )
+
+
+def test_plot_engagement_trend_with_group_context_returns_governador_e_media_grupo():
+    fig = plot_engagement_trend_with_group_context(
+        df_governador=_df_history_um_governador(),
+        df_grupo=_df_history_multi_governador(),
+        y_col="TOTAL ENGAJAMENTO",
+        governor_label="Fulano",
+    )
+    trace_names = {trace.name for trace in fig.data}
+    assert trace_names == {"Fulano", "Média do grupo"}
+
+
+def test_plot_engagement_trend_with_group_context_media_do_grupo_usa_df_grupo():
+    # df_grupo (a e b) tem médias [15, 40] por execução -- não deve bater com o
+    # valor do próprio df_governador ([10, 30]), confirmando que a média de
+    # contexto vem do grupo inteiro, não do governador selecionado.
+    fig = plot_engagement_trend_with_group_context(
+        df_governador=_df_history_um_governador(),
+        df_grupo=_df_history_multi_governador(),
+        y_col="TOTAL ENGAJAMENTO",
+        governor_label="Fulano",
+    )
+    trace_media = next(trace for trace in fig.data if trace.name == "Média do grupo")
+    assert list(trace_media.y) == [15.0, 40.0]
+
+
+def test_plot_engagement_trend_with_group_context_governador_vazio_nao_levanta():
+    df_vazio = pd.DataFrame(
+        columns=["inputUrl", "_run_id", "TOTAL ENGAJAMENTO", "_generated_at"]
+    )
+    fig = plot_engagement_trend_with_group_context(
+        df_governador=df_vazio,
+        df_grupo=_df_history_multi_governador(),
+        y_col="TOTAL ENGAJAMENTO",
+        governor_label="Fulano",
+    )
+    assert isinstance(fig, go.Figure)
+    trace_names = {trace.name for trace in fig.data}
+    assert trace_names == {"Fulano", "Média do grupo"}


### PR DESCRIPTION
## Summary
- Closes #67: substitui a pizza de distribuição de sentimento (Insights) por uma diverging stacked bar centrada no zero — sentimento é uma escala ordenada (Likert), não categorias nominais.
- Closes #68: Performance para de plotar até 27 linhas/cores quando "Todos os Governadores" está selecionado (agrega em Média/Mediana do grupo); com um governador específico, adiciona a média do grupo como linha de contexto cinza atrás da linha em destaque (padrão *emphasis*).
- As cores da identidade visual da IESB foram tentadas primeiro nos dois casos, validadas via `scripts/validate_palette.js` (skill `/dataviz`) — ambos os pares reprovaram (vermelho/azul falha banda de luminosidade no escuro; dourado/verde falha separação sob daltonismo, ΔE 1.0, nos dois modos) — código usa os fallbacks genéricos documentados em `references/palette.md`, como cada issue já previa.
- `/code-review` (Standards + Spec, dois sub-agents) rodado antes de abrir a PR; achados endereçados no segundo commit (duplicação de lógica de resolução de nome extraída pra `src/dashboard/filters.py::build_governor_label_map`; limiar mínimo de % pra rótulo direto na diverging bar; contradição na redação da issue #68 corrigida no GitHub).

## Test plan
- [x] `pytest` completo: 192 passed, 1 skipped (skip pré-existente, não relacionado — `tests/test_repository.py`, condicionado à existência de uma tabela Delta real).
- [x] `streamlit.testing.v1.AppTest` em `pages/02_insights.py` e `pages/03_performance.py`, nos dois modos de seleção (Todos / governador específico), com dados sintéticos seedados no worktree — sem exceção, número de gráficos esperado em cada caso.
- [x] Testes unitários novos em `tests/test_charts.py` para as 3 funções novas (`plot_sentiment_diverging_bar`, `plot_engagement_group_summary_trend`, `plot_engagement_trend_with_group_context`), cobrindo cálculo de percentuais, centralização no zero, agregação média/mediana, DataFrame vazio, e supressão de rótulo em segmento pequeno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)