### PR TITLE
feat(dashboard): card de lacuna de execucao em Performance (ADR 0019, parte E)

### DIFF
--- a/pages/03_performance.py
+++ b/pages/03_performance.py
@@ -10,7 +10,11 @@ if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
 from config import settings
-from src.dashboard.comparisons import compute_engagement_quadrants, compute_governor_comparison
+from src.dashboard.comparisons import (
+    compute_engagement_quadrants,
+    compute_execution_gap,
+    compute_governor_comparison,
+)
 from src.dashboard.filters import (
     TODOS_GOVERNADORES,
     build_governor_directory,
@@ -19,7 +23,11 @@ from src.dashboard.filters import (
     render_governor_selector,
     select_governor_rows,
 )
-from src.dashboard.loaders import load_engagement_history, load_profiles
+from src.dashboard.loaders import (
+    load_engagement_history,
+    load_post_performance_predictions,
+    load_profiles,
+)
 from src.visualization.charts import (
     plot_engagement_group_summary_trend,
     plot_engagement_quadrant_matrix,
@@ -153,6 +161,64 @@ else:
         width="stretch",
     )
 st.markdown("---")
+
+# Lacuna de execução (issue #77 / ADR 0019, parte E): individual, mesmo
+# raciocínio de Recommendations (issue #65) -- não faz sentido agregada
+# para "Todos os Governadores", então fica fora da matriz de quadrantes
+# acima (que já vale para todos), num bloco condicional próprio.
+if governador_selecionado != TODOS_GOVERNADORES:
+    st.markdown("### Lacuna de Execução")
+    df_post_performance = load_post_performance_predictions()
+    df_lacuna = compute_execution_gap(df_post_performance, governador_selecionado)
+    if df_lacuna.empty:
+        st.info(
+            "Sem dado de performance-por-post para este governador ainda -- "
+            "rode o pipeline com o estágio de modelagem "
+            "(`uv run python pipeline.py --run-modeling`) primeiro."
+        )
+    else:
+        cols = st.columns(len(df_lacuna))
+        for col, (_, linha) in zip(cols, df_lacuna.iterrows()):
+            with col:
+                st.metric(
+                    f"Resíduo médio — {linha['grupo']}",
+                    value=f"{linha['residuo_medio']:+.4f}",
+                    help=(
+                        f"{int(linha['n_posts'])} posts neste grupo. Positivo = "
+                        "performou acima do esperado pelos preditores controlados."
+                    ),
+                )
+
+        N_POSTS_DESTAQUE = 3
+        universo_urls = df_post_performance["inputUrl"].dropna().unique().tolist()
+        posts_governador = select_governor_rows(
+            df_post_performance, governador_selecionado, universo_urls
+        )
+        # Um top-N por grupo (não um ranking combinado) -- vídeo e estático
+        # têm escalas de resíduo diferentes (ADR 0019); misturar os dois
+        # numa única classificação deixaria o grupo de escala maior dominar
+        # as duas listas, escondendo o outro grupo por engano.
+        for grupo in df_lacuna["grupo"]:
+            st.markdown(f"**Posts do grupo {grupo}**")
+            posts_do_grupo = posts_governador[posts_governador["grupo"] == grupo]
+            col_acima, col_abaixo = st.columns(2)
+            with col_acima:
+                st.caption("Maior resíduo positivo (acima do esperado)")
+                st.dataframe(
+                    posts_do_grupo.nlargest(N_POSTS_DESTAQUE, "residuo")[
+                        ["id", "y_real", "y_previsto", "residuo"]
+                    ],
+                    hide_index=True,
+                )
+            with col_abaixo:
+                st.caption("Maior resíduo negativo (abaixo do esperado)")
+                st.dataframe(
+                    posts_do_grupo.nsmallest(N_POSTS_DESTAQUE, "residuo")[
+                        ["id", "y_real", "y_previsto", "residuo"]
+                    ],
+                    hide_index=True,
+                )
+    st.markdown("---")
 
 
 @st.fragment(run_every=f"{settings.DASHBOARD_REFRESH_SECONDS}s")

--- a/src/dashboard/comparisons.py
+++ b/src/dashboard/comparisons.py
@@ -133,3 +133,37 @@ def compute_engagement_quadrants(df_engagement: pd.DataFrame) -> pd.DataFrame:
     out["mediana_engajamento"] = mediana_engajamento
 
     return out
+
+
+_EXECUTION_GAP_COLUMNS = ["grupo", "residuo_medio", "n_posts"]
+
+
+def compute_execution_gap(df_predictions: pd.DataFrame, governor_url: str) -> pd.DataFrame:
+    """Resíduo médio por grupo (vídeo/estático) do governador selecionado, a
+    partir da tabela de previsões da regressão de performance-por-post
+    (issue #75 / ADR 0019) -- quanto o governador performou acima/abaixo do
+    esperado pelos preditores controlados ("lacuna de execução").
+
+    Uma linha por grupo em que o governador tem pelo menos um post -- nunca
+    inventa uma linha vazia pro grupo sem dado (ex.: sem posts de vídeo
+    ainda), e nunca combina os dois grupos numa métrica única (ADR 0019:
+    escalas de resíduo diferentes entre vídeo e estático).
+
+    Retorna DataFrame vazio (mesmas colunas) se `df_predictions` estiver
+    vazio ou o governador não tiver nenhuma linha correspondente -- nunca
+    levanta exceção, mesmo contrato de degradação de
+    `compute_governor_comparison`."""
+    if df_predictions.empty or "inputUrl" not in df_predictions.columns:
+        return pd.DataFrame(columns=_EXECUTION_GAP_COLUMNS)
+
+    universo_urls = df_predictions["inputUrl"].dropna().unique().tolist()
+    linhas_governador = select_governor_rows(df_predictions, governor_url, universo_urls)
+    if linhas_governador.empty:
+        return pd.DataFrame(columns=_EXECUTION_GAP_COLUMNS)
+
+    agregado = (
+        linhas_governador.groupby("grupo")["residuo"]
+        .agg(residuo_medio="mean", n_posts="count")
+        .reset_index()
+    )
+    return agregado[_EXECUTION_GAP_COLUMNS]

--- a/src/dashboard/loaders.py
+++ b/src/dashboard/loaders.py
@@ -74,6 +74,22 @@ def load_engagement_history() -> pd.DataFrame:
 
 
 @st.cache_data
+def load_post_performance_coefficients() -> pd.DataFrame:
+    try:
+        return get_delta_repository().load_post_performance_coefficients()
+    except FileNotFoundError:
+        return pd.DataFrame()
+
+
+@st.cache_data
+def load_post_performance_predictions() -> pd.DataFrame:
+    try:
+        return get_delta_repository().load_post_performance_predictions()
+    except FileNotFoundError:
+        return pd.DataFrame()
+
+
+@st.cache_data
 def load_sentiment_history() -> pd.DataFrame:
     # Sem TTL (ao contrário de load_engagement_history) -- modelagem não
     # roda por execução de extração (ADR 0011), não precisa de auto-refresh

--- a/src/repositories/delta_repository.py
+++ b/src/repositories/delta_repository.py
@@ -76,6 +76,12 @@ class DeltaRepository(DataRepository):
     def load_profile_clusters_engagement(self) -> pd.DataFrame:
         return self._load(_join(self._gold_dir, "governor_profile_clusters_engagement"))
 
+    def load_post_performance_coefficients(self) -> pd.DataFrame:
+        return self._load(_join(self._gold_dir, "post_performance_coefficients"))
+
+    def load_post_performance_predictions(self) -> pd.DataFrame:
+        return self._load(_join(self._gold_dir, "post_performance_predictions"))
+
     def load_governors_metadata(self) -> pd.DataFrame:
         if self._silver_dir is None:
             raise ValueError("silver_dir não foi configurado neste repositório.")

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -2,7 +2,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.dashboard.comparisons import compute_engagement_quadrants, compute_governor_comparison
+from src.dashboard.comparisons import (
+    compute_engagement_quadrants,
+    compute_execution_gap,
+    compute_governor_comparison,
+)
 
 METRICS = ["followersCount", "TOTAL ENGAJAMENTO", "% ENGAJAMENTO"]
 
@@ -192,3 +196,60 @@ def test_quadrantes_ignora_linhas_com_valor_nulo():
     out = compute_engagement_quadrants(df)
     assert "https://www.instagram.com/gov_mediano/" not in out["inputUrl"].values
     assert len(out) == 4
+
+
+# --- compute_execution_gap (issue #77 / ADR 0019, parte E) ---
+
+
+def _df_predictions():
+    return pd.DataFrame(
+        {
+            "id": ["p1", "p2", "p3", "r1", "r2"],
+            "inputUrl": [
+                "https://www.instagram.com/governador_a/",
+                "https://www.instagram.com/governador_a/",
+                "https://www.instagram.com/governador_b/",
+                "https://www.instagram.com/governador_a/",
+                "https://www.instagram.com/governador_a/",
+            ],
+            "grupo": ["estatico", "estatico", "estatico", "video", "video"],
+            "y_real": [0.10, 0.20, 0.15, 0.30, 0.40],
+            "y_previsto": [0.12, 0.18, 0.10, 0.25, 0.35],
+            "residuo": [-0.02, 0.02, 0.05, 0.05, 0.05],
+        }
+    )
+
+
+def test_execution_gap_media_correta_por_grupo():
+    out = compute_execution_gap(_df_predictions(), "https://www.instagram.com/governador_a/")
+    out_por_grupo = out.set_index("grupo")
+
+    # estatico: (-0.02 + 0.02) / 2 = 0.0, 2 posts.
+    assert out_por_grupo.loc["estatico", "residuo_medio"] == pytest.approx(0.0)
+    assert out_por_grupo.loc["estatico", "n_posts"] == 2
+    # video: (0.05 + 0.05) / 2 = 0.05, 2 posts.
+    assert out_por_grupo.loc["video", "residuo_medio"] == pytest.approx(0.05)
+    assert out_por_grupo.loc["video", "n_posts"] == 2
+
+
+def test_execution_gap_dataframe_vazio_retorna_vazio_sem_quebrar():
+    out = compute_execution_gap(
+        pd.DataFrame(columns=["id", "inputUrl", "grupo", "residuo"]),
+        "https://www.instagram.com/qualquer/",
+    )
+    assert out.empty
+    assert list(out.columns) == ["grupo", "residuo_medio", "n_posts"]
+
+
+def test_execution_gap_governador_sem_linha_correspondente_retorna_vazio():
+    out = compute_execution_gap(_df_predictions(), "https://www.instagram.com/nao_existe/")
+    assert out.empty
+
+
+def test_execution_gap_governador_sem_posts_de_um_grupo_nao_inventa_linha():
+    """governador_b só tem posts do grupo estático -- não pode aparecer uma
+    linha "video" com resíduo inventado (0, NaN, etc.) pra ele."""
+    out = compute_execution_gap(_df_predictions(), "https://www.instagram.com/governador_b/")
+
+    assert list(out["grupo"]) == ["estatico"]
+    assert out.set_index("grupo").loc["estatico", "residuo_medio"] == pytest.approx(0.05)

--- a/tests/test_dashboard_loaders.py
+++ b/tests/test_dashboard_loaders.py
@@ -138,3 +138,68 @@ def test_load_sentiment_history_returns_empty_dataframe_when_missing(tmp_path, m
     assert isinstance(out, pd.DataFrame)
     assert out.empty
     _clear_caches()
+
+
+def test_load_post_performance_coefficients_returns_delta_table(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+    path = settings.GOLD_DIR / "post_performance_coefficients"
+    df = pd.DataFrame(
+        {
+            "grupo": ["video"],
+            "preditor": ["hora_do_dia"],
+            "coeficiente": [0.1],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    write_deltalake(str(path), df, mode="overwrite")
+
+    out = loaders.load_post_performance_coefficients()
+
+    assert "coeficiente" in out.columns
+    _clear_caches()
+
+
+def test_load_post_performance_coefficients_returns_empty_dataframe_when_missing(
+    tmp_path, monkeypatch
+):
+    _point_settings_at(monkeypatch, tmp_path)
+
+    out = loaders.load_post_performance_coefficients()
+
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty
+    _clear_caches()
+
+
+def test_load_post_performance_predictions_returns_delta_table(tmp_path, monkeypatch):
+    _point_settings_at(monkeypatch, tmp_path)
+    path = settings.GOLD_DIR / "post_performance_predictions"
+    df = pd.DataFrame(
+        {
+            "id": ["p1"],
+            "inputUrl": ["https://www.instagram.com/governador_a/"],
+            "grupo": ["estatico"],
+            "residuo": [0.05],
+            "_run_id": ["r1"],
+            "_generated_at": pd.to_datetime(["2026-05-01"], utc=True),
+        }
+    )
+    write_deltalake(str(path), df, mode="overwrite")
+
+    out = loaders.load_post_performance_predictions()
+
+    assert "residuo" in out.columns
+    _clear_caches()
+
+
+def test_load_post_performance_predictions_returns_empty_dataframe_when_missing(
+    tmp_path, monkeypatch
+):
+    _point_settings_at(monkeypatch, tmp_path)
+
+    out = loaders.load_post_performance_predictions()
+
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty
+    _clear_caches()


### PR DESCRIPTION
## Summary
- Card novo em `pages/03_performance.py`, abaixo da matriz de quadrantes, só para governador individual (não "Todos os Governadores").
- Resíduo médio por grupo (vídeo/estático, nunca combinados) + posts com maior resíduo positivo/negativo, **separados por grupo** (não um ranking misto — escalas de resíduo diferentes entre os grupos, ADR 0019).
- `DeltaRepository.load_post_performance_coefficients`/`load_post_performance_predictions` (mesmo padrão de `load_clusters`/`load_profile_clusters_engagement`) + dois loaders correspondentes em `src/dashboard/loaders.py`.
- `compute_execution_gap` em `src/dashboard/comparisons.py`: função pura, mesmo contrato de degradação de `compute_governor_comparison` — nunca inventa uma linha pro grupo sem dado.

## Validação
Sem navegador disponível neste ambiente (extensão Claude in Chrome não conectada nesta sessão em background) — validado via `streamlit.testing.v1.AppTest` (execução real do Streamlit, headless) contra Gold sintético: card renderiza sem exceção, métricas batem com a média calculada à mão, tabelas por grupo mostram só os posts do grupo correto, corretamente ordenadas.

## Fora de escopo (por design)
- Gráfico novo de visualização do resíduo.
- Combinar vídeo/estático numa métrica única.
- Uso da lacuna de execução em Recommendations.
- Qualquer mudança nos coeficientes/modelo em si.

## Test plan
- [x] `pytest tests/` — 247 passed, 3 skipped
- [x] `ruff check src/` — limpo
- [x] `streamlit.testing.v1.AppTest` — card renderiza sem exceção, valores conferidos
- [x] `/code-review` (Standards + Spec, sub-agentes paralelos) — achado real corrigido antes do commit: tabela de top-N dividida por grupo (antes misturava vídeo/estático). Dois achados menores mantidos deliberadamente (guard de "Todos os Governadores" em bloco próprio; página refiltra `df_predictions` pra montar a tabela — mesmo precedente já usado em `render_performance_trend`).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DNsAP2pcPURMq2JFpYscd