### PR TITLE
feat(modeling): BERTopic sobre captions de post, preditor de Tema (ADR 0019, parte B)

### DIFF
--- a/src/modeling/config.py
+++ b/src/modeling/config.py
@@ -73,6 +73,20 @@ class TopicModelConfig:
 
 
 @dataclass
+class PostTopicModelConfig(TopicModelConfig):
+    """Config de BERTopic para captions de post (ADR 0019, parte B) --
+    corpus de algumas centenas de documentos (não ~13,5 mil como
+    comentários), então `nr_topics`/HDBSCAN bem menores que
+    `TopicModelConfig` evitam fragmentar demais o preditor de Tema. Valores
+    ainda placeholders (issue explicitamente deixa "a calibrar" contra o
+    volume real de posts coletados), não derivados de dados reais."""
+
+    hdbscan_min_cluster_size: int = 5
+    hdbscan_min_samples: int = 2
+    nr_topics: int = 15
+
+
+@dataclass
 class ModelingConfig:
     pca: PCAConfig = field(default_factory=PCAConfig)
     cluster: ClusterConfig = field(default_factory=ClusterConfig)

--- a/src/modeling/topics.py
+++ b/src/modeling/topics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import logging
 import time
 from typing import Any
@@ -13,7 +14,12 @@ from bertopic.representation import KeyBERTInspired
 from hdbscan import HDBSCAN
 from sklearn.feature_extraction.text import CountVectorizer
 
-from src.modeling.config import TopicModelConfig
+from src.modeling.config import (
+    PostTopicModelConfig,
+    PreprocessingConfig,
+    TopicModelConfig,
+)
+from src.modeling.preprocessing import preprocess_comments
 
 logger = logging.getLogger(__name__)
 
@@ -79,3 +85,68 @@ def model_topics(
     topics = document_info["Topic"].tolist()
 
     return topic_model, topics, probs, document_info
+
+
+def merge_topic_info(df: pd.DataFrame, document_info: pd.DataFrame) -> pd.DataFrame:
+    """Junta por posição (não por índice) o `document_info` do BERTopic a
+    `df`, na mesma ordem de `docs` usada em `model_topics`, descartando a
+    coluna `Document` (redundante com o texto de origem).
+
+    Mesma lógica de `_merge_topic_info` em `orchestration.py` (comentários)
+    -- duplicada aqui, não promovida, porque a consolidação das duas
+    chamadas fica para a issue #75 (ADR 0019, parte C), que é quem de fato
+    une os dois usos na orquestração."""
+    df_reset = df.reset_index(drop=True)
+    info_reset = document_info.reset_index(drop=True)
+    return pd.concat([df_reset, info_reset], axis=1).drop(columns=["Document"])
+
+
+def hashtags_to_text(hashtags: Any) -> str:
+    """`hashtags` chega do Silver como uma lista serializada em string (ex.:
+    `'["politica", "brasil"]'`, ver ADR 0019 parte A) -- extrai as palavras
+    como texto plano, sem colchetes/aspas, pra não poluir o vocabulário do
+    BERTopic com sintaxe de lista. Nulo/vazio/malformado vira string vazia,
+    nunca quebra o ajuste."""
+    if not isinstance(hashtags, str) or not hashtags.strip():
+        return ""
+    try:
+        tags = ast.literal_eval(hashtags)
+    except (ValueError, SyntaxError):
+        return ""
+    if not isinstance(tags, list):
+        return ""
+    return " ".join(str(tag) for tag in tags)
+
+
+def _build_post_documents(df_posts: pd.DataFrame) -> pd.Series:
+    captions = df_posts["caption"].fillna("")
+    hashtags_texto = df_posts["hashtags"].apply(hashtags_to_text)
+    return (captions + " " + hashtags_texto).str.strip()
+
+
+def classify_post_topics(
+    df_posts: pd.DataFrame,
+    config: PostTopicModelConfig,
+    preprocessing_config: PreprocessingConfig | None = None,
+    embedding_model: Any | None = None,
+) -> tuple[BERTopic, pd.DataFrame]:
+    """Classifica cada post num tópico (BERTopic sobre `caption`+`hashtags`),
+    pro preditor de Tema da regressão de performance-por-post (ADR 0019,
+    parte B). Reaproveita `model_topics()` como está -- só uma config e uma
+    chamada novas, sem nenhuma mudança na função genérica.
+
+    `df_posts` precisa das colunas `caption` e `hashtags` (Silver, ADR 0019
+    parte A); posts com `caption` nula/vazia não quebram o ajuste (viram
+    documento vazio ou só hashtags). Retorna o DataFrame de posts com as
+    colunas do BERTopic (`Topic`, `Name`, etc.) juntadas por posição."""
+    preprocessing_config = preprocessing_config or PreprocessingConfig(text_column="document")
+    df_docs = pd.DataFrame({preprocessing_config.text_column: _build_post_documents(df_posts)})
+    df_preprocessed = preprocess_comments(df_docs, preprocessing_config)
+    docs = list(df_preprocessed["text_demojized"])
+
+    topic_model, _topics, _probs, document_info = model_topics(
+        docs, config, embedding_model=embedding_model
+    )
+
+    df_final = merge_topic_info(df_posts, document_info)
+    return topic_model, df_final

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,8 +1,14 @@
 import numpy as np
+import pandas as pd
 from bertopic.backend import BaseEmbedder
 
-from src.modeling.config import TopicModelConfig
-from src.modeling.topics import model_topics
+from src.modeling.config import PostTopicModelConfig, TopicModelConfig
+from src.modeling.topics import (
+    classify_post_topics,
+    hashtags_to_text,
+    merge_topic_info,
+    model_topics,
+)
 
 N_GRUPOS = 4
 DOCS_POR_GRUPO = 8
@@ -98,3 +104,83 @@ def test_model_topics_retorna_document_info_com_colunas_esperadas():
     _, _, _, document_info = model_topics(docs, config, embedding_model=_FakeEmbedder())
 
     assert {"Document", "Topic", "Name"} <= set(document_info.columns)
+
+
+def test_merge_topic_info_junta_por_posicao_e_descarta_document():
+    df = pd.DataFrame({"caption": ["a", "b"]})
+    document_info = pd.DataFrame({"Document": ["x", "y"], "Topic": [0, 1], "Name": ["t0", "t1"]})
+
+    resultado = merge_topic_info(df, document_info)
+
+    assert "Document" not in resultado.columns
+    assert resultado["Topic"].tolist() == [0, 1]
+    assert resultado["caption"].tolist() == ["a", "b"]
+
+
+def test_hashtags_to_text_extrai_palavras_da_lista_serializada():
+    assert hashtags_to_text('["politica", "brasil"]') == "politica brasil"
+    assert hashtags_to_text("[]") == ""
+
+
+def test_hashtags_to_text_trata_nulo_vazio_e_malformado_como_vazio():
+    assert hashtags_to_text(None) == ""
+    assert hashtags_to_text(np.nan) == ""
+    assert hashtags_to_text("") == ""
+    assert hashtags_to_text("   ") == ""
+    assert hashtags_to_text("não é uma lista") == ""
+    # Sintaticamente válido, mas não é uma lista -- não pode virar texto.
+    assert hashtags_to_text('"apenas uma string"') == ""
+
+
+def _df_posts_sinteticos():
+    return pd.DataFrame(
+        {
+            "caption": [
+                f"grupo{i} legenda numero {j} sobre o tema {i}"
+                for i in range(N_GRUPOS)
+                for j in range(DOCS_POR_GRUPO)
+            ],
+            "hashtags": [None] * (N_GRUPOS * DOCS_POR_GRUPO),
+        }
+    )
+
+
+def _post_topic_config():
+    return PostTopicModelConfig(
+        hdbscan_min_cluster_size=4,
+        hdbscan_min_samples=2,
+        nr_topics=3,
+        calculate_probabilities=False,
+        verbose=False,
+    )
+
+
+def test_classify_post_topics_com_embedder_fake_produz_topico_por_post():
+    df_posts = _df_posts_sinteticos()
+
+    topic_model, df_final = classify_post_topics(
+        df_posts, _post_topic_config(), embedding_model=_FakeEmbedder()
+    )
+
+    assert len(df_final) == len(df_posts)
+    assert "Topic" in df_final.columns
+    assert "Document" not in df_final.columns
+    # Colunas originais de df_posts preservadas, na mesma ordem de linhas.
+    assert df_final["caption"].tolist() == df_posts["caption"].tolist()
+    topicos_nao_ruido = {t for t in df_final["Topic"] if t != -1}
+    assert len(topicos_nao_ruido) < N_GRUPOS
+
+
+def test_classify_post_topics_caption_nula_ou_vazia_nao_quebra():
+    df_posts = _df_posts_sinteticos()
+    # Últimos dois posts: caption nula (None) e vazia ("") -- nenhum dos
+    # dois pode quebrar o ajuste.
+    df_posts.loc[len(df_posts) - 1, "caption"] = None
+    df_posts.loc[len(df_posts) - 1, "hashtags"] = '["extra"]'
+    df_posts.loc[len(df_posts) - 2, "caption"] = ""
+
+    topic_model, df_final = classify_post_topics(
+        df_posts, _post_topic_config(), embedding_model=_FakeEmbedder()
+    )
+
+    assert len(df_final) == len(df_posts)


### PR DESCRIPTION
## Summary
- `PostTopicModelConfig` (herda de `TopicModelConfig`, só troca `nr_topics`/HDBSCAN para o corpus bem menor de captions de post).
- `classify_post_topics()` em `src/modeling/topics.py`: concatena `caption`+`hashtags` (parseado via `hashtags_to_text()`, que trata o formato serializado `'["a", "b"]'` do Silver), preprocessa (reaproveita `preprocess_comments`) e chama `model_topics()` — sem nenhuma mudança na função genérica.
- `merge_topic_info()`: junta o `document_info` do BERTopic de volta ao DataFrame de posts por posição, análoga a `_merge_topic_info` (privada em `orchestration.py`) — duplicada, não promovida; consolidação fica para a issue #75.

## Fora de escopo (por design)
- Wiring em `orchestration.py`/execução no pipeline — issue #75 (parte C, núcleo da regressão).
- Refinamento via Gemini.
- Qualquer mudança em `model_topics()`.

## Test plan
- [x] `pytest tests/` — 223 passed, 3 skipped
- [x] `ruff check src/` — limpo
- [x] `/code-review` (Standards + Spec, sub-agentes paralelos) — achados corrigidos antes do commit (herança em `PostTopicModelConfig`, teste de caption vazia adicionado)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DNsAP2pcPURMq2JFpYscd