### PR TITLE
feat(modeling): nucleo da regressao de performance-por-post (ADR 0019, parte C)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -68,6 +68,11 @@ GOLD_SENTIMENT = GOLD_DIR / "governor_sentiment"
 GOLD_SENTIMENT_HISTORY = GOLD_DIR / "governor_sentiment_history"
 GOLD_CLUSTERS = GOLD_DIR / "governor_clusters"
 GOLD_PROFILE_CLUSTERS_ENGAGEMENT = GOLD_DIR / "governor_profile_clusters_engagement"
+# ADR 0019 (parte C): regressão de performance-por-post, uma tabela por
+# conceito (coeficientes+R² e previsão/resíduo por post), `grupo`
+# (vídeo/estático) como dimensão em vez de duas tabelas quase idênticas.
+GOLD_POST_PERFORMANCE_COEFFICIENTS = GOLD_DIR / "post_performance_coefficients"
+GOLD_POST_PERFORMANCE_PREDICTIONS = GOLD_DIR / "post_performance_predictions"
 
 # Checkpoints locais do estágio determinístico de modelagem (ver ADR 0003) —
 # não são Delta, ficam fora do git.

--- a/pipeline.py
+++ b/pipeline.py
@@ -133,7 +133,12 @@ def run_medallion_pipeline(
                 "(PCA -> clustering -> sentimento -> tópicos)..."
             )
             result = run_deterministic_modeling(
-                df_reels_silver, df_comments_silver, ModelingConfig(), parent_run_id=run_id
+                df_reels_silver,
+                df_comments_silver,
+                df_posts_silver,
+                df_gold,
+                ModelingConfig(),
+                parent_run_id=run_id,
             )
             logger.info(f"[MODELAGEM] Concluída com run_id: {result.run_id}")
         except Exception as e:

--- a/scripts/run_modeling.py
+++ b/scripts/run_modeling.py
@@ -1,7 +1,7 @@
 """
 Roda o estágio determinístico de modelagem (PCA -> clustering -> sentimento
--> tópicos) sobre a Silver já existente, sem reprocessar Bronze/Silver/
-Gold-engagement. Ver ADR 0003.
+-> tópicos -> performance-por-post) sobre a Silver/Gold-engagement já
+existentes, sem reprocessar Bronze/Silver/Gold-engagement. Ver ADR 0003.
 """
 
 import argparse
@@ -24,9 +24,17 @@ def run(run_id: str | None = None, parent_run_id: str | None = None) -> str:
     repo = DeltaRepository(gold_dir=settings.GOLD_DIR, silver_dir=settings.SILVER_DIR)
     df_reels = repo.load_reels()
     df_comments = repo.load_comments()
+    df_posts = repo.load_posts()
+    df_engagement = repo.load_profiles()
 
     result = run_deterministic_modeling(
-        df_reels, df_comments, ModelingConfig(), run_id=run_id, parent_run_id=parent_run_id
+        df_reels,
+        df_comments,
+        df_posts,
+        df_engagement,
+        ModelingConfig(),
+        run_id=run_id,
+        parent_run_id=parent_run_id,
     )
     return result.run_id
 

--- a/src/features/gold/model_enricher.py
+++ b/src/features/gold/model_enricher.py
@@ -12,6 +12,8 @@ import pandas as pd
 from src.delta_io import write_delta
 from src.schemas_delta import (
     GOLD_CLUSTERS_SCHEMA,
+    GOLD_POST_PERFORMANCE_COEFFICIENTS_SCHEMA,
+    GOLD_POST_PERFORMANCE_PREDICTIONS_SCHEMA,
     GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA,
     GOLD_SENTIMENT_SCHEMA,
 )
@@ -97,3 +99,56 @@ class ModelEnricher:
             }
         )
         write_delta(path, df_clusters, GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA)
+
+    def write_post_performance_coefficients(
+        self,
+        df_coefficients: pd.DataFrame,
+        path: Path | str,
+        run_id: str,
+    ) -> None:
+        """Grava coeficientes+R² da regressão de performance-por-post (ADR
+        0019, parte C). Espera as colunas produzidas por
+        `run_post_performance_stage`: grupo, preditor, coeficiente,
+        r2_treino, r2_holdout, n_treino, n_holdout, alpha."""
+        required = {
+            "grupo",
+            "preditor",
+            "coeficiente",
+            "r2_treino",
+            "r2_holdout",
+            "n_treino",
+            "n_holdout",
+            "alpha",
+        }
+        missing = required - set(df_coefficients.columns)
+        if missing:
+            raise ValueError(
+                f"df_coefficients não tem as colunas esperadas: {sorted(missing)}"
+            )
+
+        df = df_coefficients.copy()
+        df["_run_id"] = run_id
+        df["_generated_at"] = datetime.now(timezone.utc)
+        write_delta(path, df, GOLD_POST_PERFORMANCE_COEFFICIENTS_SCHEMA)
+
+    def write_post_performance_predictions(
+        self,
+        df_predictions: pd.DataFrame,
+        path: Path | str,
+        run_id: str,
+    ) -> None:
+        """Grava previsão/resíduo por post da regressão de
+        performance-por-post (ADR 0019, parte C). Espera as colunas
+        produzidas por `run_post_performance_stage`: id, inputUrl, grupo,
+        y_real, y_previsto, residuo."""
+        required = {"id", "inputUrl", "grupo", "y_real", "y_previsto", "residuo"}
+        missing = required - set(df_predictions.columns)
+        if missing:
+            raise ValueError(
+                f"df_predictions não tem as colunas esperadas: {sorted(missing)}"
+            )
+
+        df = df_predictions.copy()
+        df["_run_id"] = run_id
+        df["_generated_at"] = datetime.now(timezone.utc)
+        write_delta(path, df, GOLD_POST_PERFORMANCE_PREDICTIONS_SCHEMA)

--- a/src/modeling/config.py
+++ b/src/modeling/config.py
@@ -87,16 +87,59 @@ class PostTopicModelConfig(TopicModelConfig):
 
 
 @dataclass
+class PostPerformanceConfig:
+    """Config do estágio de regressão de performance-por-post (ADR 0019,
+    parte C) -- dois grupos (vídeo=Reels, estático=Posts), holdout de
+    governadores compartilhado entre os dois grupos, Lasso com alpha
+    escolhido por validação cruzada (`LassoCV`)."""
+
+    holdout_governors_count: int = 7
+    random_state: int = 42
+    lasso_cv_folds: int = 5
+    lasso_max_iter: int = 10_000
+    circularity_correlation_threshold: float = 0.95
+    # Colunas brutas que compõem Y (`(likesCount + commentsCount*Wc) /
+    # followersCount`) -- nenhum preditor pode ser literalmente uma delas.
+    raw_target_columns: tuple[str, ...] = ("likesCount", "commentsCount")
+    numeric_predictors_comuns: list[str] = field(
+        default_factory=lambda: ["hora_do_dia", "FREQUENCIA", "videoDuration", "tem_duracao"]
+    )
+    categorical_predictors_comuns: list[str] = field(
+        default_factory=lambda: ["type_raw", "dia_da_semana"]
+    )
+    # `videoPlayCount` (controle de alcance, ADR 0019 decisão 2) e
+    # `paidPartnership` (via `isSponsored`) só existem para o grupo vídeo
+    # (Reels) -- `isSponsored` nem existe no Bronze/Silver de posts estáticos.
+    numeric_predictors_video: list[str] = field(
+        default_factory=lambda: ["videoPlayCount", "paidPartnership"]
+    )
+    categorical_predictors_video: list[str] = field(default_factory=list)
+    # `comprimento_legenda`/`Topic` (Tema) só existem para o grupo estático
+    # (Posts) -- Reels não têm campo de caption no Bronze/Silver hoje
+    # (limitação estrutural de dado coletado, não escolha de design; ver
+    # `BRONZE_REELS_SCHEMA`/`SILVER_REELS_SCHEMA`, nenhum dos dois declara
+    # `caption`/`hashtags`).
+    numeric_predictors_estatico: list[str] = field(
+        default_factory=lambda: ["comprimento_legenda"]
+    )
+    categorical_predictors_estatico: list[str] = field(default_factory=lambda: ["Topic"])
+
+
+@dataclass
 class ModelingConfig:
     pca: PCAConfig = field(default_factory=PCAConfig)
     cluster: ClusterConfig = field(default_factory=ClusterConfig)
     sentiment: SentimentConfig = field(default_factory=SentimentConfig)
     preprocessing: PreprocessingConfig = field(default_factory=PreprocessingConfig)
     topics: TopicModelConfig = field(default_factory=TopicModelConfig)
+    post_topics: PostTopicModelConfig = field(default_factory=PostTopicModelConfig)
+    post_performance: PostPerformanceConfig = field(default_factory=PostPerformanceConfig)
     gold_clusters_path: Path = settings.GOLD_CLUSTERS
     gold_sentiment_path: Path = settings.GOLD_SENTIMENT
     # Tabela paralela de histórico (mode append) -- ver issue #52 / ADR 0017.
     gold_sentiment_history_path: Path = settings.GOLD_SENTIMENT_HISTORY
+    gold_post_performance_coefficients_path: Path = settings.GOLD_POST_PERFORMANCE_COEFFICIENTS
+    gold_post_performance_predictions_path: Path = settings.GOLD_POST_PERFORMANCE_PREDICTIONS
     checkpoints_dir: Path = settings.MODEL_CHECKPOINTS_DIR
     logs_dir: Path = settings.LOGS_DIR
 

--- a/src/modeling/orchestration.py
+++ b/src/modeling/orchestration.py
@@ -16,9 +16,10 @@ from src.modeling.clustering import cluster_reels
 from src.modeling.config import GeminiRefinerConfig, ModelingConfig
 from src.modeling.gemini_refiner import apply_gemini_refinement
 from src.modeling.pca import reduce_dimensions
+from src.modeling.post_performance import run_post_performance_stage
 from src.modeling.preprocessing import preprocess_comments
 from src.modeling.sentiment import analyze_sentiment
-from src.modeling.topics import model_topics
+from src.modeling.topics import classify_post_topics, model_topics
 from src.run_id import build_run_id
 
 logger = logging.getLogger(__name__)
@@ -52,14 +53,18 @@ def _merge_topic_info(df_comments: pd.DataFrame, document_info: pd.DataFrame) ->
 def run_deterministic_modeling(
     df_reels: pd.DataFrame,
     df_comments: pd.DataFrame,
+    df_posts: pd.DataFrame,
+    df_engagement: pd.DataFrame,
     config: ModelingConfig,
     run_id: str | None = None,
     parent_run_id: str | None = None,
 ) -> DeterministicModelingResult:
     """Estágio 100% automatizável: PCA -> clustering -> sentimento -> tópicos
-    (representação determinística via KeyBERTInspired, não via Gemini).
-    Escreve as duas tabelas Gold (clusters e sentimento/tópicos provisórios)
-    sob um único `run_id` novo.
+    -> performance-por-post (representação determinística via
+    KeyBERTInspired, não via Gemini). Escreve as quatro tabelas Gold
+    (clusters, sentimento/tópicos provisórios, coeficientes e
+    previsão/resíduo da regressão de performance-por-post) sob um único
+    `run_id` novo.
 
     `parent_run_id`, se informado, é só rastreabilidade -- o `run_id` da
     extração/invocação de `pipeline.py` que disparou esta chamada, gravado
@@ -117,6 +122,35 @@ def run_deterministic_modeling(
         mode="append",
         generated_at=generated_at,
     )
+
+    logger.info(
+        "[PERFORMANCE-POR-POST] Classificando tema das captions e treinando "
+        "Lasso vídeo/estático..."
+    )
+    try:
+        _post_topic_model, df_posts_com_tema = classify_post_topics(df_posts, config.post_topics)
+        performance_result = run_post_performance_stage(
+            df_posts_com_tema, df_reels, df_engagement, config.post_performance
+        )
+        enricher.write_post_performance_coefficients(
+            performance_result.coefficients,
+            config.gold_post_performance_coefficients_path,
+            run_id,
+        )
+        enricher.write_post_performance_predictions(
+            performance_result.predictions,
+            config.gold_post_performance_predictions_path,
+            run_id,
+        )
+    except Exception:
+        # ADR 0019 (parte C), user story 13: dado insuficiente para treinar
+        # (ou qualquer outra falha desta etapa) não pode derrubar PCA/
+        # clustering/sentimento/tópicos que já rodaram com sucesso na mesma
+        # execução -- loga e pula só a escrita Gold desta etapa.
+        logger.exception(
+            "[PERFORMANCE-POR-POST] Falha ao treinar/persistir -- etapa "
+            "pulada, pipeline segue com os demais estágios."
+        )
 
     # Checkpoint incondicional (ver ADR 0003): sem ele, o refinamento via
     # Gemini só poderia rodar no mesmo processo que acabou de ajustar o

--- a/src/modeling/post_performance.py
+++ b/src/modeling/post_performance.py
@@ -1,0 +1,335 @@
+"""Regressão de performance-por-post: circularidade + preditores + Lasso
+vídeo/estático (ADR 0019, parte C)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import LassoCV
+from sklearn.metrics import r2_score
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from src.modeling.config import PostPerformanceConfig
+
+logger = logging.getLogger(__name__)
+
+GRUPO_VIDEO = "video"
+GRUPO_ESTATICO = "estatico"
+
+_DIAS_DA_SEMANA_PT = [
+    "segunda",
+    "terca",
+    "quarta",
+    "quinta",
+    "sexta",
+    "sabado",
+    "domingo",
+]
+
+
+class CircularityError(Exception):
+    """Preditor circular detectado -- a regressão não deve rodar (ADR 0019,
+    decisão 7: é o erro que motivou todo este trabalho)."""
+
+
+@dataclass
+class GroupModelResult:
+    grupo: str
+    coeficientes: pd.DataFrame
+    previsoes: pd.DataFrame
+    r2_treino: float
+    r2_holdout: float
+    n_treino: int
+    n_holdout: int
+    alpha: float
+
+
+@dataclass
+class PostPerformanceStageResult:
+    coefficients: pd.DataFrame
+    predictions: pd.DataFrame
+
+
+def assemble_predictors(
+    df_group: pd.DataFrame,
+    df_engagement: pd.DataFrame,
+    grupo: str,
+) -> pd.DataFrame:
+    """Monta preditores + Y de um grupo (`GRUPO_VIDEO`/`GRUPO_ESTATICO`) a
+    partir do Silver já enriquecido (`type_raw`/`hashtags` da issue A,
+    `Topic` da issue B quando presente) e do `governor_engagement` (Gold,
+    `_WC_COMENTARIO`/`FREQUENCIA`/`followersCount` por perfil).
+
+    `caption`/`hashtags`/`Topic` só existem hoje em `posts_clean` -- Reels
+    não têm campo de caption no Bronze/Silver (limitação estrutural de dado
+    coletado, não escolha de design) -- por isso comprimento de legenda e
+    Tema só entram quando essas colunas já estão presentes em `df_group`
+    (grupo estático).
+
+    Descarta posts cujo perfil não tem `followersCount` positivo em
+    `df_engagement` -- sem seguidores não há como calcular a taxa que
+    compõe Y (divisão por zero)."""
+    df = df_group.copy()
+
+    df["hora_do_dia"] = df["data_hora"].dt.hour
+    df["dia_da_semana"] = df["data_hora"].dt.dayofweek.map(dict(enumerate(_DIAS_DA_SEMANA_PT)))
+    df["tem_duracao"] = df["videoDuration"].notna().astype(int)
+    df["videoDuration"] = df["videoDuration"].fillna(0.0)
+
+    if "caption" in df.columns:
+        df["comprimento_legenda"] = df["caption"].fillna("").str.len()
+
+    if grupo == GRUPO_VIDEO:
+        df["paidPartnership"] = df["isSponsored"].fillna(False).astype(int)
+
+    # `df_engagement["id"]` é o governador -- renomeado antes do merge para
+    # não colidir com o `id` do próprio post/reel já presente em `df`.
+    engagement_cols = df_engagement[["id", "_WC_COMENTARIO", "FREQUENCIA", "followersCount"]].rename(
+        columns={"id": "_governor_id"}
+    )
+    df = df.merge(engagement_cols, left_on="ownerId", right_on="_governor_id", how="inner").drop(
+        columns=["_governor_id"]
+    )
+
+    followers_validos = df["followersCount"].where(df["followersCount"] > 0)
+    df["y"] = (df["likesCount"] + df["commentsCount"] * df["_WC_COMENTARIO"]) / followers_validos
+
+    n_antes = len(df)
+    df = df.dropna(subset=["y"])
+    if len(df) < n_antes:
+        logger.debug(
+            "assemble_predictors (%s): %d posts descartados por followersCount<=0.",
+            grupo,
+            n_antes - len(df),
+        )
+
+    return df
+
+
+def resolve_predictor_columns(
+    df: pd.DataFrame, config: PostPerformanceConfig, grupo: str
+) -> tuple[list[str], list[str]]:
+    """Resolve as colunas numéricas/categóricas de um grupo, filtrando às
+    que de fato existem em `df` -- `comprimento_legenda`/`Topic` (estático)
+    e `videoPlayCount`/`paidPartnership` (vídeo) só entram quando o grupo
+    correspondente de fato os produziu (ver `assemble_predictors`)."""
+    numeric = list(config.numeric_predictors_comuns)
+    categorical = list(config.categorical_predictors_comuns)
+    if grupo == GRUPO_VIDEO:
+        numeric += config.numeric_predictors_video
+        categorical += config.categorical_predictors_video
+    else:
+        numeric += config.numeric_predictors_estatico
+        categorical += config.categorical_predictors_estatico
+
+    numeric = [coluna for coluna in numeric if coluna in df.columns]
+    categorical = [coluna for coluna in categorical if coluna in df.columns]
+    return numeric, categorical
+
+
+def check_circularity(
+    df: pd.DataFrame,
+    y_column: str,
+    numeric_predictors: list[str],
+    categorical_predictors: list[str],
+    raw_target_columns: tuple[str, ...],
+    correlation_threshold: float,
+) -> None:
+    """Falha alto e cedo (ADR 0019, decisão 7) se algum preditor for
+    literalmente uma das colunas brutas que compõem Y, ou se a correlação
+    bruta entre um preditor numérico e Y ultrapassar `correlation_threshold`."""
+    todos_preditores = set(numeric_predictors) | set(categorical_predictors)
+    preditores_proibidos = todos_preditores & set(raw_target_columns)
+    if preditores_proibidos:
+        raise CircularityError(
+            f"Preditores derivados das mesmas colunas brutas de Y: "
+            f"{sorted(preditores_proibidos)}"
+        )
+
+    y = df[y_column]
+    for coluna in numeric_predictors:
+        # Coluna constante (variância zero, ex.: `tem_duracao` sempre 1 no
+        # grupo vídeo) não tem correlação definida -- e não carrega
+        # informação nenhuma sobre Y, então não pode ser circular.
+        if df[coluna].std(ddof=0) == 0:
+            continue
+        correlacao = df[coluna].corr(y)
+        if pd.notna(correlacao) and abs(correlacao) > correlation_threshold:
+            raise CircularityError(
+                f"Preditor '{coluna}' tem correlação {correlacao:.3f} com Y "
+                f"(limiar: {correlation_threshold}) -- risco de circularidade."
+            )
+
+
+def select_holdout_governors(
+    governor_ids: pd.Series, config: PostPerformanceConfig
+) -> set[str]:
+    """Sorteia o conjunto de governadores em holdout, o mesmo para os dois
+    grupos (ADR 0019, decisão 5 -- os dois R² de holdout ficam comparáveis).
+    Ordena antes de sortear para que o resultado dependa só de
+    `config.random_state`, não da ordem de chegada de `governor_ids`."""
+    ids_unicos = sorted(set(governor_ids))
+    n_holdout = min(config.holdout_governors_count, len(ids_unicos))
+    rng = np.random.default_rng(config.random_state)
+    holdout = rng.choice(ids_unicos, size=n_holdout, replace=False)
+    return set(holdout)
+
+
+def train_evaluate_group(
+    df: pd.DataFrame,
+    grupo: str,
+    numeric_predictors: list[str],
+    categorical_predictors: list[str],
+    holdout_governors: set[str],
+    config: PostPerformanceConfig,
+) -> GroupModelResult:
+    """Ajusta um `Lasso` (alpha por `LassoCV`) sobre o holdout de
+    governadores em `holdout_governors`, com `StandardScaler` nos
+    preditores numéricos e one-hot nos categóricos. Retorna coeficientes
+    por preditor, R² de treino/holdout, e previsão/resíduo por post
+    (treino e holdout juntos)."""
+    em_holdout = df["ownerId"].isin(holdout_governors)
+    df_treino = df.loc[~em_holdout]
+    df_holdout = df.loc[em_holdout]
+
+    colunas_preditoras = numeric_predictors + categorical_predictors
+    preprocessador = ColumnTransformer(
+        [
+            ("numericas", StandardScaler(), numeric_predictors),
+            (
+                "categoricas",
+                OneHotEncoder(handle_unknown="ignore"),
+                categorical_predictors,
+            ),
+        ]
+    )
+    modelo = Pipeline(
+        [
+            ("preprocessamento", preprocessador),
+            (
+                "lasso",
+                LassoCV(
+                    cv=min(config.lasso_cv_folds, len(df_treino)),
+                    random_state=config.random_state,
+                    max_iter=config.lasso_max_iter,
+                ),
+            ),
+        ]
+    )
+
+    X_treino = df_treino[colunas_preditoras]
+    y_treino = df_treino["y"]
+    modelo.fit(X_treino, y_treino)
+
+    y_treino_previsto = modelo.predict(X_treino)
+    r2_treino = r2_score(y_treino, y_treino_previsto)
+
+    previsoes_partes = [
+        pd.DataFrame(
+            {
+                "id": df_treino["id"].to_numpy(),
+                "inputUrl": df_treino["inputUrl"].to_numpy(),
+                "y_real": y_treino.to_numpy(),
+                "y_previsto": y_treino_previsto,
+            }
+        )
+    ]
+
+    if len(df_holdout) > 0:
+        X_holdout = df_holdout[colunas_preditoras]
+        y_holdout = df_holdout["y"]
+        y_holdout_previsto = modelo.predict(X_holdout)
+        r2_holdout = r2_score(y_holdout, y_holdout_previsto)
+        previsoes_partes.append(
+            pd.DataFrame(
+                {
+                    "id": df_holdout["id"].to_numpy(),
+                    "inputUrl": df_holdout["inputUrl"].to_numpy(),
+                    "y_real": y_holdout.to_numpy(),
+                    "y_previsto": y_holdout_previsto,
+                }
+            )
+        )
+    else:
+        # Amostra pequena demais/holdout sem posts deste grupo -- degrada
+        # para NaN em vez de dividir por zero postos em holdout.
+        r2_holdout = float("nan")
+
+    previsoes = pd.concat(previsoes_partes, ignore_index=True)
+    previsoes["grupo"] = grupo
+    previsoes["residuo"] = previsoes["y_real"] - previsoes["y_previsto"]
+
+    nomes_features = modelo.named_steps["preprocessamento"].get_feature_names_out()
+    coeficientes = pd.DataFrame(
+        {
+            "grupo": grupo,
+            "preditor": nomes_features,
+            "coeficiente": modelo.named_steps["lasso"].coef_,
+            "r2_treino": r2_treino,
+            "r2_holdout": r2_holdout,
+            "n_treino": len(df_treino),
+            "n_holdout": len(df_holdout),
+            "alpha": modelo.named_steps["lasso"].alpha_,
+        }
+    )
+
+    return GroupModelResult(
+        grupo=grupo,
+        coeficientes=coeficientes,
+        previsoes=previsoes,
+        r2_treino=r2_treino,
+        r2_holdout=r2_holdout,
+        n_treino=len(df_treino),
+        n_holdout=len(df_holdout),
+        alpha=modelo.named_steps["lasso"].alpha_,
+    )
+
+
+def run_post_performance_stage(
+    df_posts: pd.DataFrame,
+    df_reels: pd.DataFrame,
+    df_engagement: pd.DataFrame,
+    config: PostPerformanceConfig,
+) -> PostPerformanceStageResult:
+    """Treina os dois grupos (vídeo=Reels, estático=Posts) com o mesmo
+    holdout de governadores, e junta coeficientes/previsões dos dois num
+    par de DataFrames prontos para `ModelEnricher.write_post_performance_*`.
+
+    `df_posts` precisa já ter passado por
+    `src.modeling.topics.classify_post_topics` (issue B) -- é de lá que vem
+    a coluna `Topic` (Tema)."""
+    holdout_governors = select_holdout_governors(df_engagement["id"], config)
+
+    resultados: list[GroupModelResult] = []
+    for df_group, grupo in ((df_reels, GRUPO_VIDEO), (df_posts, GRUPO_ESTATICO)):
+        df_assemblado = assemble_predictors(df_group, df_engagement, grupo)
+        numeric_predictors, categorical_predictors = resolve_predictor_columns(
+            df_assemblado, config, grupo
+        )
+        check_circularity(
+            df_assemblado,
+            "y",
+            numeric_predictors,
+            categorical_predictors,
+            config.raw_target_columns,
+            config.circularity_correlation_threshold,
+        )
+        resultados.append(
+            train_evaluate_group(
+                df_assemblado,
+                grupo,
+                numeric_predictors,
+                categorical_predictors,
+                holdout_governors,
+                config,
+            )
+        )
+
+    coefficients = pd.concat([r.coeficientes for r in resultados], ignore_index=True)
+    predictions = pd.concat([r.previsoes for r in resultados], ignore_index=True)
+    return PostPerformanceStageResult(coefficients=coefficients, predictions=predictions)

--- a/src/schemas_delta.py
+++ b/src/schemas_delta.py
@@ -248,3 +248,40 @@ GOLD_PROFILE_CLUSTERS_ENGAGEMENT_SCHEMA = pa.schema(
         pa.field("_generated_at", pa.timestamp("us", tz="UTC"), nullable=False),
     ]
 )
+
+# ADR 0019 (parte C): regressão de performance-por-post -- formato longo, uma
+# linha por preditor por grupo por execução. Uma tabela por conceito, com
+# `grupo` (vídeo/estático) como dimensão, em vez de duplicar dois schemas
+# quase idênticos para cada grupo.
+GOLD_POST_PERFORMANCE_COEFFICIENTS_SCHEMA = pa.schema(
+    [
+        pa.field("grupo", pa.string(), nullable=False),
+        pa.field("preditor", pa.string(), nullable=False),
+        pa.field("coeficiente", pa.float64(), nullable=False),
+        pa.field("r2_treino", pa.float64(), nullable=False),
+        # Nulo só no caso degenerado de um grupo sem nenhum governador em
+        # holdout (amostra pequena demais) -- ver `train_evaluate_group`.
+        pa.field("r2_holdout", pa.float64(), nullable=True),
+        pa.field("n_treino", pa.int64(), nullable=False),
+        pa.field("n_holdout", pa.int64(), nullable=False),
+        pa.field("alpha", pa.float64(), nullable=False),
+        pa.field("_run_id", pa.string(), nullable=False),
+        pa.field("_generated_at", pa.timestamp("us", tz="UTC"), nullable=False),
+    ]
+)
+
+# Granularidade de post individual -- previsão/resíduo, treino e holdout
+# juntos (ver ADR 0019, decisão 9: habilita a "lacuna de execução" do
+# dashboard, issue E, sem exigir uma tabela extra só para holdout).
+GOLD_POST_PERFORMANCE_PREDICTIONS_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string(), nullable=False),
+        pa.field("inputUrl", pa.string(), nullable=True),
+        pa.field("grupo", pa.string(), nullable=False),
+        pa.field("y_real", pa.float64(), nullable=False),
+        pa.field("y_previsto", pa.float64(), nullable=False),
+        pa.field("residuo", pa.float64(), nullable=False),
+        pa.field("_run_id", pa.string(), nullable=False),
+        pa.field("_generated_at", pa.timestamp("us", tz="UTC"), nullable=False),
+    ]
+)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -6,8 +6,9 @@ import pandas as pd
 from deltalake import DeltaTable
 
 from src.features.gold.model_enricher import ModelEnricher
-from src.modeling.config import ClusterConfig, GeminiRefinerConfig, ModelingConfig
+from src.modeling.config import ClusterConfig, GeminiRefinerConfig, ModelingConfig, PostPerformanceConfig
 from src.modeling.orchestration import run_deterministic_modeling, refine_topics_with_gemini
+from src.modeling.post_performance import PostPerformanceStageResult
 
 
 def _df_reels():
@@ -28,6 +29,24 @@ def _df_comments():
         {
             "id_comment": ["c1", "c2", "c3"],
             "text": ["ótimo trabalho", "péssimo governo", "concordo com a proposta"],
+        }
+    )
+
+
+def _df_posts_placeholder():
+    """Usada só nos testes que fazem monkeypatch de `classify_post_topics`
+    e `run_post_performance_stage` -- conteúdo irrelevante, os fakes não
+    olham para as colunas."""
+    return pd.DataFrame({"id": ["p1"], "caption": ["texto qualquer"]})
+
+
+def _df_engagement_placeholder():
+    return pd.DataFrame(
+        {
+            "id": ["governador_teste"],
+            "_WC_COMENTARIO": [1.0],
+            "FREQUENCIA": [1.0],
+            "followersCount": [1000],
         }
     )
 
@@ -53,8 +72,51 @@ def _make_fake_model_topics(nome_provisorio, nome_refinado):
     return _fake_model_topics
 
 
+def _fake_classify_post_topics(df_posts, config, preprocessing_config=None, embedding_model=None):
+    """Fake leve (issue #74 já testa `classify_post_topics` de verdade em
+    `tests/test_topics.py`) -- aqui só precisa devolver `df_posts` com uma
+    coluna `Topic` para não travar `run_post_performance_stage`."""
+    topic_model = MagicMock()
+    df_final = df_posts.copy()
+    df_final["Topic"] = 0
+    return topic_model, df_final
+
+
+_EMPTY_COEFFICIENTS_COLUMNS = [
+    "grupo",
+    "preditor",
+    "coeficiente",
+    "r2_treino",
+    "r2_holdout",
+    "n_treino",
+    "n_holdout",
+    "alpha",
+]
+_EMPTY_PREDICTIONS_COLUMNS = ["id", "inputUrl", "grupo", "y_real", "y_previsto", "residuo"]
+
+
+def _fake_run_post_performance_stage(df_posts, df_reels, df_engagement, config):
+    """Fake usado nos testes que não são sobre performance-por-post em si --
+    devolve tabelas vazias, mas com o schema certo, para que a escrita Gold
+    da nova etapa não quebre nem precise de dado real."""
+    return PostPerformanceStageResult(
+        coefficients=pd.DataFrame(columns=_EMPTY_COEFFICIENTS_COLUMNS),
+        predictions=pd.DataFrame(columns=_EMPTY_PREDICTIONS_COLUMNS),
+    )
+
+
 def _fake_apply_gemini_refinement(topic_model, docs, config):
     return topic_model
+
+
+def _patch_post_performance_fakes(monkeypatch):
+    monkeypatch.setattr(
+        "src.modeling.orchestration.classify_post_topics", _fake_classify_post_topics
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.run_post_performance_stage",
+        _fake_run_post_performance_stage,
+    )
 
 
 def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id(
@@ -67,17 +129,22 @@ def test_run_deterministic_modeling_grava_clusters_e_sentimento_com_mesmo_run_id
         "src.modeling.orchestration.model_topics",
         _make_fake_model_topics("0_provisorio", "0_refinado"),
     )
+    _patch_post_performance_fakes(monkeypatch)
 
     config = ModelingConfig(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
 
-    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), _df_posts_placeholder(), _df_engagement_placeholder(), config
+    )
 
     clusters_out = DeltaTable(str(config.gold_clusters_path)).to_pandas()
     sentiment_out = DeltaTable(str(config.gold_sentiment_path)).to_pandas()
@@ -109,17 +176,22 @@ def test_run_deterministic_modeling_grava_sentimento_tambem_no_historico_em_appe
         "src.modeling.orchestration.model_topics",
         _make_fake_model_topics("0_provisorio", "0_refinado"),
     )
+    _patch_post_performance_fakes(monkeypatch)
 
     config = ModelingConfig(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
 
-    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), _df_posts_placeholder(), _df_engagement_placeholder(), config
+    )
 
     sentiment_out = DeltaTable(str(config.gold_sentiment_path)).to_pandas()
     history_out = DeltaTable(str(config.gold_sentiment_history_path)).to_pandas()
@@ -147,16 +219,21 @@ def test_refine_topics_with_gemini_nao_grava_no_historico_de_sentimento(monkeypa
     monkeypatch.setattr(
         "src.modeling.orchestration.apply_gemini_refinement", _fake_apply_gemini_refinement
     )
+    _patch_post_performance_fakes(monkeypatch)
 
     config = ModelingConfig(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
-    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), _df_posts_placeholder(), _df_engagement_placeholder(), config
+    )
 
     calls = []
     original_write_sentiment = ModelEnricher.write_sentiment
@@ -193,18 +270,26 @@ def test_run_deterministic_modeling_grava_parent_run_id_como_primeira_linha_do_l
         "src.modeling.orchestration.model_topics",
         _make_fake_model_topics("0_provisorio", "0_refinado"),
     )
+    _patch_post_performance_fakes(monkeypatch)
 
     config = ModelingConfig(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
 
     result = run_deterministic_modeling(
-        _df_reels(), _df_comments(), config, parent_run_id="run_extracao_pai"
+        _df_reels(),
+        _df_comments(),
+        _df_posts_placeholder(),
+        _df_engagement_placeholder(),
+        config,
+        parent_run_id="run_extracao_pai",
     )
 
     assert result.parent_run_id == "run_extracao_pai"
@@ -232,16 +317,21 @@ def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
     monkeypatch.setattr(
         "src.modeling.orchestration.apply_gemini_refinement", _fake_apply_gemini_refinement
     )
+    _patch_post_performance_fakes(monkeypatch)
 
     config = ModelingConfig(
         cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
         gold_clusters_path=tmp_path / "governor_clusters",
         gold_sentiment_path=tmp_path / "governor_sentiment",
         gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
         checkpoints_dir=tmp_path / "checkpoints",
         logs_dir=tmp_path / "logs",
     )
-    result = run_deterministic_modeling(_df_reels(), _df_comments(), config)
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), _df_posts_placeholder(), _df_engagement_placeholder(), config
+    )
 
     gemini_config = GeminiRefinerConfig(
         api_key="fake-key", gold_sentiment_path=tmp_path / "governor_sentiment"
@@ -262,3 +352,175 @@ def test_refine_topics_with_gemini_so_reescreve_sentimento_com_run_id_novo(
 
     # governor_clusters não é tocado pelo refinamento de tópicos.
     assert (clusters_out["_run_id"] == result.run_id).all()
+
+
+# ---------------------------------------------------------------------------
+# ADR 0019 (parte C): estágio novo [PERFORMANCE-POR-POST].
+# ---------------------------------------------------------------------------
+
+N_GOVERNADORES_PERFORMANCE = 6
+POSTS_POR_GOVERNADOR_PERFORMANCE = 4
+
+
+def _df_engagement_performance():
+    rng = np.random.default_rng(10)
+    ids = [f"gov{i}" for i in range(N_GOVERNADORES_PERFORMANCE)]
+    return pd.DataFrame(
+        {
+            "id": ids,
+            "_WC_COMENTARIO": 1.5,
+            "FREQUENCIA": rng.uniform(0.1, 2.0, size=N_GOVERNADORES_PERFORMANCE),
+            "followersCount": rng.integers(10_000, 500_000, size=N_GOVERNADORES_PERFORMANCE),
+        }
+    )
+
+
+def _df_reels_performance(df_engagement):
+    rng = np.random.default_rng(11)
+    linhas = []
+    for gov in df_engagement["id"]:
+        for j in range(POSTS_POR_GOVERNADOR_PERFORMANCE):
+            linhas.append(
+                {
+                    "id": f"{gov}_reel_{j}",
+                    "ownerId": gov,
+                    "ownerUsername": gov,
+                    "inputUrl": f"https://instagram.com/{gov}",
+                    "commentsCount": int(rng.integers(0, 200)),
+                    "likesCount": int(rng.integers(0, 5000)),
+                    "data_hora": pd.Timestamp("2026-01-01")
+                    + pd.Timedelta(days=j, hours=int(rng.integers(0, 24))),
+                    "type_raw": "Video",
+                    "videoDuration": float(rng.uniform(5, 90)),
+                    "videoPlayCount": int(rng.integers(100, 100_000)),
+                    "isSponsored": bool(rng.integers(0, 2)),
+                }
+            )
+    return pd.DataFrame(linhas)
+
+
+def _df_posts_performance(df_engagement):
+    rng = np.random.default_rng(12)
+    linhas = []
+    for gov in df_engagement["id"]:
+        for j in range(POSTS_POR_GOVERNADOR_PERFORMANCE):
+            linhas.append(
+                {
+                    "id": f"{gov}_post_{j}",
+                    "ownerId": gov,
+                    "ownerUsername": gov,
+                    "inputUrl": f"https://instagram.com/{gov}",
+                    "commentsCount": int(rng.integers(0, 200)),
+                    "likesCount": int(rng.integers(0, 5000)),
+                    "data_hora": pd.Timestamp("2026-01-01")
+                    + pd.Timedelta(days=j, hours=int(rng.integers(0, 24))),
+                    "type_raw": rng.choice(["Image", "Sidecar"]),
+                    "videoDuration": np.nan,
+                    "caption": f"legenda {j} do governador {gov}",
+                    "hashtags": None,
+                }
+            )
+    return pd.DataFrame(linhas)
+
+
+def _config_performance(tmp_path):
+    return ModelingConfig(
+        cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
+        post_performance=PostPerformanceConfig(holdout_governors_count=2, lasso_cv_folds=2),
+        gold_clusters_path=tmp_path / "governor_clusters",
+        gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
+        checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
+    )
+
+
+def test_run_deterministic_modeling_grava_coeficientes_e_previsoes_de_performance_por_post(
+    monkeypatch, tmp_path
+):
+    """ADR 0019 (parte C): o novo passo roda de verdade (Lasso real sobre
+    dado sintético pequeno) e persiste as duas tabelas Gold novas sob o
+    mesmo `run_id` da execução -- só `classify_post_topics` é fake (já
+    coberto em tests/test_topics.py), o resto do estágio é real."""
+    monkeypatch.setattr(
+        "src.modeling.orchestration.analyze_sentiment", _fake_analyze_sentiment
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.model_topics",
+        _make_fake_model_topics("0_provisorio", "0_refinado"),
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.classify_post_topics", _fake_classify_post_topics
+    )
+
+    df_engagement = _df_engagement_performance()
+    df_reels = _df_reels_performance(df_engagement)
+    df_posts = _df_posts_performance(df_engagement)
+    config = _config_performance(tmp_path)
+
+    result = run_deterministic_modeling(df_reels, _df_comments(), df_posts, df_engagement, config)
+
+    coefficients_out = DeltaTable(
+        str(config.gold_post_performance_coefficients_path)
+    ).to_pandas()
+    predictions_out = DeltaTable(str(config.gold_post_performance_predictions_path)).to_pandas()
+
+    assert (coefficients_out["_run_id"] == result.run_id).all()
+    assert (predictions_out["_run_id"] == result.run_id).all()
+    assert set(coefficients_out["grupo"].unique()) == {"video", "estatico"}
+    assert set(predictions_out["grupo"].unique()) == {"video", "estatico"}
+    assert len(predictions_out) == len(df_reels) + len(df_posts)
+
+
+def test_run_deterministic_modeling_degrada_sem_derrubar_pipeline_se_performance_por_post_falhar(
+    monkeypatch, tmp_path
+):
+    """User story 13 (issue #75): dado insuficiente (ou qualquer outra
+    falha) na etapa de performance-por-post não pode derrubar PCA/
+    clustering/sentimento/tópicos, que já rodaram com sucesso na mesma
+    execução -- a etapa só é pulada."""
+    monkeypatch.setattr(
+        "src.modeling.orchestration.analyze_sentiment", _fake_analyze_sentiment
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.model_topics",
+        _make_fake_model_topics("0_provisorio", "0_refinado"),
+    )
+    monkeypatch.setattr(
+        "src.modeling.orchestration.classify_post_topics", _fake_classify_post_topics
+    )
+
+    def _fake_run_post_performance_stage_falha(df_posts, df_reels, df_engagement, config):
+        raise ValueError("dado insuficiente para treinar")
+
+    monkeypatch.setattr(
+        "src.modeling.orchestration.run_post_performance_stage",
+        _fake_run_post_performance_stage_falha,
+    )
+
+    config = ModelingConfig(
+        cluster=ClusterConfig(max_evals_per_algo=10, random_state=42, max_n_clusters=5),
+        gold_clusters_path=tmp_path / "governor_clusters",
+        gold_sentiment_path=tmp_path / "governor_sentiment",
+        gold_sentiment_history_path=tmp_path / "governor_sentiment_history",
+        gold_post_performance_coefficients_path=tmp_path / "post_performance_coefficients",
+        gold_post_performance_predictions_path=tmp_path / "post_performance_predictions",
+        checkpoints_dir=tmp_path / "checkpoints",
+        logs_dir=tmp_path / "logs",
+    )
+
+    result = run_deterministic_modeling(
+        _df_reels(), _df_comments(), _df_posts_placeholder(), _df_engagement_placeholder(), config
+    )
+
+    # Os demais estágios completaram normalmente, apesar da falha.
+    clusters_out = DeltaTable(str(config.gold_clusters_path)).to_pandas()
+    assert (clusters_out["_run_id"] == result.run_id).all()
+    checkpoint_dir = config.checkpoints_dir / result.run_id
+    assert (checkpoint_dir / "metadata.json").exists()
+
+    # A etapa pulada não deixou as tabelas novas para trás.
+    assert not config.gold_post_performance_coefficients_path.exists()
+    assert not config.gold_post_performance_predictions_path.exists()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -85,7 +85,7 @@ def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(mo
 
     df_reels_silver = pd.DataFrame({"id": ["1"]})
     df_comments_silver = pd.DataFrame({"text": ["oi"]})
-    fake_modeling, _aggregator = _patch_medallion_dependencies(
+    fake_modeling, aggregator = _patch_medallion_dependencies(
         monkeypatch, df_reels_silver, df_comments_silver
     )
 
@@ -97,6 +97,12 @@ def test_run_medallion_pipeline_com_run_modeling_chama_estagio_deterministico(mo
     args, kwargs = fake_modeling.call_args
     assert args[0] is df_reels_silver
     assert args[1] is df_comments_silver
+    # ADR 0019 (parte C): o novo passo [PERFORMANCE-POR-POST] precisa de
+    # df_posts_silver e do df_gold (governor_engagement) já calculados aqui.
+    # `pipeline.PostCleaner()` devolve o mesmo mock usado internamente (ver
+    # `_patch_medallion_dependencies`).
+    assert args[2] is pipeline.PostCleaner().clean_posts.return_value
+    assert args[3] is aggregator.aggregate.return_value
     # ADR 0001: "um run_id = um estado imutável" -- a modelagem deve gerar o
     # seu próprio run_id, nunca reaproveitar o run_id da ingestão.
     assert kwargs.get("run_id") != "r1"

--- a/tests/test_post_performance.py
+++ b/tests/test_post_performance.py
@@ -1,0 +1,287 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.modeling.config import PostPerformanceConfig
+from src.modeling.post_performance import (
+    GRUPO_ESTATICO,
+    GRUPO_VIDEO,
+    CircularityError,
+    assemble_predictors,
+    check_circularity,
+    resolve_predictor_columns,
+    run_post_performance_stage,
+    select_holdout_governors,
+    train_evaluate_group,
+)
+
+N_GOVERNADORES = 12
+POSTS_POR_GOVERNADOR = 6
+
+
+def _config(**overrides):
+    defaults = {"holdout_governors_count": 3, "lasso_cv_folds": 3}
+    defaults.update(overrides)
+    return PostPerformanceConfig(**defaults)
+
+
+def _df_engagement():
+    rng = np.random.default_rng(0)
+    ids = [f"gov{i}" for i in range(N_GOVERNADORES)]
+    return pd.DataFrame(
+        {
+            "id": ids,
+            "_WC_COMENTARIO": 1.5,
+            "FREQUENCIA": rng.uniform(0.1, 2.0, size=N_GOVERNADORES),
+            "followersCount": rng.integers(10_000, 500_000, size=N_GOVERNADORES),
+        }
+    )
+
+
+def _df_reels(df_engagement):
+    rng = np.random.default_rng(1)
+    linhas = []
+    for gov in df_engagement["id"]:
+        for j in range(POSTS_POR_GOVERNADOR):
+            linhas.append(
+                {
+                    "id": f"{gov}_reel_{j}",
+                    "ownerId": gov,
+                    "ownerUsername": gov,
+                    "inputUrl": f"https://instagram.com/{gov}",
+                    "commentsCount": int(rng.integers(0, 200)),
+                    "likesCount": int(rng.integers(0, 5000)),
+                    "data_hora": pd.Timestamp("2026-01-01")
+                    + pd.Timedelta(days=j, hours=int(rng.integers(0, 24))),
+                    "type_raw": "Video",
+                    "videoDuration": float(rng.uniform(5, 90)),
+                    "videoPlayCount": int(rng.integers(100, 100_000)),
+                    "isSponsored": bool(rng.integers(0, 2)),
+                }
+            )
+    return pd.DataFrame(linhas)
+
+
+def _df_posts(df_engagement):
+    rng = np.random.default_rng(2)
+    linhas = []
+    for gov in df_engagement["id"]:
+        for j in range(POSTS_POR_GOVERNADOR):
+            linhas.append(
+                {
+                    "id": f"{gov}_post_{j}",
+                    "ownerId": gov,
+                    "ownerUsername": gov,
+                    "inputUrl": f"https://instagram.com/{gov}",
+                    "commentsCount": int(rng.integers(0, 200)),
+                    "likesCount": int(rng.integers(0, 5000)),
+                    "data_hora": pd.Timestamp("2026-01-01")
+                    + pd.Timedelta(days=j, hours=int(rng.integers(0, 24))),
+                    "type_raw": rng.choice(["Image", "Sidecar"]),
+                    "videoDuration": np.nan,
+                    "caption": f"legenda {j} do governador {gov}",
+                    "hashtags": '["politica"]',
+                    "Topic": int(rng.integers(0, 3)),
+                }
+            )
+    return pd.DataFrame(linhas)
+
+
+def test_check_circularity_dispara_quando_preditor_e_coluna_bruta_de_y():
+    df = pd.DataFrame({"y": [1.0, 2.0, 3.0], "likesCount": [10, 20, 30]})
+    with pytest.raises(CircularityError):
+        check_circularity(df, "y", ["likesCount"], [], ("likesCount", "commentsCount"), 0.95)
+
+
+def test_check_circularity_dispara_quando_correlacao_ultrapassa_limiar():
+    y = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    df = pd.DataFrame({"y": y, "preditor_circular": y * 2 + 0.001})
+    with pytest.raises(CircularityError):
+        check_circularity(
+            df, "y", ["preditor_circular"], [], ("likesCount", "commentsCount"), 0.95
+        )
+
+
+def test_check_circularity_passa_com_preditores_sem_correlacao_alta():
+    df = pd.DataFrame({"y": [1.0, 2.0, 3.0, 4.0], "hora_do_dia": [10, 20, 5, 15]})
+    check_circularity(df, "y", ["hora_do_dia"], [], ("likesCount", "commentsCount"), 0.95)
+
+
+def test_select_holdout_governors_e_reproduzivel_e_respeita_contagem():
+    ids = pd.Series([f"gov{i}" for i in range(10)])
+    config = _config(holdout_governors_count=3)
+
+    holdout1 = select_holdout_governors(ids, config)
+    holdout2 = select_holdout_governors(ids, config)
+
+    assert holdout1 == holdout2
+    assert len(holdout1) == 3
+    assert holdout1 <= set(ids)
+
+
+def test_assemble_predictors_video_nao_tem_comprimento_legenda_nem_tema():
+    df_engagement = _df_engagement()
+    df = assemble_predictors(_df_reels(df_engagement), df_engagement, GRUPO_VIDEO)
+
+    assert "comprimento_legenda" not in df.columns
+    assert "paidPartnership" in df.columns
+    assert "y" in df.columns
+    assert df["y"].notna().all()
+
+
+def test_assemble_predictors_estatico_tem_comprimento_legenda_e_nao_tem_preditores_de_video():
+    df_engagement = _df_engagement()
+    df = assemble_predictors(_df_posts(df_engagement), df_engagement, GRUPO_ESTATICO)
+
+    assert "comprimento_legenda" in df.columns
+    assert "paidPartnership" not in df.columns
+    assert "y" in df.columns
+
+
+def test_assemble_predictors_descarta_posts_de_governador_sem_seguidores():
+    df_engagement = _df_engagement()
+    df_engagement.loc[0, "followersCount"] = 0
+    df_posts = _df_posts(df_engagement)
+    governador_sem_seguidores = df_engagement.loc[0, "id"]
+
+    df = assemble_predictors(df_posts, df_engagement, GRUPO_ESTATICO)
+
+    assert governador_sem_seguidores not in set(df["ownerId"])
+    assert len(df) == len(df_posts) - POSTS_POR_GOVERNADOR
+
+
+def test_resolve_predictor_columns_video_vs_estatico():
+    df_engagement = _df_engagement()
+    config = _config()
+
+    df_video = assemble_predictors(_df_reels(df_engagement), df_engagement, GRUPO_VIDEO)
+    numeric_v, categorical_v = resolve_predictor_columns(df_video, config, GRUPO_VIDEO)
+    assert "videoPlayCount" in numeric_v
+    assert "paidPartnership" in numeric_v
+    assert "comprimento_legenda" not in numeric_v
+    assert "Topic" not in categorical_v
+
+    df_estatico = assemble_predictors(_df_posts(df_engagement), df_engagement, GRUPO_ESTATICO)
+    numeric_e, categorical_e = resolve_predictor_columns(df_estatico, config, GRUPO_ESTATICO)
+    assert "comprimento_legenda" in numeric_e
+    assert "Topic" in categorical_e
+    assert "videoPlayCount" not in numeric_e
+    assert "paidPartnership" not in numeric_e
+
+
+def test_train_evaluate_group_isola_governador_do_holdout_de_um_lado_so():
+    df_engagement = _df_engagement()
+    config = _config()
+    df_assemblado = assemble_predictors(_df_posts(df_engagement), df_engagement, GRUPO_ESTATICO)
+    numeric, categorical = resolve_predictor_columns(df_assemblado, config, GRUPO_ESTATICO)
+    holdout = select_holdout_governors(df_engagement["id"], config)
+
+    resultado = train_evaluate_group(
+        df_assemblado, GRUPO_ESTATICO, numeric, categorical, holdout, config
+    )
+
+    em_holdout = df_assemblado["ownerId"].isin(holdout)
+    ids_holdout_esperados = set(df_assemblado.loc[em_holdout, "id"])
+    ids_treino_esperados = set(df_assemblado.loc[~em_holdout, "id"])
+
+    assert set(resultado.previsoes["id"]) == ids_holdout_esperados | ids_treino_esperados
+    assert resultado.n_treino == len(ids_treino_esperados)
+    assert resultado.n_holdout == len(ids_holdout_esperados)
+    assert isinstance(resultado.r2_treino, float)
+    assert isinstance(resultado.r2_holdout, float)
+
+
+def test_train_evaluate_group_produz_coeficientes_por_preditor():
+    df_engagement = _df_engagement()
+    config = _config()
+    df_assemblado = assemble_predictors(_df_reels(df_engagement), df_engagement, GRUPO_VIDEO)
+    numeric, categorical = resolve_predictor_columns(df_assemblado, config, GRUPO_VIDEO)
+    holdout = select_holdout_governors(df_engagement["id"], config)
+
+    resultado = train_evaluate_group(
+        df_assemblado, GRUPO_VIDEO, numeric, categorical, holdout, config
+    )
+
+    colunas_esperadas = {
+        "grupo",
+        "preditor",
+        "coeficiente",
+        "r2_treino",
+        "r2_holdout",
+        "n_treino",
+        "n_holdout",
+        "alpha",
+    }
+    assert colunas_esperadas <= set(resultado.coeficientes.columns)
+    assert (resultado.coeficientes["grupo"] == GRUPO_VIDEO).all()
+    assert len(resultado.coeficientes) > 0
+
+
+def test_run_post_performance_stage_end_to_end():
+    df_engagement = _df_engagement()
+    df_reels = _df_reels(df_engagement)
+    df_posts = _df_posts(df_engagement)
+    config = _config()
+
+    resultado = run_post_performance_stage(df_posts, df_reels, df_engagement, config)
+
+    assert set(resultado.coefficients["grupo"].unique()) == {GRUPO_VIDEO, GRUPO_ESTATICO}
+    assert set(resultado.predictions["grupo"].unique()) == {GRUPO_VIDEO, GRUPO_ESTATICO}
+    assert len(resultado.predictions) == len(df_reels) + len(df_posts)
+    assert {"id", "inputUrl", "grupo", "y_real", "y_previsto", "residuo"} <= set(
+        resultado.predictions.columns
+    )
+
+
+def test_run_post_performance_stage_usa_o_mesmo_holdout_nos_dois_grupos():
+    """ADR 0019, decisão 5 / user story 9: o holdout de governadores precisa
+    ser o mesmo conjunto para vídeo e estático, para que os dois R² de
+    holdout sejam comparáveis -- não só do mesmo tamanho por coincidência."""
+    df_engagement = _df_engagement()
+    df_reels = _df_reels(df_engagement)
+    df_posts = _df_posts(df_engagement)
+    config = _config()
+
+    holdout_esperado = select_holdout_governors(df_engagement["id"], config)
+    resultado = run_post_performance_stage(df_posts, df_reels, df_engagement, config)
+
+    n_holdout_video_esperado = int(df_reels["ownerId"].isin(holdout_esperado).sum())
+    n_holdout_estatico_esperado = int(df_posts["ownerId"].isin(holdout_esperado).sum())
+
+    coef_video = resultado.coefficients[resultado.coefficients["grupo"] == GRUPO_VIDEO]
+    coef_estatico = resultado.coefficients[resultado.coefficients["grupo"] == GRUPO_ESTATICO]
+
+    assert coef_video["n_holdout"].iloc[0] == n_holdout_video_esperado
+    assert coef_estatico["n_holdout"].iloc[0] == n_holdout_estatico_esperado
+
+
+def test_check_circularity_passa_com_preditores_reais_do_grupo_video():
+    df_engagement = _df_engagement()
+    config = _config()
+    df_assemblado = assemble_predictors(_df_reels(df_engagement), df_engagement, GRUPO_VIDEO)
+    numeric, categorical = resolve_predictor_columns(df_assemblado, config, GRUPO_VIDEO)
+
+    check_circularity(
+        df_assemblado,
+        "y",
+        numeric,
+        categorical,
+        config.raw_target_columns,
+        config.circularity_correlation_threshold,
+    )
+
+
+def test_check_circularity_passa_com_preditores_reais_do_grupo_estatico():
+    df_engagement = _df_engagement()
+    config = _config()
+    df_assemblado = assemble_predictors(_df_posts(df_engagement), df_engagement, GRUPO_ESTATICO)
+    numeric, categorical = resolve_predictor_columns(df_assemblado, config, GRUPO_ESTATICO)
+
+    check_circularity(
+        df_assemblado,
+        "y",
+        numeric,
+        categorical,
+        config.raw_target_columns,
+        config.circularity_correlation_threshold,
+    )

--- a/tests/test_run_modeling_script.py
+++ b/tests/test_run_modeling_script.py
@@ -3,12 +3,19 @@ from unittest.mock import MagicMock
 import pandas as pd
 
 
-def test_run_le_silver_e_chama_run_deterministic_modeling(monkeypatch):
-    import scripts.run_modeling as run_modeling_script
-
+def _fake_repo():
     fake_repo = MagicMock()
     fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
     fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    fake_repo.load_posts.return_value = pd.DataFrame({"id": ["p1"]})
+    fake_repo.load_profiles.return_value = pd.DataFrame({"id": ["gov1"]})
+    return fake_repo
+
+
+def test_run_le_silver_e_chama_run_deterministic_modeling(monkeypatch):
+    import scripts.run_modeling as run_modeling_script
+
+    fake_repo = _fake_repo()
     monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
 
     fake_result = MagicMock(run_id="run_abc")
@@ -24,15 +31,17 @@ def test_run_le_silver_e_chama_run_deterministic_modeling(monkeypatch):
     args, kwargs = fake_run_deterministic_modeling.call_args
     assert args[0] is fake_repo.load_reels.return_value
     assert args[1] is fake_repo.load_comments.return_value
+    # ADR 0019 (parte C): o novo passo [PERFORMANCE-POR-POST] precisa de
+    # posts_clean e do governor_engagement (Gold) já carregados aqui.
+    assert args[2] is fake_repo.load_posts.return_value
+    assert args[3] is fake_repo.load_profiles.return_value
     assert kwargs["run_id"] == "run_fixo"
 
 
 def test_run_repassa_parent_run_id_para_o_orquestrador(monkeypatch):
     import scripts.run_modeling as run_modeling_script
 
-    fake_repo = MagicMock()
-    fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
-    fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    fake_repo = _fake_repo()
     monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
 
     fake_run_deterministic_modeling = MagicMock(return_value=MagicMock(run_id="run_abc"))
@@ -49,9 +58,7 @@ def test_run_repassa_parent_run_id_para_o_orquestrador(monkeypatch):
 def test_run_sem_run_id_deixa_orquestrador_gerar_um_novo(monkeypatch):
     import scripts.run_modeling as run_modeling_script
 
-    fake_repo = MagicMock()
-    fake_repo.load_reels.return_value = pd.DataFrame({"id": ["r1"]})
-    fake_repo.load_comments.return_value = pd.DataFrame({"text": ["oi"]})
+    fake_repo = _fake_repo()
     monkeypatch.setattr("scripts.run_modeling.DeltaRepository", lambda **kwargs: fake_repo)
 
     fake_run_deterministic_modeling = MagicMock(return_value=MagicMock(run_id="gerado"))


### PR DESCRIPTION
## Summary
- Módulo novo `src/modeling/post_performance.py` (funções puras testáveis isoladamente): `assemble_predictors`, `check_circularity`, `select_holdout_governors`, `train_evaluate_group`, `run_post_performance_stage`.
- `Y = (likesCount + commentsCount×Wc) / followersCount`, idêntico para os dois grupos (ADR 0019 decisão 3). `videoPlayCount`/`paidPartnership` só no grupo vídeo (controle de alcance, decisão 2 — não fazem parte da fórmula de Y). `comprimento_legenda`/`Topic` (Tema) só no grupo estático: Reels não têm `caption`/`hashtags` no Bronze/Silver (limitação estrutural, não escolha de design).
- Checagem de circularidade (decisão 7): falha alto e cedo se um preditor for uma coluna bruta de Y ou tiver correlação > 0.95 com Y.
- Holdout de governadores compartilhado entre os dois grupos (decisão 5), reprodutível via `random_state`.
- Lasso com `StandardScaler`+`OneHotEncoder` via `ColumnTransformer`, alpha por `LassoCV`.
- Duas tabelas Gold novas (`GOLD_POST_PERFORMANCE_COEFFICIENTS_SCHEMA`, `GOLD_POST_PERFORMANCE_PREDICTIONS_SCHEMA`) + dois métodos novos em `ModelEnricher`.
- Novo passo `[PERFORMANCE-POR-POST]` em `run_deterministic_modeling` (entre tópicos e checkpoint), que classifica tema via `classify_post_topics` (issue #74) antes de treinar. `pipeline.py`/`scripts/run_modeling.py` atualizados para passar `df_posts`/`df_engagement`.
- Falha desta etapa é capturada e logada sem derrubar PCA/clustering/sentimento/tópicos já executados na mesma chamada (user story 13).

## Fora de escopo (por design)
- BERTopic sobre captions e restauração de `type`/`hashtags` no Silver — issues #73/#74.
- Notebooks de diagnóstico e remoção do notebook antigo — issue #76.
- Consumo no dashboard (card de "lacuna de execução") — issue #77.

## Test plan
- [x] `pytest tests/` — 239 passed, 3 skipped
- [x] `ruff check src/` — limpo
- [x] `/code-review` (Standards + Spec, sub-agentes paralelos) — achados eram só lacunas de cobertura de teste (holdout idêntico nos dois grupos, circularidade com preditores reais), corrigidas antes deste commit. As duas decisões de design mais sensíveis (`videoPlayCount` como preditor de controle, não parte de Y; Tema/legenda só no grupo estático) foram confirmadas corretas contra a ADR 0019 pelos dois revisores.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DNsAP2pcPURMq2JFpYscd