### PR TITLE
feat(dashboard): ADR 0018 + engajamento ponderado e matriz de quadrantes

### DIFF
--- a/docs/adr/0018-realinhar-engajamento-e-matriz-de-quadrantes-ao-relatorio-vhl-sem-produto-deputados.md
+++ b/docs/adr/0018-realinhar-engajamento-e-matriz-de-quadrantes-ao-relatorio-vhl-sem-produto-deputados.md
@@ -1,0 +1,155 @@
+---
+status: accepted
+---
+
+# Realinhar métrica de engajamento e adicionar matriz de quadrantes ao relatório da VHL, sem construir produto para deputados
+
+## Contexto
+
+O handoff de 2026-09-03 (fim da reestruturação do dashboard, ADR 0017 + issues #52-#68 mergeadas)
+registrou como próximo passo do usuário decidir como o TCC (governadores) e um produto comercial da
+VHL Comunicações (deputados) coexistiriam a partir do mesmo código, com o dashboard virando template
+de produto. As ADRs [0004](0004-manter-pipelines-separados-por-entidade-sem-generalizar-schema-agora.md)
+e [0006](0006-integrar-scraping-de-deputados-via-api-de-dados-abertos-da-camara.md) já tinham desenhado
+(sem implementar) como uma segunda entidade política entraria no Medallion.
+
+Nesta sessão, o documento `VHL_Plano_de_Acao_Reconstrucao_Tese_Vendas.docx` (24/08/2026, sócios
+Vinícius/Henrique/Luan) foi lido por completo. Ele diagnostica que a tese de vendas atual da VHL
+("Grande Dicotomia" / vídeo pesa 2,44× mais que seguidores) é estatisticamente furada — regressão
+circular (visualizações prevendo curtidas, o mesmo fenômeno medido duas vezes) e confusão entre
+volume (curtidas) e o engajamento real que o próprio Manual de Operações da VHL define (comentários +
+salvamentos + compartilhamentos). Propõe um plano de reconstrução em 6 fases e identifica este
+repositório como o protótipo funcional do "motor" que a VHL queria (Playbook do Gêmeo Digital).
+
+Durante `/grilling` desta sessão, o usuário cortou o escopo antes de qualquer decisão de arquitetura
+multi-entidade: **não haverá dados de deputados nesta rodada, nem repositório/dashboard novo**. O
+pedido concreto é alinhar o dashboard **dos governadores já existente** ao que o relatório da VHL
+pede metodologicamente, usando só os dados já coletados. ADR 0004/0006 continuam válidas como desenho
+para quando uma segunda entidade for implementada de fato — nada aqui as revoga.
+
+Inspeção do código nesta sessão confirmou dois pontos que mudaram o desenho:
+
+- `src/data_extract/scraper.py` já tem os três scrapers que a VHL pede (Profile/Post/Reel), mas
+  nenhum schema (`schemas_delta.py`, `schemas.py`) tem campo de `shares`/salvamentos, e nenhuma
+  chamada passa `includeSharesCount`/`includeTranscript` via `extra_run_input`. A fórmula de
+  engajamento da VHL (`curtidas×1 + comentários×Wc + shares×Ws + salvamentos×Wv`) depende de dados
+  que a coleta nunca trouxe para os governadores.
+- `% ENGAJAMENTO` (`EngagementAggregator`, `src/features/gold/engagement_aggregator.py`) já é
+  `(comentários + curtidas) / seguidores` — estruturalmente igual à fórmula da VHL, só sem pesar
+  comentário mais que curtida (peso implícito 1 para os dois). O gap real é o peso, não a fórmula.
+- `governor_profile_clusters_engagement` (ADR 0017 Fase 2, `scripts/run_profile_clustering_engagement.py`)
+  clusteriza os 27 governadores por `% ENGAJAMENTO`/`RECENCIA`/`FREQUENCIA` via `AutoClusterHPO` — K
+  clusters descobertos automaticamente, **sem usar `followersCount`**. A matriz de quadrantes que a
+  VHL pede (corte por mediana de audiência × engajamento, 4 rótulos fixos: Inexpressivo/Gigante
+  Adormecido/Nicho/Superstar) é um mecanismo diferente — geometria de dispersão, não clustering. A
+  suspeita do handoff anterior ("talvez `governor_profile_clusters_engagement` já resolva a matriz")
+  estava só parcialmente certa: mesma granularidade (perfil), mecanismo diferente.
+- `src/dashboard/recommendations.py` (motor de regras da página Recommendations, ADR 0017) já é
+  100% funções puras sobre DataFrames Gold já carregados pelo dashboard — não é um estágio de
+  pipeline persistido. `governor_engagement_history` tem só 1 execução registrada até agora — sem
+  série histórica real para uma mudança de fórmula quebrar.
+
+## Decisão
+
+1. **Sem produto para deputados nesta rodada.** ADR 0004/0006 continuam como desenho futuro, não
+   implementado. Nenhum repositório novo, nenhum dashboard novo, nenhum dado de deputados.
+2. **`% ENGAJAMENTO` é substituído no lugar** (mesma coluna, mesmo schema Gold) por
+   `(curtidas × 1 + comentários × Wc) / seguidores`, com `Wc > 1`. Shares e salvamentos ficam de fora
+   da fórmula — a coleta atual não os captura — e essa ausência é documentada aqui como limitação
+   conhecida, não corrigida nesta rodada (sem re-scraping dos 27 governadores).
+3. **`Wc` é calibrado empiricamente a cada execução**, como razão `curtidas totais / comentários
+   totais` da base dos 27 governadores na execução mais recente — não um valor fixo hardcoded. Segue
+   literalmente a recomendação da VHL ("pela raridade relativa de cada ação na base").
+4. **Regressão nova com preditores (Fase 3 do relatório: formato, tema, duração, horário, frequência,
+   `paidPartnership`, teste de circularidade, validação fora da amostra) fica fora de escopo desta
+   rodada.** Vira trabalho de uma rodada futura, potencialmente como análise/pipeline separado.
+5. **Matriz de quadrantes é uma feature nova e independente do clustering comportamental
+   existente.** Corte por mediana de `followersCount` × `% ENGAJAMENTO` (já corrigido), 4 rótulos
+   fixos. Calculada no lado do dashboard, no mesmo padrão de `src/dashboard/recommendations.py`
+   (função pura sobre `governor_engagement` já carregado) — não vira tabela Gold nova nem exige
+   pipeline stage. `governor_profile_clusters_engagement` continua como está, sem mudança.
+6. **A matriz entra na página Performance**, que já é a página de comparação-com-pares (job
+   principal do dashboard, ADR 0017) e já tem o histórico de engajamento — mesma família de
+   pergunta que a página já responde.
+7. **Recommendations ganha regra(s) nova(s)** usando a métrica corrigida e a classificação de
+   quadrante (ex.: "engajamento honesto caiu X%", "você está no quadrante Inexpressivo/Gigante
+   Adormecido/Nicho/Superstar").
+8. **Fora de escopo, explicitamente**: qualquer coisa específica do produto comercial da VHL —
+   anonimização de pares em benchmark, LGPD, linguagem de funil/pitch comercial, Playbook do Gêmeo
+   Digital. Essas preocupações só fazem sentido quando (e se) um produto VHL real existir neste
+   código, o que não é o caso agora.
+
+## Por que
+
+- O usuário cortou explicitamente o escopo multi-entidade nesta rodada — insistir nele seria
+  redesenhar algo que ADR 0004/0006 já cobrem como decisão futura, sem caso real (deputados) para
+  validar contra, mesmo raciocínio de "não generalizar sem caso concreto" já usado no projeto.
+- Substituir `% ENGAJAMENTO` no lugar, em vez de manter duas métricas, evita a confusão de "qual
+  engajamento usar" que o próprio relatório da VHL aponta como um dos três defeitos da tese
+  atual — e o custo de quebrar continuidade histórica é hoje próximo de zero (1 execução gravada).
+- Adiar shares/salvamentos em vez de re-raspar agora evita gastar créditos Apify e reabrir a Fase 1
+  antes de validar se a mudança de peso (Wc) já resolve o problema central apontado (curtidas
+  tratadas como engajamento) — mesma lógica de escopo mínimo já usada nas ADRs 0004/0005/0010.
+- Adiar a regressão nova (Fase 3) evita transformar uma correção de métrica em um projeto de
+  modelagem completo (novos preditores, teste de circularidade, validação fora da amostra) na mesma
+  rodada — escopo maior, risco de nunca fechar nada.
+- Matriz de quadrantes como feature independente do clustering comportamental evita forçar uma
+  correspondência artificial entre um cluster livre (K descoberto por `AutoClusterHPO`, sem
+  `followersCount`) e 4 categorias fixas de outro conceito (corte de mediana por audiência) — os dois
+  mecanismos respondem perguntas diferentes e continuam como visões complementares, não uma
+  substituindo a outra.
+- Calcular a matriz no dashboard, não em Gold, segue o padrão já validado de
+  `src/dashboard/recommendations.py`: é uma derivação barata (27 linhas, mediana + comparação) sobre
+  dado já carregado, sem necessidade de persistência nem de rodar como estágio de pipeline.
+- `Wc` calibrado empiricamente por execução, em vez de fixo, segue literalmente o método que a VHL
+  recomenda e evita arbitrar um número sem base nos dados reais dos 27 governadores.
+- Excluir explicitamente LGPD/anonimização/funil comercial evita que preocupações de um produto que
+  não existe neste repo (VHL/deputados) vazem para o dashboard acadêmico do TCC — seguem registradas
+  aqui como fora de escopo, não esquecidas, para quando (e se) o produto VHL for revisitado.
+
+## Opções consideradas
+
+- **Reraspar os 27 governadores agora para capturar shares/salvamentos** — rejeitada por ora: gasta
+  créditos Apify antes de saber se a correção de peso (Wc) já resolve o problema central; fica como
+  opção para uma rodada futura se a VHL insistir em ter shares/saves na fórmula.
+- **Não mexer na métrica agora, só ajustar linguagem/apresentação** — rejeitada: deixaria o defeito
+  central que o relatório aponta (curtidas pesando igual a comentário) sem correção, que é o ponto
+  mais barato e mais citado do documento.
+- **Incluir a regressão nova (Fase 3) já nesta rodada** — rejeitada: escopo muito maior (novos
+  preditores, teste de circularidade, validação fora da amostra) para a mesma rodada da correção de
+  métrica; usuário escolheu escopo menor primeiro.
+- **Manter `% ENGAJAMENTO` como está e adicionar `% ENGAJAMENTO_V2` ao lado** — rejeitada: dado que
+  `governor_engagement_history` não tem série histórica real a proteger, manter duas métricas só
+  criaria ambiguidade sobre qual usar em Performance/Recommendations.
+- **Estender `governor_profile_clusters_engagement` para incluir `followersCount` e mapear os
+  clusters resultantes para os 4 rótulos da VHL** — rejeitada: força correspondência entre um
+  mecanismo de cluster livre e 4 categorias fixas de outro conceito, risco de não bater.
+- **Matriz de quadrantes como tabela Gold persistida** — rejeitada: over-engineering para uma
+  derivação de 27 linhas que já tem um padrão dashboard-side validado (`recommendations.py`); sem
+  necessidade de rodar como pipeline stage.
+- **Página nova dedicada à matriz de quadrantes** — rejeitada: Performance já é a página de
+  comparação-com-pares; uma 6ª página aumentaria a superfície de navegação sem necessidade.
+- **Incluir LGPD/anonimização/funil comercial nesta rodada** — rejeitada: essas preocupações são do
+  produto comercial da VHL, que não existe neste repositório agora; fora de escopo por decisão
+  explícita do usuário.
+
+## Consequências
+
+- **Não implementado nesta sessão ainda** — esta ADR registra a decisão de escopo e desenho; a
+  implementação (mudança em `EngagementAggregator`, nova função de classificação de quadrante em
+  `src/dashboard/`, gráfico em Performance, regra(s) nova(s) em `recommendations.py`) fica para uma
+  spec/issue futura, mesmo padrão de `/to-spec`-como-issue já usado nas rodadas anteriores.
+- A ausência de shares/salvamentos na coleta dos governadores continua como limitação conhecida e
+  documentada — qualquer apresentação da métrica de engajamento corrigida precisa comunicar isso.
+- `Wc` muda a cada execução (recalculado sobre a base corrente), o que significa que o valor exato do
+  peso não é comparável entre execuções — só o `% ENGAJAMENTO` resultante é. Isso deve ficar claro se
+  o peso for exposto em algum lugar do dashboard.
+- `governor_profile_clusters_engagement` (cluster comportamental) e a matriz de quadrantes (corte por
+  mediana de audiência × engajamento) coexistem como duas visões de perfil diferentes — nenhuma
+  substitui a outra, e um consumidor futuro não deve presumir que são a mesma coisa.
+- A regressão com novos preditores (Fase 3 do relatório da VHL) continua pendente — quando entrar,
+  precisa decidir se reconcilia ou substitui a métrica de engajamento desta ADR, e se roda como
+  análise pontual ou vira estágio de pipeline.
+- Qualquer trabalho futuro de produto para a VHL (deputados, anonimização, funil comercial) parte do
+  zero em relação às decisões desta ADR — nada aqui adianta esse desenho, só documenta que foi
+  deliberadamente deixado de fora.

--- a/pages/03_performance.py
+++ b/pages/03_performance.py
@@ -10,7 +10,7 @@ if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
 from config import settings
-from src.dashboard.comparisons import compute_governor_comparison
+from src.dashboard.comparisons import compute_engagement_quadrants, compute_governor_comparison
 from src.dashboard.filters import (
     TODOS_GOVERNADORES,
     build_governor_directory,
@@ -22,6 +22,7 @@ from src.dashboard.filters import (
 from src.dashboard.loaders import load_engagement_history, load_profiles
 from src.visualization.charts import (
     plot_engagement_group_summary_trend,
+    plot_engagement_quadrant_matrix,
     plot_engagement_trend_with_group_context,
 )
 
@@ -131,6 +132,27 @@ if governador_selecionado != TODOS_GOVERNADORES:
                         delta=f"{delta_fmt} vs. média (#{metrica['rank']} de {metrica['total']})",
                     )
     st.markdown("---")
+
+# Matriz de quadrantes (ADR 0018): fora do `if` acima -- ao contrário da
+# comparação com pares, faz sentido para "Todos os Governadores" também
+# (user story 7), só sem destaque de nenhum ponto nesse caso.
+st.markdown("### Matriz de Quadrantes — Audiência × Engajamento")
+df_quadrantes = compute_engagement_quadrants(df_engagement)
+if df_quadrantes.empty:
+    st.info("Dado insuficiente para montar a matriz de quadrantes ainda (mínimo 2 governadores).")
+else:
+    governor_url_destaque = (
+        None if governador_selecionado == TODOS_GOVERNADORES else governador_selecionado
+    )
+    st.plotly_chart(
+        plot_engagement_quadrant_matrix(
+            df_quadrantes,
+            governor_url=governor_url_destaque,
+            governor_label=nome_governador_selecionado if governor_url_destaque else None,
+        ),
+        width="stretch",
+    )
+st.markdown("---")
 
 
 @st.fragment(run_every=f"{settings.DASHBOARD_REFRESH_SECONDS}s")

--- a/src/dashboard/comparisons.py
+++ b/src/dashboard/comparisons.py
@@ -61,3 +61,75 @@ def compute_governor_comparison(
         )
 
     return pd.DataFrame(rows, columns=_COLUMNS)
+
+
+INEXPRESSIVO = "Inexpressivo"
+GIGANTE_ADORMECIDO = "Gigante Adormecido"
+NICHO = "Nicho"
+SUPERSTAR = "Superstar"
+
+_QUADRANT_COLUMNS = [
+    "inputUrl",
+    "followersCount",
+    "% ENGAJAMENTO",
+    "quadrante",
+    "mediana_followers",
+    "mediana_engajamento",
+]
+
+
+def compute_engagement_quadrants(df_engagement: pd.DataFrame) -> pd.DataFrame:
+    """Classifica cada governador em um dos 4 quadrantes da matriz
+    audiência × engajamento da VHL (ADR 0018): corte pela mediana de
+    `followersCount` e de `% ENGAJAMENTO` sobre o `df_engagement` recebido.
+
+    - baixa audiência + baixo engajamento -> Inexpressivo
+    - alta audiência + baixo engajamento -> Gigante Adormecido
+    - baixa audiência + alto engajamento -> Nicho
+    - alta audiência + alto engajamento -> Superstar
+
+    "Alta"/"alto" é estritamente acima da mediana -- o próprio ponto que
+    define a mediana cai do lado "baixo" nos dois eixos, não fica "acima de
+    si mesmo". Retorna DataFrame vazio (mesmas colunas) se `df_engagement`
+    não tiver pelo menos 2 linhas com `followersCount`/`% ENGAJAMENTO`
+    válidos -- mediana sem sentido com 1 ponto ou menos -- mesmo padrão de
+    degradação graciosa de `compute_governor_comparison`. Também retorna
+    vazio se `df_engagement` não tiver `followersCount`/`% ENGAJAMENTO`
+    (chamadores como `check_engagement_quadrant`, em `recommendations.py`,
+    recebem o mesmo `df_engagement` que outras regras usam com um
+    subconjunto de colunas diferente -- sem esse guard, a ausência de
+    qualquer uma das duas levantaria `KeyError` em vez de degradar)."""
+    if df_engagement.empty or not {"followersCount", "% ENGAJAMENTO"} <= set(
+        df_engagement.columns
+    ):
+        return pd.DataFrame(columns=_QUADRANT_COLUMNS)
+
+    followers = pd.to_numeric(df_engagement["followersCount"], errors="coerce")
+    engajamento = pd.to_numeric(df_engagement["% ENGAJAMENTO"], errors="coerce")
+    validos = followers.notna() & engajamento.notna()
+    if validos.sum() < 2:
+        return pd.DataFrame(columns=_QUADRANT_COLUMNS)
+
+    mediana_followers = followers[validos].median()
+    mediana_engajamento = engajamento[validos].median()
+
+    out = pd.DataFrame(
+        {
+            "inputUrl": df_engagement.loc[validos, "inputUrl"].values,
+            "followersCount": followers[validos].values,
+            "% ENGAJAMENTO": engajamento[validos].values,
+        }
+    )
+
+    audiencia_alta = out["followersCount"] > mediana_followers
+    engajamento_alto = out["% ENGAJAMENTO"] > mediana_engajamento
+
+    out["quadrante"] = INEXPRESSIVO
+    out.loc[audiencia_alta & ~engajamento_alto, "quadrante"] = GIGANTE_ADORMECIDO
+    out.loc[~audiencia_alta & engajamento_alto, "quadrante"] = NICHO
+    out.loc[audiencia_alta & engajamento_alto, "quadrante"] = SUPERSTAR
+
+    out["mediana_followers"] = mediana_followers
+    out["mediana_engajamento"] = mediana_engajamento
+
+    return out

--- a/src/dashboard/recommendations.py
+++ b/src/dashboard/recommendations.py
@@ -13,7 +13,27 @@ from __future__ import annotations
 
 import pandas as pd
 
+from src.dashboard.comparisons import (
+    GIGANTE_ADORMECIDO,
+    INEXPRESSIVO,
+    NICHO,
+    SUPERSTAR,
+    compute_engagement_quadrants,
+)
 from src.dashboard.filters import select_governor_rows
+
+# Chaveado pelas mesmas constantes que `compute_engagement_quadrants` usa
+# para classificar (não strings soltas) -- um desalinhamento entre os dois
+# levantaria KeyError aqui, quebrando o contrato "nunca levanta exceção" que
+# toda `check_*` deste módulo segue.
+_QUADRANT_DESCRIPTIONS = {
+    INEXPRESSIVO: "audiência e engajamento honesto abaixo da mediana do grupo.",
+    GIGANTE_ADORMECIDO: (
+        "audiência acima da mediana, mas engajamento honesto abaixo da mediana do grupo."
+    ),
+    NICHO: "audiência abaixo da mediana, mas engajamento honesto acima da mediana do grupo.",
+    SUPERSTAR: "audiência e engajamento honesto acima da mediana do grupo.",
+}
 
 
 def _peer_urls(df_profile_clusters: pd.DataFrame, governor_url: str) -> list[str] | None:
@@ -242,6 +262,31 @@ def check_frequency_below_cluster_peers(
     return None
 
 
+def check_engagement_quadrant(
+    df_engagement: pd.DataFrame,
+    governor_url: str,
+) -> str | None:
+    """Classifica o governador num dos 4 quadrantes da matriz audiência ×
+    engajamento (ADR 0018, `compute_engagement_quadrants`) e devolve uma
+    frase com o que aquele quadrante significa. Diferente das outras
+    `check_*`, não é um alerta condicional a um limiar -- é um achado
+    informativo de posicionamento, dispara sempre que houver classificação
+    disponível. `None` se não houver dado suficiente para classificar (ver
+    `compute_engagement_quadrants`: DataFrame vazio, colunas ausentes, ou
+    menos de 2 governadores com followersCount/% ENGAJAMENTO válidos) ou se
+    o governador não tiver linha correspondente."""
+    quadrantes = compute_engagement_quadrants(df_engagement)
+    if quadrantes.empty:
+        return None
+    universo = quadrantes["inputUrl"].dropna().unique().tolist()
+    linha_governador = select_governor_rows(quadrantes, governor_url, universo)
+    if linha_governador.empty:
+        return None
+
+    quadrante = linha_governador["quadrante"].iloc[0]
+    return f"Você está no quadrante {quadrante}: {_QUADRANT_DESCRIPTIONS[quadrante]}"
+
+
 def compute_recommendations(
     governor_url: str,
     df_engagement: pd.DataFrame,
@@ -251,7 +296,7 @@ def compute_recommendations(
     df_reels: pd.DataFrame,
     df_profile_clusters: pd.DataFrame,
 ) -> list[str]:
-    """Roda as 5 regras na ordem definida, retorna as mensagens disparadas
+    """Roda as 6 regras na ordem definida, retorna as mensagens disparadas
     (lista vazia se nenhuma regra disparou)."""
     checagens = [
         check_engagement_drop(df_engagement_history, governor_url),
@@ -259,5 +304,6 @@ def compute_recommendations(
         check_negative_sentiment_topic(df_sentiment, governor_url),
         check_shorter_or_longer_reels_than_peers(df_reels, df_profile_clusters, governor_url),
         check_frequency_below_cluster_peers(df_engagement, df_profile_clusters, governor_url),
+        check_engagement_quadrant(df_engagement, governor_url),
     ]
     return [mensagem for mensagem in checagens if mensagem is not None]

--- a/src/features/gold/engagement_aggregator.py
+++ b/src/features/gold/engagement_aggregator.py
@@ -50,9 +50,20 @@ class EngagementAggregator:
 
         df["TOTAL ENGAJAMENTO"] = (df["commentsSum"] + df["likesSum"]).astype("int64")
 
+        # ADR 0018: curtida e comentário não custam a mesma atenção -- Wc pesa
+        # comentário mais que curtida, calibrado pela própria base (razão
+        # curtidas/comentários da execução inteira) em vez de arbitrado. Sem
+        # comentário nenhum na execução, Wc cairia em divisão por zero; 1.0
+        # degrada para o mesmo peso curtida=comentário de antes.
+        total_likes = df["likesSum"].sum()
+        total_comments = df["commentsSum"].sum()
+        wc_comentario = float(total_likes) / total_comments if total_comments > 0 else 1.0
+        df["_WC_COMENTARIO"] = wc_comentario
+
         followers = pd.to_numeric(df["followersCount"], errors="coerce").astype("float64")
+        engajamento_ponderado = df["likesSum"] + df["commentsSum"] * wc_comentario
         df["% ENGAJAMENTO"] = (
-            df["TOTAL ENGAJAMENTO"].div(followers.where(followers > 0)).fillna(0.0)
+            engajamento_ponderado.div(followers.where(followers > 0)).fillna(0.0)
         )
 
         if "maxData" in df.columns:

--- a/src/schemas_delta.py
+++ b/src/schemas_delta.py
@@ -177,6 +177,7 @@ GOLD_ENGAGEMENT_SCHEMA = pa.schema(
         pa.field("postsCount", pa.int32(), nullable=False),
         pa.field("TOTAL ENGAJAMENTO", pa.int64(), nullable=False),
         pa.field("% ENGAJAMENTO", pa.float64(), nullable=False),
+        pa.field("_WC_COMENTARIO", pa.float64(), nullable=False),
         pa.field("RECENCIA", pa.float64(), nullable=False),
         pa.field("FREQUENCIA", pa.float64(), nullable=False),
         pa.field("commentsSum", pa.int64(), nullable=False),

--- a/src/visualization/charts.py
+++ b/src/visualization/charts.py
@@ -260,3 +260,104 @@ def plot_engagement_trend_with_group_context(
 
     fig.update_layout(title=title)
     return fig
+
+
+def plot_engagement_quadrant_matrix(
+    df_quadrantes: pd.DataFrame,
+    governor_url: str | None = None,
+    governor_label: str | None = None,
+    title: str | None = None,
+) -> go.Figure:
+    """Matriz de quadrantes (ADR 0018): `followersCount` × `% ENGAJAMENTO`,
+    com linhas de corte na mediana de cada eixo e um rótulo por quadrante nos
+    4 cantos. Espera `df_quadrantes` no formato de saída de
+    `compute_engagement_quadrants` (colunas `inputUrl`, `followersCount`,
+    `% ENGAJAMENTO`, `quadrante`, `mediana_followers`, `mediana_engajamento`).
+
+    Identidade de quadrante não é carregada por cor nos pontos -- a paleta
+    categórica de fallback deste projeto (skill /dataviz, issues #67/#68) só
+    valida "all-pairs" (necessário em scatter, onde qualquer par de pontos
+    pode ficar lado a lado) para os 3 primeiros slots; o 4º já falha contra o
+    3º. O quadrante é uma região geométrica definida pelas linhas de
+    mediana + rótulo de canto, não uma cor de série; pontos usam só destaque
+    (`governor_url`) vs. contexto, mesmo padrão "emphasis" de
+    `plot_engagement_trend_with_group_context`.
+
+    `governor_url` opcional -- `None` (ex.: "Todos os Governadores"
+    selecionado) deixa todos os pontos no mesmo nível de contexto, sem
+    destaque."""
+    if df_quadrantes.empty:
+        return go.Figure()
+
+    mediana_followers = df_quadrantes["mediana_followers"].iloc[0]
+    mediana_engajamento = df_quadrantes["mediana_engajamento"].iloc[0]
+
+    destaque = (
+        df_quadrantes["inputUrl"] == governor_url
+        if governor_url is not None
+        else pd.Series(False, index=df_quadrantes.index)
+    )
+
+    hovertemplate = (
+        "Seguidores: %{x:,.0f}<br>% Engajamento: %{y:.4f}"
+        "<br>Quadrante: %{customdata}<extra></extra>"
+    )
+
+    fig = go.Figure()
+
+    contexto = df_quadrantes.loc[~destaque]
+    fig.add_trace(
+        go.Scatter(
+            x=contexto["followersCount"],
+            y=contexto["% ENGAJAMENTO"],
+            mode="markers",
+            name="Demais governadores" if destaque.any() else "Governadores",
+            marker={"color": _MUTED_CONTEXT_COLOR, "size": 9},
+            customdata=contexto["quadrante"],
+            hovertemplate=hovertemplate,
+        )
+    )
+
+    if destaque.any():
+        selecionado = df_quadrantes.loc[destaque]
+        fig.add_trace(
+            go.Scatter(
+                x=selecionado["followersCount"],
+                y=selecionado["% ENGAJAMENTO"],
+                mode="markers",
+                name=governor_label or "Selecionado",
+                marker={
+                    "color": _CATEGORICAL_SLOT_1,
+                    "size": 14,
+                    "line": {"color": "white", "width": 1},
+                },
+                customdata=selecionado["quadrante"],
+                hovertemplate=hovertemplate,
+            )
+        )
+
+    fig.add_vline(x=mediana_followers, line_dash="dash", line_color=_MUTED_CONTEXT_COLOR)
+    fig.add_hline(y=mediana_engajamento, line_dash="dash", line_color=_MUTED_CONTEXT_COLOR)
+
+    for texto, x_paper, y_paper in [
+        ("Nicho", 0.02, 0.98),
+        ("Superstar", 0.98, 0.98),
+        ("Inexpressivo", 0.02, 0.02),
+        ("Gigante Adormecido", 0.98, 0.02),
+    ]:
+        fig.add_annotation(
+            x=x_paper,
+            y=y_paper,
+            xref="paper",
+            yref="paper",
+            text=texto,
+            showarrow=False,
+            font={"color": _MUTED_CONTEXT_COLOR, "size": 11},
+        )
+
+    fig.update_layout(
+        title=title,
+        xaxis_title="Seguidores",
+        yaxis_title="% Engajamento",
+    )
+    return fig

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.visualization.charts import (
     plot_engagement_group_summary_trend,
+    plot_engagement_quadrant_matrix,
     plot_engagement_trend,
     plot_engagement_trend_with_group_context,
     plot_sentiment_diverging_bar,
@@ -217,3 +218,54 @@ def test_plot_engagement_trend_with_group_context_governador_vazio_nao_levanta()
     assert isinstance(fig, go.Figure)
     trace_names = {trace.name for trace in fig.data}
     assert trace_names == {"Fulano", "Média do grupo"}
+
+
+def _df_quadrantes():
+    return pd.DataFrame(
+        {
+            "inputUrl": [
+                "https://www.instagram.com/gov_a/",
+                "https://www.instagram.com/gov_b/",
+                "https://www.instagram.com/gov_c/",
+            ],
+            "followersCount": [100, 900, 500],
+            "% ENGAJAMENTO": [0.01, 0.30, 0.05],
+            "quadrante": ["Inexpressivo", "Superstar", "Inexpressivo"],
+            "mediana_followers": [500, 500, 500],
+            "mediana_engajamento": [0.05, 0.05, 0.05],
+        }
+    )
+
+
+def test_plot_engagement_quadrant_matrix_returns_figure():
+    fig = plot_engagement_quadrant_matrix(_df_quadrantes())
+    assert isinstance(fig, go.Figure)
+
+
+def test_plot_engagement_quadrant_matrix_nao_levanta_com_dataframe_vazio():
+    fig = plot_engagement_quadrant_matrix(pd.DataFrame())
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) == 0
+
+
+def test_plot_engagement_quadrant_matrix_sem_governador_selecionado_um_trace_so():
+    fig = plot_engagement_quadrant_matrix(_df_quadrantes(), governor_url=None)
+    assert len(fig.data) == 1
+    assert len(fig.data[0].x) == 3
+
+
+def test_plot_engagement_quadrant_matrix_destaca_governador_selecionado():
+    fig = plot_engagement_quadrant_matrix(
+        _df_quadrantes(),
+        governor_url="https://www.instagram.com/gov_b/",
+        governor_label="Governador B",
+    )
+    trace_names = {trace.name for trace in fig.data}
+    assert "Governador B" in trace_names
+
+    trace_destacado = next(trace for trace in fig.data if trace.name == "Governador B")
+    assert list(trace_destacado.x) == [900]
+    assert list(trace_destacado.y) == [0.30]
+
+    trace_contexto = next(trace for trace in fig.data if trace.name != "Governador B")
+    assert len(trace_contexto.x) == 2  # gov_a e gov_c, sem o destacado

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.dashboard.comparisons import compute_governor_comparison
+from src.dashboard.comparisons import compute_engagement_quadrants, compute_governor_comparison
 
 METRICS = ["followersCount", "TOTAL ENGAJAMENTO", "% ENGAJAMENTO"]
 
@@ -95,3 +95,100 @@ def test_valores_nulos_na_metrica_nao_entram_no_peer_mean_nem_no_total():
     # governador_a (NaN) fica de fora tanto do total quanto do peer_mean.
     assert linha["total"] == 3
     assert linha["peer_mean"] == pytest.approx((2.0 + 4.0) / 2)
+
+
+# --- compute_engagement_quadrants (ADR 0018) ---
+
+
+def _df_quadrantes():
+    """5 governadores desenhados para cair um em cada quadrante, mais um
+    exatamente na mediana dos dois eixos (gov_mediano) -- mediana de
+    followersCount é 500 (gov_mediano), de % ENGAJAMENTO é 0.05 (também
+    gov_mediano). "Alto"/"alta" é estritamente > mediana, então o próprio
+    ponto da mediana cai do lado "baixo" nos dois eixos."""
+    return pd.DataFrame(
+        {
+            "inputUrl": [
+                "https://www.instagram.com/gov_inexpressivo/",
+                "https://www.instagram.com/gov_gigante/",
+                "https://www.instagram.com/gov_mediano/",
+                "https://www.instagram.com/gov_nicho/",
+                "https://www.instagram.com/gov_superstar/",
+            ],
+            "followersCount": [100, 900, 500, 200, 800],
+            "% ENGAJAMENTO": [0.01, 0.02, 0.05, 0.20, 0.30],
+        }
+    )
+
+
+def _quadrante_de(out: pd.DataFrame, url: str) -> str:
+    return out.set_index("inputUrl").loc[url, "quadrante"]
+
+
+def test_baixa_audiencia_baixo_engajamento_e_inexpressivo():
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert _quadrante_de(out, "https://www.instagram.com/gov_inexpressivo/") == "Inexpressivo"
+
+
+def test_alta_audiencia_baixo_engajamento_e_gigante_adormecido():
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert _quadrante_de(out, "https://www.instagram.com/gov_gigante/") == "Gigante Adormecido"
+
+
+def test_baixa_audiencia_alto_engajamento_e_nicho():
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert _quadrante_de(out, "https://www.instagram.com/gov_nicho/") == "Nicho"
+
+
+def test_alta_audiencia_alto_engajamento_e_superstar():
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert _quadrante_de(out, "https://www.instagram.com/gov_superstar/") == "Superstar"
+
+
+def test_governador_exatamente_na_mediana_cai_do_lado_baixo():
+    """"Alto"/"alta" é estritamente > mediana -- o próprio ponto que define a
+    mediana não pode ficar "acima de si mesmo", então cai em Inexpressivo."""
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert _quadrante_de(out, "https://www.instagram.com/gov_mediano/") == "Inexpressivo"
+
+
+def test_medianas_calculadas_aparecem_como_colunas_de_contexto():
+    out = compute_engagement_quadrants(_df_quadrantes())
+    assert (out["mediana_followers"] == 500).all()
+    assert out["mediana_engajamento"].unique() == pytest.approx([0.05])
+
+
+def test_quadrantes_dataframe_vazio_retorna_vazio_sem_quebrar():
+    out = compute_engagement_quadrants(pd.DataFrame(columns=["inputUrl", "followersCount", "% ENGAJAMENTO"]))
+    assert out.empty
+    assert list(out.columns) == [
+        "inputUrl",
+        "followersCount",
+        "% ENGAJAMENTO",
+        "quadrante",
+        "mediana_followers",
+        "mediana_engajamento",
+    ]
+
+
+def test_quadrantes_uma_linha_so_retorna_vazio_mediana_sem_sentido():
+    df = _df_quadrantes().iloc[[0]]
+    out = compute_engagement_quadrants(df)
+    assert out.empty
+
+
+def test_quadrantes_sem_colunas_necessarias_retorna_vazio_sem_quebrar():
+    """Chamadores como `check_engagement_quadrant` (recommendations.py)
+    recebem `df_engagement` com um subconjunto de colunas diferente por
+    teste -- ausência de followersCount/% ENGAJAMENTO degrada, não quebra."""
+    df = pd.DataFrame({"inputUrl": ["a", "b"], "FREQUENCIA": [1.0, 2.0]})
+    out = compute_engagement_quadrants(df)
+    assert out.empty
+
+
+def test_quadrantes_ignora_linhas_com_valor_nulo():
+    df = _df_quadrantes()
+    df.loc[df["inputUrl"] == "https://www.instagram.com/gov_mediano/", "followersCount"] = np.nan
+    out = compute_engagement_quadrants(df)
+    assert "https://www.instagram.com/gov_mediano/" not in out["inputUrl"].values
+    assert len(out) == 4

--- a/tests/test_engagement_aggregator.py
+++ b/tests/test_engagement_aggregator.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from src.delta_io import conform_to_schema
 from src.features.gold.engagement_aggregator import EngagementAggregator
@@ -99,3 +100,41 @@ def test_colunas_de_perfil_sobrevivem_ate_a_gold():
     df = EngagementAggregator().aggregate(_perfis(), _publicacoes(), pd.DataFrame(), "r1")
     table = conform_to_schema(df, GOLD_ENGAGEMENT_SCHEMA)
     assert {"followsCount", "postsCount"} <= set(table.column_names)
+
+
+def test_engajamento_pondera_comentario_mais_que_curtida():
+    """ADR 0018: `% ENGAJAMENTO` deixa de ser TOTAL/seguidores (curtida e
+    comentário pesando igual) e passa a ser (curtidas + comentários * Wc) /
+    seguidores, com Wc = soma(curtidas) / soma(comentários) da execução
+    inteira. Em `_publicacoes()`, só "ativo" tem posts: likesSum=300,
+    commentsSum=30 -- únicos valores não-zero do dataset -- então
+    Wc = 300/30 = 10.0, e % ENGAJAMENTO(ativo) = (300 + 30*10) / 1000 = 0.6
+    (bem diferente do 0.33 que a fórmula antiga, TOTAL/seguidores, dava)."""
+    df = EngagementAggregator().aggregate(_perfis(), _publicacoes(), pd.DataFrame(), "r1")
+
+    ativo = df.loc[df["username"] == "ativo"].iloc[0]
+    assert ativo["_WC_COMENTARIO"] == pytest.approx(10.0)
+    assert ativo["% ENGAJAMENTO"] == pytest.approx(0.6)
+    # TOTAL ENGAJAMENTO continua a soma bruta (sem peso) -- não muda com o Wc.
+    assert ativo["TOTAL ENGAJAMENTO"] == 330
+
+
+def test_wc_cai_para_1_quando_nao_ha_comentarios_na_execucao():
+    """Sem nenhum comentário na base inteira, Wc = soma(curtidas)/0 dividiria
+    por zero -- precisa degradar para 1.0 (mesmo comportamento da fórmula
+    antiga, curtida e comentário pesando igual) em vez de levantar exceção."""
+    publicacoes_sem_comentarios = _publicacoes().assign(commentsCount=0)
+    df = EngagementAggregator().aggregate(
+        _perfis(), publicacoes_sem_comentarios, pd.DataFrame(), "r1"
+    )
+
+    assert (df["_WC_COMENTARIO"] == 1.0).all()
+    ativo = df.loc[df["username"] == "ativo"].iloc[0]
+    assert ativo["% ENGAJAMENTO"] == pytest.approx(300 / 1000)
+
+
+def test_wc_e_o_mesmo_para_todas_as_linhas_da_execucao():
+    """Wc é calibrado sobre a base inteira, não por perfil -- toda linha da
+    mesma execução carrega o mesmo valor."""
+    df = EngagementAggregator().aggregate(_perfis(), _publicacoes(), pd.DataFrame(), "r1")
+    assert df["_WC_COMENTARIO"].nunique() == 1

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from src.dashboard.recommendations import (
     check_engagement_drop,
+    check_engagement_quadrant,
     check_frequency_below_cluster_peers,
     check_negative_sentiment_topic,
     check_sentiment_trend_drop,
@@ -12,6 +13,7 @@ from src.dashboard.recommendations import (
 GOV_A = "https://www.instagram.com/governador_a/"
 GOV_B = "https://www.instagram.com/governador_b/"
 GOV_C = "https://www.instagram.com/governador_c/"
+GOV_D = "https://www.instagram.com/governador_d/"
 
 
 # --- check_engagement_drop ---
@@ -248,6 +250,63 @@ def test_frequency_below_peers_nao_dispara_com_dataframe_vazio():
     assert check_frequency_below_cluster_peers(df_engagement, _df_profile_clusters(), GOV_A) is None
 
 
+# --- check_engagement_quadrant (ADR 0018) ---
+
+
+def _df_quadrantes_engagement():
+    """Mesma configuração de test_comparisons.py::_df_quadrantes -- um
+    governador em cada quadrante, mais um exatamente na mediana dos dois
+    eixos (mediana de followersCount é 500, de % ENGAJAMENTO é 0.05)."""
+    return pd.DataFrame(
+        {
+            "inputUrl": [GOV_A, GOV_B, "https://www.instagram.com/mediano/", GOV_C, GOV_D],
+            "followersCount": [100, 900, 500, 200, 800],
+            "% ENGAJAMENTO": [0.01, 0.02, 0.05, 0.20, 0.30],
+        }
+    )
+
+
+def test_engagement_quadrant_inexpressivo():
+    msg = check_engagement_quadrant(_df_quadrantes_engagement(), GOV_A)
+    assert msg is not None
+    assert "Inexpressivo" in msg
+
+
+def test_engagement_quadrant_gigante_adormecido():
+    msg = check_engagement_quadrant(_df_quadrantes_engagement(), GOV_B)
+    assert msg is not None
+    assert "Gigante Adormecido" in msg
+
+
+def test_engagement_quadrant_nicho():
+    msg = check_engagement_quadrant(_df_quadrantes_engagement(), GOV_C)
+    assert msg is not None
+    assert "Nicho" in msg
+
+
+def test_engagement_quadrant_superstar():
+    msg = check_engagement_quadrant(_df_quadrantes_engagement(), GOV_D)
+    assert msg is not None
+    assert "Superstar" in msg
+
+
+def test_engagement_quadrant_dado_insuficiente_retorna_none():
+    df = pd.DataFrame({"inputUrl": [GOV_A], "followersCount": [100], "% ENGAJAMENTO": [0.01]})
+    assert check_engagement_quadrant(df, GOV_A) is None
+
+
+def test_engagement_quadrant_sem_colunas_necessarias_retorna_none():
+    df = pd.DataFrame({"inputUrl": [GOV_A, GOV_B], "FREQUENCIA": [1.0, 2.0]})
+    assert check_engagement_quadrant(df, GOV_A) is None
+
+
+def test_engagement_quadrant_governador_nao_encontrado_retorna_none():
+    msg = check_engagement_quadrant(
+        _df_quadrantes_engagement(), "https://www.instagram.com/nao_existe/"
+    )
+    assert msg is None
+
+
 # --- compute_recommendations ---
 
 
@@ -280,6 +339,31 @@ def test_compute_recommendations_agrega_regras_disparadas_na_ordem():
     assert len(achados) == 2
     assert "caiu" in achados[0]
     assert "abaixo da média" in achados[1]
+
+
+def test_compute_recommendations_inclui_achado_de_quadrante_quando_ha_dado():
+    """check_engagement_quadrant é a 6ª regra da lista -- com followersCount/
+    % ENGAJAMENTO suficientes em df_engagement, o achado de quadrante entra
+    junto dos demais."""
+    df_engagement = _df_quadrantes_engagement().assign(FREQUENCIA=1.0)
+    df_engagement_history = pd.DataFrame(columns=["inputUrl", "% ENGAJAMENTO", "_generated_at"])
+    df_sentiment = pd.DataFrame(columns=["inputUrl", "Name", "sentiment_label"])
+    df_sentiment_history = pd.DataFrame(
+        columns=["inputUrl", "sentiment_label", "_run_id", "_generated_at"]
+    )
+    df_reels = pd.DataFrame(columns=["inputUrl", "videoDuration"])
+    df_profile_clusters = pd.DataFrame(columns=["inputUrl", "cluster_perfil_engajamento"])
+
+    achados = compute_recommendations(
+        GOV_A,
+        df_engagement,
+        df_engagement_history,
+        df_sentiment,
+        df_sentiment_history,
+        df_reels,
+        df_profile_clusters,
+    )
+    assert any("Inexpressivo" in achado for achado in achados)
 
 
 def test_compute_recommendations_retorna_lista_vazia_sem_nenhum_disparo():


### PR DESCRIPTION
## Summary
- Registra a ADR 0018, resultado de uma rodada de `/grilling`: alinhar o dashboard/pipeline dos governadores já existente ao que o relatório estratégico da VHL (`VHL_Plano_de_Acao_Reconstrucao_Tese_Vendas.docx`) pede metodologicamente — sem construir nenhum produto/dashboard novo para deputados nesta rodada.
- Implementa a spec da issue #71 (derivada da ADR): `% ENGAJAMENTO` é substituído no lugar por uma versão ponderada (comentário pesa mais que curtida, `Wc` calibrado empiricamente a cada execução, novo campo `_WC_COMENTARIO` no schema Gold; `TOTAL ENGAJAMENTO` fica intacto).
- Adiciona a matriz de quadrantes (audiência × engajamento, corte por mediana, 4 rótulos: Inexpressivo/Gigante Adormecido/Nicho/Superstar) — nova, independente de `governor_profile_clusters_engagement` — calculada no lado do dashboard e plotada na página Performance.
- Adiciona um novo achado em Recommendations (`check_engagement_quadrant`) usando a classificação de quadrante.
- Deixa explicitamente fora de escopo: re-scraping de shares/salvamentos, regressão nova com preditores (Fase 3 do relatório da VHL), e qualquer coisa específica do produto comercial da VHL (LGPD, anonimização, funil de vendas).
- Desvio documentado da spec (comentário na issue #71): o gráfico da matriz não colore pontos por quadrante — a paleta categórica de fallback só valida "all-pairs" (necessário em scatter) até 3 slots, insuficiente para 4 categorias; usa destaque geométrico (linhas de mediana + rótulo de canto) em vez de cor de série.

Closes #71

## Test plan
- [x] `pytest tests/ -q` — 215 passed, 3 skipped
- [x] `ruff check src/` — limpo
- [x] TDD em todos os seams (EngagementAggregator, comparisons.py, charts.py, recommendations.py)
- [x] Revisado via `/code-review` (Standards + Spec) — achados de duplicação corrigidos antes do commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAfkohCjRJVJ1iXz3dZxFg