### PR TITLE
feat(silver): preserva type bruto e hashtags em posts/reels (ADR 0019, parte A)

### DIFF
--- a/src/features/silver/post_cleaner.py
+++ b/src/features/silver/post_cleaner.py
@@ -15,7 +15,6 @@ from src.schemas_delta import SILVER_POSTS_SCHEMA, SILVER_REELS_SCHEMA
 
 class PostCleaner:
     POSTS_COLUMNS_TO_DROP: ClassVar[list[str]] = [
-        "hashtags",
         "mentions",
         "images",
         "childPosts",
@@ -29,6 +28,7 @@ class PostCleaner:
         df = self._drop_null_id(df)
         df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
+        df = self._preserve_type_raw(df)
         df["Tipo"] = "FEED"
         df = self._cast_numerics(df)
         df = self._drop_noise_columns(df)
@@ -40,6 +40,7 @@ class PostCleaner:
         df = self._drop_null_id(df)
         df = deduplicate_latest(df, id_col="id")
         df = self._parse_timestamp(df)
+        df = self._preserve_type_raw(df)
         df["Tipo"] = "REELS"
         df["Total de Engajamento"] = (
             df.get("commentsCount", pd.Series(dtype="int64")).fillna(0)
@@ -63,6 +64,17 @@ class PostCleaner:
 
     def write_reels(self, df_silver: pd.DataFrame, path: Path | str) -> None:
         write_delta(path, df_silver, SILVER_REELS_SCHEMA)
+
+    def _preserve_type_raw(self, df: pd.DataFrame) -> pd.DataFrame:
+        # Preserva o campo bruto `type` do Apify (Image/Video/Sidecar) como
+        # `type_raw`, antes de `Tipo` (FEED/REELS) ser atribuído logo abaixo
+        # -- sem isso, a granularidade original se perde (ADR 0019, parte A:
+        # é o preditor de Formato da regressão de performance-por-post). Se
+        # `type` não vier no Bronze, o método não cria `type_raw` -- quem
+        # preenche o nulo na escrita é `conform_to_schema`.
+        if "type" in df.columns:
+            df = df.rename(columns={"type": "type_raw"})
+        return df
 
     def _parse_timestamp(self, df: pd.DataFrame) -> pd.DataFrame:
         if "timestamp" in df.columns:

--- a/src/schemas_delta.py
+++ b/src/schemas_delta.py
@@ -104,8 +104,16 @@ SILVER_POSTS_SCHEMA = pa.schema(
         pa.field("likesCount", pa.int64(), nullable=False),
         pa.field("data_hora", pa.timestamp("us"), nullable=False),
         pa.field("Tipo", pa.string(), nullable=False),
+        # Campo bruto do Apify (Image/Video/Sidecar), preservado à parte de
+        # `Tipo` (FEED/REELS) -- ADR 0019 (parte A): preditor de Formato da
+        # regressão de performance-por-post.
+        pa.field("type_raw", pa.string(), nullable=True),
         pa.field("shortCode", pa.string(), nullable=True),
         pa.field("caption", pa.string(), nullable=True),
+        # ADR 0019 (parte A): dado já coletado no Bronze, antes descartado em
+        # POSTS_COLUMNS_TO_DROP -- alimenta o BERTopic de tema sobre captions
+        # (parte B).
+        pa.field("hashtags", pa.string(), nullable=True),
         pa.field("videoPlayCount", pa.int64(), nullable=True),
         pa.field("videoDuration", pa.float64(), nullable=True),
         pa.field("_ingested_at", pa.timestamp("us", tz="UTC"), nullable=False),
@@ -126,6 +134,10 @@ SILVER_REELS_SCHEMA = pa.schema(
         pa.field("videoDuration", pa.float64(), nullable=True),
         pa.field("data_hora", pa.timestamp("us"), nullable=False),
         pa.field("Tipo", pa.string(), nullable=False),
+        # Mesmo campo bruto de SILVER_POSTS_SCHEMA -- reels são inerentemente
+        # vídeo hoje, mas preserva a granularidade original por consistência
+        # (ADR 0019, parte A).
+        pa.field("type_raw", pa.string(), nullable=True),
         pa.field("shortCode", pa.string(), nullable=True),
         pa.field("isSponsored", pa.bool_(), nullable=True),
         pa.field("isCommentsDisabled", pa.bool_(), nullable=True),

--- a/tests/test_silver_cleaners.py
+++ b/tests/test_silver_cleaners.py
@@ -126,6 +126,74 @@ def test_post_cleaner_descarta_linhas_com_id_nulo():
     assert outr.iloc[0]["id"] == "p1"
 
 
+def test_post_cleaner_preserva_type_raw_e_hashtags():
+    """ADR 0019 (issue A): o campo bruto `type` do Apify (Image/Video/Sidecar)
+    e `hashtags` já chegam ao Bronze, mas hoje são descartados no
+    Bronze->Silver -- `type` porque `Tipo` (FEED/REELS) o sobrescreve sem
+    preservar o original, `hashtags` porque está em
+    POSTS_COLUMNS_TO_DROP. Precisam sobreviver como `type_raw`/`hashtags`,
+    sem mudar `Tipo`."""
+    df = pd.DataFrame(
+        {
+            "id": ["p1"],
+            "ownerId": ["1"],
+            "ownerUsername": ["g"],
+            "commentsCount": [1],
+            "likesCount": [2],
+            "timestamp": ["2026-05-01T00:00:00+00:00"],
+            "type": ["Sidecar"],
+            "hashtags": ['["politica", "brasil"]'],
+            "_ingested_at": pd.to_datetime(["2026-05-01"], utc=True),
+            "_run_id": ["r1"],
+        }
+    )
+    out = PostCleaner().clean_posts(df)
+    assert out.loc[0, "type_raw"] == "Sidecar"
+    assert out.loc[0, "hashtags"] == '["politica", "brasil"]'
+    assert out.loc[0, "Tipo"] == "FEED"
+
+
+def test_reel_cleaner_preserva_type_raw():
+    df = pd.DataFrame(
+        {
+            "id": ["r1"],
+            "ownerId": ["1"],
+            "ownerUsername": ["g"],
+            "commentsCount": [1],
+            "likesCount": [2],
+            "timestamp": ["2026-05-01T00:00:00+00:00"],
+            "type": ["Video"],
+            "latestComments": ["[]"],
+            "_ingested_at": pd.to_datetime(["2026-05-01"], utc=True),
+            "_run_id": ["r1"],
+        }
+    )
+    out = PostCleaner().clean_reels(df)
+    assert out.loc[0, "type_raw"] == "Video"
+    assert out.loc[0, "Tipo"] == "REELS"
+
+
+def test_post_cleaner_sem_type_ou_hashtags_nao_quebra():
+    """Bronze sem esses campos (coluna ausente) não pode quebrar a limpeza --
+    `conform_to_schema` preenche `type_raw`/`hashtags` como nulos na escrita,
+    não é responsabilidade do PostCleaner sintetizá-los."""
+    df = pd.DataFrame(
+        {
+            "id": ["p1"],
+            "ownerId": ["1"],
+            "ownerUsername": ["g"],
+            "commentsCount": [1],
+            "likesCount": [2],
+            "timestamp": ["2026-05-01T00:00:00+00:00"],
+            "_ingested_at": pd.to_datetime(["2026-05-01"], utc=True),
+            "_run_id": ["r1"],
+        }
+    )
+    out = PostCleaner().clean_posts(df)
+    assert "type_raw" not in out.columns or out["type_raw"].isna().all()
+    assert "hashtags" not in out.columns or out["hashtags"].isna().all()
+
+
 def test_post_cleaner_deduplica_execucoes_acumuladas():
     """
     A Bronze é append-only. Sem deduplicação, reprocessar o pipeline


### PR DESCRIPTION
## Summary
- Implementa a issue #73 (parte A de 5 da ADR 0019, regressão de performance-por-post): `PostCleaner` passa a preservar o campo bruto `type` do Apify (como `type_raw`, sem colidir com `Tipo`=FEED/REELS) e a coluna `hashtags` (antes descartada em `POSTS_COLUMNS_TO_DROP`), em `posts_clean`/`reels_clean`.
- Sem re-scraping — os dois campos já chegam no Bronze, só eram descartados na limpeza Bronze→Silver.
- `Tipo` (FEED/REELS) fica completamente intocado. Ausência de `type`/`hashtags` no Bronze não quebra a limpeza (`conform_to_schema` preenche nulo na escrita, mesmo padrão já usado no resto do projeto).

Closes #73

## Test plan
- [x] `pytest tests/ -q` — 218 passed, 3 skipped
- [x] `ruff check src/` — limpo
- [x] TDD (`tests/test_silver_cleaners.py`)
- [x] Revisado via `/code-review` (Standards + Spec) — achados de estilo corrigidos antes do commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAfkohCjRJVJ1iXz3dZxFg